### PR TITLE
remove old animation frame polyfill

### DIFF
--- a/app/assets/javascripts/notifications.js
+++ b/app/assets/javascripts/notifications.js
@@ -23,7 +23,7 @@ function showNotification(content, properties = {}) {
         $notification.append("<div class='spinner'></div>");
     }
 
-    requestAnimationFrame(function () {
+    window.requestAnimationFrame(function () {
         $notification.removeClass("notification-show");
     });
 

--- a/app/assets/javascripts/notifications.js
+++ b/app/assets/javascripts/notifications.js
@@ -1,4 +1,3 @@
-/* globals requestAnimFrame */
 /**
  * Shows a notification in the bottom left corner
  *
@@ -24,7 +23,7 @@ function showNotification(content, properties = {}) {
         $notification.append("<div class='spinner'></div>");
     }
 
-    requestAnimFrame(function () {
+    requestAnimationFrame(function () {
         $notification.removeClass("notification-show");
     });
 

--- a/app/assets/javascripts/polyfills.js
+++ b/app/assets/javascripts/polyfills.js
@@ -102,15 +102,3 @@
     window.fullScreenApi = fullScreenApi;
 })();
 
-/**
- * requestAnimationFrame shim
- * source: http://www.paulirish.com/2011/requestanimationframe-for-smart-animating/
- */
-window.requestAnimFrame = (function () {
-    return window.requestAnimationFrame ||
-        window.webkitRequestAnimationFrame ||
-        window.mozRequestAnimationFrame ||
-        function (callback) {
-            window.setTimeout(callback, 1000 / 60);
-        };
-})();

--- a/app/assets/javascripts/types/index.d.ts
+++ b/app/assets/javascripts/types/index.d.ts
@@ -1,6 +1,4 @@
 declare interface Window {
-    requestAnimFrame: (fun: Function) => void;
-    mozRequestAnimationFrame: (fun: Function) => void;
     dodona: any;
 }
 
@@ -11,5 +9,3 @@ declare module I18n {
 }
 
 declare var dodona;
-
-declare function requestAnimFrame(fun: Function): void;

--- a/app/assets/javascripts/util.js
+++ b/app/assets/javascripts/util.js
@@ -142,19 +142,6 @@ function getArrayURLParameter(name, _url) {
     return result;
 }
 
-/**
- * requestAnimationFrame shim
- * source: http://www.paulirish.com/2011/requestanimationframe-for-smart-animating/
- */
-window.requestAnimFrame = (function () {
-    return window.requestAnimationFrame ||
-        window.webkitRequestAnimationFrame ||
-        window.mozRequestAnimationFrame ||
-        function (callback) {
-            window.setTimeout(callback, 1000 / 60);
-        };
-})();
-
 /*
  * Logs data to Google Analytics
  */


### PR DESCRIPTION
There is no need for the old animation frame polyfill anymore: https://developer.mozilla.org/en-US/docs/Web/API/window/requestAnimationFrame#Browser_compatibility.

Unfortunately, the same is not true for the full-screen API: https://developer.mozilla.org/en-US/docs/Web/API/Element/requestFullScreen#Browser_compatibility.