### PR TITLE
add linting for typescript files

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
 app/assets/config/manifest.js
 app/assets/javascripts/application.js
 app/assets/javascripts/i18n/translations.js
+app/assets/javascripts/types/index.d.ts

--- a/.eslintrc
+++ b/.eslintrc
@@ -27,5 +27,18 @@
     "jQuery": "readonly",
     "I18n": "readonly",
     "dodona": "readonly"
-  }
+  },
+  "overrides": [
+    {
+      "extends": ["plugin:@typescript-eslint/recommended"],
+      "files": ["*.ts"],
+      "parser": "@typescript-eslint/parser",
+      "parserOptions": {
+        // this seems to be extremely slow
+        // without 1.5s, with 22s
+        //"project": "./tsconfig.json"
+      },
+      "plugins": ["@typescript-eslint"]
+    }
+  ]
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -38,7 +38,15 @@
         // without 1.5s, with 22s
         //"project": "./tsconfig.json"
       },
-      "plugins": ["@typescript-eslint"]
+      "plugins": ["@typescript-eslint"],
+      "rules": {
+        "@typescript-eslint/explicit-member-accessibility": "off",
+        "@typescript-eslint/explicit-function-return-type": [
+          "error",
+          { "allowExpressions": true }
+        ],
+        "@typescript-eslint/no-parameter-properties": "off"
+      }
     }
   ]
 }

--- a/app/assets/javascripts/drawer.ts
+++ b/app/assets/javascripts/drawer.ts
@@ -4,7 +4,6 @@ export class Drawer {
     constructor(drawerSelector = "#drawer",
         toggleSelector = ".drawer-toggle",
         backgroundSelector = ".drawer-background") {
-
         this.drawer = document.querySelector(drawerSelector);
 
         document

--- a/app/assets/javascripts/heatmap.ts
+++ b/app/assets/javascripts/heatmap.ts
@@ -2,7 +2,7 @@ import * as d3 from "d3";
 import * as moment from "moment";
 
 const selector = "#heatmap-container";
-const margin = {top: 50, right: 10, bottom: 20, left: 30};
+const margin = { top: 50, right: 10, bottom: 20, left: 30 };
 const isoDateFormat = "YYYY-MM-DD";
 const monthKeys = ["jan", "feb", "mar", "apr", "may", "jun", "jul", "aug", "sep", "oct", "nov", "dec"];
 const dayKeys = ["mon", "tue", "wed", "thu", "fri", "sat", "sun"];
@@ -59,7 +59,7 @@ function initHeatmap(url: string, year: string | undefined) {
     });
 }
 
