### PR TITLE
Fix Faker in seeds

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -114,16 +114,16 @@ if Rails.env.development?
   courses.each do |course|
     series = []
     series << Series.create(name: 'Verborgen reeks',
-                            description: Faker::Lorem.paragraph(25),
+                            description: Faker::Lorem.paragraph(sentence_count: 25),
                             course: course,
                             visibility: :hidden)
     series << Series.create(name: 'Gesloten reeks',
-                            description: Faker::Lorem.paragraph(25),
+                            description: Faker::Lorem.paragraph(sentence_count: 25),
                             course: course,
                             visibility: :closed)
     20.times do |i|
       s = Series.create(name: "Reeks #{i}",
-                        description: Faker::Lorem.paragraph(25),
+                        description: Faker::Lorem.paragraph(sentence_count: 25),
                         course: course)
       if Random.rand < 0.1
         t = if Random.rand < 0.3


### PR DESCRIPTION
Due to an update (probably) of Faker, the current seeds are no longer working because the amount of sentences has been changed to be an optional argument.

**Behaviour before applying these changes:**
This behaviour was observed on a fresh clone of the repository, using ruby 2.5.1
```
$ bin/rails db:seed
Creating institution
Creating users
Creating courses
Adding users to courses
Create & clone judge
Create & clone exercise repository
Add series, exercises and submissions to courses
rails aborted!
ArgumentError: wrong number of arguments (given 1, expected 0)
```