### PR TITLE
Execute 'yarn install' before deploy:assets:precompile

### DIFF
--- a/config/deploy/develop.rb
+++ b/config/deploy/develop.rb
@@ -10,3 +10,18 @@ set :rails_env, :development
 
 set :delayed_job_workers, 3
 
+# Perform yarn install before precompiling the assets in order to pass the
+# integrity check.
+namespace :deploy do
+  namespace :assets do
+    before :precompile, :yarn_install do
+      on release_roles(fetch(:assets_roles)) do
+        within release_path do
+          with rails_env: fetch(:rails_env) do
+            execute :yarn, "install"
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Deploying on develop (`cap develop deploy`) now doesn't require manually `ssh`'ing anymore in order to run `yarn install`.