-function drawHeatmap(data: Array<[moment.Moment, number]>) {
+function drawHeatmap(data: [moment.Moment, number][]) {
     const darkMode = window.dodona.darkMode;
     const emptyColor = darkMode ? "#37474F" : "white";
     const lowColor = darkMode ? "#01579B" : "#E3F2FD";
@@ -186,4 +186,4 @@ function drawHeatmap(data: Array<[moment.Moment, number]>) {
         .attr("fill", d => d[1] === 0 ? "" : colorRange(d[1]));
 }
 
-export {initHeatmap};
+export { initHeatmap };

--- a/app/assets/javascripts/heatmap.ts
+++ b/app/assets/javascripts/heatmap.ts
@@ -1,3 +1,5 @@
+/* eslint @typescript-eslint/no-use-before-define: "off" */
+
 import * as d3 from "d3";
 import * as moment from "moment";
 
@@ -17,7 +19,7 @@ function setToAYStart(day: moment.Moment): moment.Moment {
     return day.month(8).date(1);
 }
 
-function initHeatmap(url: string, year: string | undefined) {
+function initHeatmap(url: string, year: string | undefined): void {
     d3.select(selector).attr("class", "text-center").append("span").text(I18n.t("js.loading"));
     d3.json(url).then(data => {
         d3.select(`${selector} *`).remove();
@@ -55,11 +57,17 @@ function initHeatmap(url: string, year: string | undefined) {
             }
         }
 
-        drawHeatmap(keys.sort().map(k => (<[moment.Moment, number]>[moment.utc(k), data[k] || 0])));
+        drawHeatmap(
+            keys
+                .sort()
+                .map(
+                    k => [moment.utc(k), data[k] || 0] as [moment.Moment, number]
+                )
+        );
     });
 }
 
-function drawHeatmap(data: [moment.Moment, number][]) {
+function drawHeatmap(data: [moment.Moment, number][]): void {
     const darkMode = window.dodona.darkMode;
     const emptyColor = darkMode ? "#37474F" : "white";
     const lowColor = darkMode ? "#01579B" : "#E3F2FD";
@@ -71,7 +79,7 @@ function drawHeatmap(data: [moment.Moment, number][]) {
 
     const container = d3.select(selector);
     const tooltip = container.append("div").attr("class", "d3-tooltip").style("opacity", 0);
-    const width = (<Element>container.node()).getBoundingClientRect().width;
+    const width = (container.node() as Element).getBoundingClientRect().width;
     const innerWidth = width - margin.left - margin.right;
     const chartBox = container.append("svg");
     const chart = chartBox.append("g")
@@ -85,17 +93,23 @@ function drawHeatmap(data: [moment.Moment, number][]) {
     let maxWeeks = 0;
     const weekdaysData = [];
     const yearsData = [];
-    for (let y = firstAY.clone(); y < setToAYStart(lastAY.clone().add(1, "year")); y = setToAYStart(y.add(1, "year"))) {
+    for (
+        let y = firstAY.clone();
+        y < setToAYStart(lastAY.clone().add(1, "year"));
+        y = setToAYStart(y.add(1, "year"))
+    ) {
         const next = setToAYStart(y.clone().add(1, "year"));
         const weeks = moment.duration(next.diff(y)).asWeeks() + 1;
         if (weeks > maxWeeks) {
             maxWeeks = weeks;
         }
-        weekdaysData.push(...[
-            [weekdaysData.length / 3, weekdayNames[0]],
-            [weekdaysData.length / 3, weekdayNames[2]],
-            [weekdaysData.length / 3, weekdayNames[4]],
-        ]);
+        weekdaysData.push(
+            ...[
+                [weekdaysData.length / 3, weekdayNames[0]],
+                [weekdaysData.length / 3, weekdayNames[2]],
+                [weekdaysData.length / 3, weekdayNames[4]],
+            ]
+        );
         yearsData.push(`${y.format("YYYY")}–${next.format("YYYY")}`);
     }
 

--- a/app/assets/javascripts/notification.ts
+++ b/app/assets/javascripts/notification.ts
@@ -2,7 +2,6 @@
  * Shows a notification in the bottom left corner. By default, hides it after 3 seconds.
  */
 export class Notification {
-
     readonly notification: Element;
 
     constructor(readonly content: string, readonly autoHide = true, readonly loading = false) {
@@ -39,7 +38,7 @@ export class Notification {
     }
 
     private htmlToElement(html: string): Element {
-        const template = document.createElement('template');
+        const template = document.createElement("template");
         template.innerHTML = html.trim();
         return <Element>template.content.firstChild;
     }

--- a/app/assets/javascripts/notification.ts
+++ b/app/assets/javascripts/notification.ts
@@ -15,14 +15,14 @@ export class Notification {
         }
     }
 
-    private show() {
+    private show(): void {
         document.querySelector(".notifications").prepend(this.notification);
         window.requestAnimationFrame(() => {
             this.notification.classList.remove("notification-show");
         });
     }
 
-    hide() {
+    hide(): void {
         this.notification.classList.add("notification-hide");
         setTimeout(() => {
             this.notification.remove();
@@ -30,7 +30,9 @@ export class Notification {
     }
 
     private generateNotificationHTML(content: string, loading: boolean): Element {
-        const element = this.htmlToElement(`<div class='notification notification-show'>${content}</div>`);
+        const element = this.htmlToElement(
+            `<div class='notification notification-show'>${content}</div>`
+        );
         if (loading) {
             element.appendChild(this.htmlToElement("<div class='spinner'></div>"));
         }
@@ -40,6 +42,6 @@ export class Notification {
     private htmlToElement(html: string): Element {
         const template = document.createElement("template");
         template.innerHTML = html.trim();
-        return <Element>template.content.firstChild;
+        return template.content.firstChild as Element;
     }
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "dodona",
   "private": true,
   "scripts": {
-    "lint": "eslint app"
+    "lint": "eslint  --ext '.js' --ext '.ts' app/javascript app/assets/javascripts"
   },
   "dependencies": {
     "@rails/webpacker": "4.0.7",
@@ -23,6 +23,8 @@
     "typescript": "^3.5.3"
   },
   "devDependencies": {
+    "@typescript-eslint/eslint-plugin": "^1.13.0",
+    "@typescript-eslint/parser": "^1.13.0",
     "eslint": "^6.1.0",
     "eslint-config-google": "^0.13.0",
     "webpack-cli": "^3.3.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1176,6 +1176,11 @@
     "@types/d3-voronoi" "*"
     "@types/d3-zoom" "*"
 
+"@types/eslint-visitor-keys@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#1ee30d79544ca84d68d4b3cdb0af4f205663dd2d"
+  integrity sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==
+
 "@types/events@*":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@types/events/-/events-3.0.0.tgz#2862f3f58a9a7f7c3e78d79f130dd4d71c25c2a7"
@@ -1201,6 +1206,11 @@
   integrity sha512-Lz4BAJihoFw5nRzKvg4nawXPzutkv7wmfQ5121avptaSIXlDNJCUuxZxX/G+9EVidZGuO0UBlk+YjKbwRKJigg==
   dependencies:
     "@types/sizzle" "*"
+
+"@types/json-schema@^7.0.3":
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.3.tgz#bdfd69d61e464dcc81b25159c270d75a73c1a636"
+  integrity sha512-Il2DtDVRGDcqjDtE+rF8iqg1CArehSK84HZJCT7AMITlyXRBpuPhqGLDQMowraqqu1coEaimg4ZOqggt6L6L+A==
 
 "@types/long@^4.0.0":
   version "4.0.0"
@@ -1231,6 +1241,44 @@
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/@types/sizzle/-/sizzle-2.3.2.tgz#a811b8c18e2babab7d542b3365887ae2e4d9de47"
   integrity sha512-7EJYyKTL7tFR8+gDbB6Wwz/arpGa0Mywk1TJbNzKzHtzbwVmY4HR9WqS5VV7dsBUKQmPNr192jHr/VpBluj/hg==
+
+"@typescript-eslint/eslint-plugin@^1.13.0":
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-1.13.0.tgz#22fed9b16ddfeb402fd7bcde56307820f6ebc49f"
+  integrity sha512-WQHCozMnuNADiqMtsNzp96FNox5sOVpU8Xt4meaT4em8lOG1SrOv92/mUbEHQVh90sldKSfcOc/I0FOb/14G1g==
+  dependencies:
+    "@typescript-eslint/experimental-utils" "1.13.0"
+    eslint-utils "^1.3.1"
+    functional-red-black-tree "^1.0.1"
+    regexpp "^2.0.1"
+    tsutils "^3.7.0"
+
+"@typescript-eslint/experimental-utils@1.13.0":
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-1.13.0.tgz#b08c60d780c0067de2fb44b04b432f540138301e"
+  integrity sha512-zmpS6SyqG4ZF64ffaJ6uah6tWWWgZ8m+c54XXgwFtUv0jNz8aJAVx8chMCvnk7yl6xwn8d+d96+tWp7fXzTuDg==
+  dependencies:
+    "@types/json-schema" "^7.0.3"
+    "@typescript-eslint/typescript-estree" "1.13.0"
+    eslint-scope "^4.0.0"
+
+"@typescript-eslint/parser@^1.13.0":
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-1.13.0.tgz#61ac7811ea52791c47dc9fd4dd4a184fae9ac355"
+  integrity sha512-ITMBs52PCPgLb2nGPoeT4iU3HdQZHcPaZVw+7CsFagRJHUhyeTgorEwHXhFf3e7Evzi8oujKNpHc8TONth8AdQ==
+  dependencies:
+    "@types/eslint-visitor-keys" "^1.0.0"
+    "@typescript-eslint/experimental-utils" "1.13.0"
+    "@typescript-eslint/typescript-estree" "1.13.0"
+    eslint-visitor-keys "^1.0.0"
+
+"@typescript-eslint/typescript-estree@1.13.0":
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-1.13.0.tgz#8140f17d0f60c03619798f1d628b8434913dc32e"
+  integrity sha512-b5rCmd2e6DCC6tCTN9GSUAuxdYwCM/k/2wdjHGrIRGPSJotWMCe/dGpi66u42bhuh8q3QBzqM4TMA1GUUCJvdw==
+  dependencies:
+    lodash.unescape "4.0.1"
+    semver "5.5.0"
 
 "@webassemblyjs/ast@1.8.5":
   version "1.8.5"
@@ -3449,7 +3497,7 @@ eslint-config-google@^0.13.0:
   resolved "https://registry.yarnpkg.com/eslint-config-google/-/eslint-config-google-0.13.0.tgz#e277d16d2cb25c1ffd3fd13fb0035ad7421382fe"
   integrity sha512-ELgMdOIpn0CFdsQS+FuxO+Ttu4p+aLaXHv9wA9yVnzqlUGV7oN/eRRnJekk7TCur6Cu2FXX0fqfIXRBaM14lpQ==
 
-eslint-scope@^4.0.3:
+eslint-scope@^4.0.0, eslint-scope@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-4.0.3.tgz#ca03833310f6889a3264781aa82e63eb9cfe7848"
   integrity sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==
@@ -5195,6 +5243,11 @@ lodash.templatesettings@^4.0.0:
   integrity sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=
   dependencies:
     lodash._reinterpolate "~3.0.0"
+
+lodash.unescape@4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/lodash.unescape/-/lodash.unescape-4.0.1.tgz#bf2249886ce514cda112fae9218cdc065211fc9c"
+  integrity sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw=
 
 lodash.uniq@^4.5.0:
   version "4.5.0"
@@ -7605,6 +7658,11 @@ selfsigned@^1.10.4:
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.1.tgz#7dfdd8814bdb7cabc7be0fb1d734cfb66c940477"
   integrity sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw==
 
+semver@5.5.0:
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
+  integrity sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==
+
 semver@^5.4.1, semver@^5.6.0:
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.0.tgz#790a7cf6fea5459bac96110b29b60412dc8ff96b"
@@ -8377,7 +8435,7 @@ ts-pnp@^1.1.2:
   resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.1.2.tgz#be8e4bfce5d00f0f58e0666a82260c34a57af552"
   integrity sha512-f5Knjh7XCyRIzoC/z1Su1yLLRrPrFCgtUAh/9fCSP6NKbATwpOL1+idQVXQokK9GRFURn/jYPGPfegIctwunoA==
 
-tslib@1.10.0:
+tslib@1.10.0, tslib@^1.8.1:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
   integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==
@@ -8386,6 +8444,13 @@ tslib@^1.9.0:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
   integrity sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==
+
+tsutils@^3.7.0:
+  version "3.17.1"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.17.1.tgz#ed719917f11ca0dee586272b2ac49e015a2dd759"
+  integrity sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==
+  dependencies:
+    tslib "^1.8.1"
 
 tty-browserify@0.0.0:
   version "0.0.0"


### PR DESCRIPTION
This PR enables eslint checking for typescript files.
Some rules can use type formation, but this was disabled because this was very slow (> 20 seconds per run).