### PR TITLE
remove jquery from the drawer class

### DIFF
--- a/app/assets/javascripts/drawer.ts
+++ b/app/assets/javascripts/drawer.ts
@@ -1,35 +1,25 @@
-import * as jQuery from "jquery";
-
-const $ = jQuery;
-
-export default class Drawer {
-    $drawer: JQuery<HTMLElement>;
-    $handle: JQuery<HTMLElement>;
-    $toggle: JQuery<HTMLElement>;
-    $background: JQuery<HTMLElement>;
+export class Drawer {
+    drawer: Element;
 
     constructor(toggleSelector = ".drawer-toggle",
                 drawerSelector = "#drawer",
-                handleSelector = ".drawer-handle",
                 backgroundSelector = ".drawer-background") {
 
-        this.$drawer = $(drawerSelector);
-        this.$handle = $(handleSelector);
-        this.$toggle = $(toggleSelector);
-        this.$background = $(backgroundSelector);
+        this.drawer = document.querySelector(drawerSelector);
 
-        this.$toggle.on('click', () => this.toggle());
-        this.$handle.on('click', () => this.toggle());
-        this.$background.on('click', () => this.hide());
+        document
+          .querySelector(toggleSelector)
+          .addEventListener("click", () => this.toggle());
+        document
+          .querySelector(backgroundSelector)
+          .addEventListener("click", () => this.hide());
     }
 
     toggle() {
-        this.$drawer.toggleClass("active");
+        this.drawer.classList.toggle("active");
     }
 
     hide() {
-        this.$drawer.removeClass("active");
+        this.drawer.classList.remove("active");
     }
 }
-
-$(() => new Drawer());

--- a/app/assets/javascripts/drawer.ts
+++ b/app/assets/javascripts/drawer.ts
@@ -1,8 +1,8 @@
 export class Drawer {
     drawer: Element;
 
-    constructor(toggleSelector = ".drawer-toggle",
-        drawerSelector = "#drawer",
+    constructor(drawerSelector = "#drawer",
+        toggleSelector = ".drawer-toggle",
         backgroundSelector = ".drawer-background") {
 
         this.drawer = document.querySelector(drawerSelector);

--- a/app/assets/javascripts/drawer.ts
+++ b/app/assets/javascripts/drawer.ts
@@ -2,24 +2,28 @@ export class Drawer {
     drawer: Element;
 
     constructor(toggleSelector = ".drawer-toggle",
-                drawerSelector = "#drawer",
-                backgroundSelector = ".drawer-background") {
+        drawerSelector = "#drawer",
+        backgroundSelector = ".drawer-background") {
 
         this.drawer = document.querySelector(drawerSelector);
 
         document
-          .querySelector(toggleSelector)
-          .addEventListener("click", () => this.toggle());
+            .querySelector(toggleSelector)
+            .addEventListener("click", () => this.toggle());
         document
-          .querySelector(backgroundSelector)
-          .addEventListener("click", () => this.hide());
+            .querySelector(backgroundSelector)
+            .addEventListener("click", () => this.hide());
     }
 
-    toggle() {
+    toggle(): void {
         this.drawer.classList.toggle("active");
     }
 
-    hide() {
+    hide(): void {
         this.drawer.classList.remove("active");
+    }
+
+    show(): void {
+        this.drawer.classList.add("active");
     }
 }

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -21,7 +21,7 @@ window.jquery = jQuery;
 window.$ = jQuery;
 
 import "polyfills.js";
-import "drawer";
+import { Drawer } from "drawer";
 import { showNotification } from "notifications.js";
 import { checkTimeZone, initClipboard, initCSRF, initTooltips } from "util.js";
 
@@ -44,6 +44,8 @@ if (window.location.hostname === "dodona.ugent.be") {
 }
 // Initialize clipboard.js
 initClipboard();
+
+$(() => new Drawer());
 
 // Adds the CSRF token to each ajax request
 initCSRF();


### PR DESCRIPTION
This PR removes all jquery dependencies from the Drawer class as a proof of concept.

Note that I discovered that there was code to toggle the drawer using a "handle" which wasn't present in the html. This issue didn't surface before because jQuery fails silently when adding listeners to non-existing elements.

Right now, the application.js pack file contains both general init code, such as making available some variables as well as DOM initialisation (drawer, tooltips, ...). This second category should be grouped in an application init block/file going forward.