### PR TITLE
Make sure we move the code and result files when a submission's attributes are manually updated

### DIFF
--- a/test/models/submission_test.rb
+++ b/test/models/submission_test.rb
@@ -115,4 +115,31 @@ class SubmissionTest < ActiveSupport::TestCase
     assert_equal 3, result[:groups][0][:groups][0][:groups][0][:messages].count
     assert_equal 3, result[:groups][0][:groups][0][:groups][0][:tests][0][:messages].count
   end
+
+  test 'transferring to another course should move the underlying result and code' do
+    submission = create :submission, result: 'result', code: 'code'
+    new_course = create :course
+    submission.update(course: new_course)
+    assert_equal 'result', submission.result
+    assert_equal 'code', submission.code
+    assert File.exist?(submission.fs_path)
+  end
+
+  test 'transferring to another exercise should move the underlying result and code' do
+    submission = create :submission, result: 'result', code: 'code'
+    new_exercise = create :exercise
+    submission.update(exercise: new_exercise)
+    assert_equal 'result', submission.result
+    assert_equal 'code', submission.code
+    assert File.exist?(submission.fs_path)
+  end
+
+  test 'transferring to another user should move the underlying result and code' do
+    submission = create :submission, result: 'result', code: 'code'
+    new_user = create :user
+    submission.update(user: new_user)
+    assert_equal 'result', submission.result
+    assert_equal 'code', submission.code
+    assert File.exist?(submission.fs_path)
+  end
 end

--- a/test/models/submission_test.rb
+++ b/test/models/submission_test.rb
@@ -118,28 +118,34 @@ class SubmissionTest < ActiveSupport::TestCase
 
   test 'transferring to another course should move the underlying result and code' do
     submission = create :submission, result: 'result', code: 'code'
+    path = submission.fs_path
     new_course = create :course
     submission.update(course: new_course)
     assert_equal 'result', submission.result
     assert_equal 'code', submission.code
     assert File.exist?(submission.fs_path)
+    assert_not File.exist?(path)
   end
 
   test 'transferring to another exercise should move the underlying result and code' do
     submission = create :submission, result: 'result', code: 'code'
+    path = submission.fs_path
     new_exercise = create :exercise
     submission.update(exercise: new_exercise)
     assert_equal 'result', submission.result
     assert_equal 'code', submission.code
     assert File.exist?(submission.fs_path)
+    assert_not File.exist?(path)
   end
 
   test 'transferring to another user should move the underlying result and code' do
     submission = create :submission, result: 'result', code: 'code'
+    path = submission.fs_path
     new_user = create :user
     submission.update(user: new_user)
     assert_equal 'result', submission.result
     assert_equal 'code', submission.code
     assert File.exist?(submission.fs_path)
+    assert_not File.exist?(path)
   end
 end


### PR DESCRIPTION
This caused problems recently when some submissions had to be moved into a course. If [this method](https://github.com/dodona-edu/dodona/blob/develop/app/models/exercise.rb#L363) is called (also a manual action) it would cause similar problems. Same when users would need to be merged (e.g. if a user has multiple accounts through multiple institutions).