### PR TITLE
Change which dates are used for the heatmap on the course pages

### DIFF
--- a/app/views/visualizations/_heatmap.html.erb
+++ b/app/views/visualizations/_heatmap.html.erb
@@ -11,7 +11,8 @@
     $(function () {
         dodona.initHeatmap(
             '<%= raw heatmap_path(user_id: local_assigns[:user]&.id, course_id: local_assigns[:course]&.id) %>',
-            <%= raw local_assigns[:course].present? ? "'#{course.year}'" : "undefined" %>
+            <%= raw local_assigns[:course].present? ? "true" : "false" %>,
+            <%= raw local_assigns[:course].present? ? "'#{course.formatted_year}'" : "undefined" %>
         );
     });
 </script>


### PR DESCRIPTION
* Show all academic years in which there were submissions
* Show the oldest academic year first
* Bold the academic year of the course (if there are multiple years shown)

Fixes #1203 