### PR TITLE
Include course url in series json

### DIFF
--- a/app/views/series/_series.json.jbuilder
+++ b/app/views/series/_series.json.jbuilder
@@ -8,4 +8,5 @@ json.extract! series,
               :updated_at,
               :deadline
 json.url series_url(series, format: :json)
+json.course course_url(series.course, format: :json)
 json.exercises series_exercises_url(series, format: :json)


### PR DESCRIPTION
Adds the url of the course to the series partial.

**Before:**
```json
{
"id": 66,
"name": "Reeks 19",
"description": "Lorem ipsum.",
"visibility": "open",
"order": 0,
"created_at": "2019-09-13T22:12:08.000+02:00",
"updated_at": "2019-09-13T22:12:08.000+02:00",
"deadline": "2019-09-11T22:12:08.000+02:00",
"url": "http://localhost:3000/nl/series/66.json",
"exercises": "http://localhost:3000/nl/series/66/exercises.json"
}
```

**After:**
```json
{
"id": 66,
"name": "Reeks 19",
"description": "Lorem ipsum.",
"visibility": "open",
"order": 0,
"created_at": "2019-09-13T22:12:08.000+02:00",
"updated_at": "2019-09-13T22:12:08.000+02:00",
"deadline": "2019-09-11T22:12:08.000+02:00",
"url": "http://localhost:3000/nl/series/66.json",
"course": "http://localhost:3000/nl/courses/3.json",
"exercises": "http://localhost:3000/nl/series/66/exercises.json"
}
```