### PR TITLE
Webpacker production environment

### DIFF
--- a/config/webpack/production.js
+++ b/config/webpack/production.js
@@ -5,10 +5,7 @@ const environment = require("./environment");
 const tsloader = environment.loaders.get('typescript').use.find(l => l.loader === 'ts-loader');
 tsloader.options = {
   ...tsloader.options,
-  transpileOnly: true,
   reportFiles: ["!test/**/*"]
 };
 
-
 module.exports = environment.toWebpackConfig();
-

--- a/config/webpack/production.js
+++ b/config/webpack/production.js
@@ -2,4 +2,13 @@ process.env.NODE_ENV = process.env.NODE_ENV || "production";
 
 const environment = require("./environment");
 
+const tsloader = environment.loaders.get('typescript').use.find(l => l.loader === 'ts-loader');
+tsloader.options = {
+  ...tsloader.options,
+  transpileOnly: true,
+  reportFiles: ["!test/**/*"]
+};
+
+
 module.exports = environment.toWebpackConfig();
+

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "emitDecoratorMetadata": true,
     "esModuleInterop": false,
     "experimentalDecorators": true,
-    "lib": ["es6", "dom"],
+    "lib": ["es7", "dom"],
     "module": "es6",
     "moduleResolution": "node",
     "sourceMap": true,


### PR DESCRIPTION
We can now compile assets for production without the javascript `devDependencies`.