### PR TITLE
make sure we don't generate email adresses with spaces in the tests

### DIFF
--- a/test/factories/users.rb
+++ b/test/factories/users.rb
@@ -22,7 +22,7 @@ FactoryBot.define do
     first_name { Faker::Name.first_name }
     last_name { Faker::Name.last_name }
     username { Faker::Internet.unique.user_name(specifier: 5..32) }
-    email { "#{first_name}.#{last_name}.#{username}@UGent.BE".downcase }
+    email { "#{first_name}.#{last_name}.#{username}@ugent.be".downcase.gsub(' ', '_') }
     permission { :student }
     institution
   end


### PR DESCRIPTION
I tested beforehand that the tests failed when I manually added a space to the last name of a user.