### PR TITLE
Only use judged submission to determine exercise and series status

### DIFF
--- a/app/models/exercise.rb
+++ b/app/models/exercise.rb
@@ -257,7 +257,7 @@ class Exercise < ApplicationRecord
                    ->(this, options) { format(USERS_CORRECT_CACHE_STRING, course_id: options[:course].present? ? options[:course].id : 'global', id: this.id) })
 
   def users_tried(options)
-    subs = submissions.all
+    subs = submissions.judged
     subs = subs.in_course(options[:course]) if options[:course].present?
     subs.distinct.count(:user_id)
   end

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -49,6 +49,7 @@ class Submission < ApplicationRecord
   scope :in_series, ->(series) { where(course_id: series.course.id).where(exercise: series.exercises) }
   scope :of_judge, ->(judge) { where(exercise_id: Exercise.where(judge_id: judge.id)) }
 
+  scope :judged, -> { where.not(status: %i[running queued]) }
   scope :by_exercise_name, ->(name) { where(exercise: Exercise.by_name(name)) }
   scope :by_status, ->(status) { where(status: status.in?(statuses) ? status : -1) }
   scope :by_username, ->(name) { where(user: User.by_filter(name)) }

--- a/app/models/transient/exercise_summary.rb
+++ b/app/models/transient/exercise_summary.rb
@@ -61,7 +61,7 @@ class ExerciseSummary
   private
 
   def query_submissions
-    s = Submission.where(user: user, exercise: exercise).reorder(id: :desc)
+    s = Submission.judged.where(user: user, exercise: exercise).reorder(id: :desc)
     s = s.where(course_id: series.course_id) if series
     s
   end

--- a/app/models/transient/series_summary.rb
+++ b/app/models/transient/series_summary.rb
@@ -133,7 +133,7 @@ class SeriesSummary
   end
 
   def query_submissions
-    s = Submission.where(user: user, exercise: exercises)
+    s = Submission.judged.where(user: user, exercise: exercises)
     s = s.where(course_id: series.course_id) if series
     s
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -169,7 +169,7 @@ class User < ApplicationRecord
   end
 
   def attempted_exercises(options)
-    s = submissions
+    s = submissions.judged
     s = s.in_course(options[:course]) if options[:course].present?
     s.select('distinct exercise_id').count
   end
@@ -178,9 +178,9 @@ class User < ApplicationRecord
                    ->(this, options) { format(ATTEMPTED_EXERCISES_CACHE_STRING, course_id: options[:course].present? ? options[:course].id : 'global', id: this.id) })
 
   def correct_exercises(options)
-    s = submissions
+    s = submissions.where(status: :correct)
     s = s.in_course(options[:course]) if options[:course].present?
-    s.select('distinct exercise_id').where(status: :correct).count
+    s.select('distinct exercise_id').count
   end
 
   create_cacheable(:correct_exercises,

--- a/test/models/exercise_test.rb
+++ b/test/models/exercise_test.rb
@@ -178,39 +178,45 @@ class ExerciseTest < ActiveSupport::TestCase
     assert_equal 0, e.users_tried(course: course1)
     assert_equal 0, e.users_tried(course: course2)
 
-    create :submission, user: users_c1[0], course: course1, exercise: e
+    create :submission, user: users_c1[0], course: course1, exercise: e, status: :wrong
 
     assert_equal 1, e.users_tried
     assert_equal 1, e.users_tried(course: course1)
     assert_equal 0, e.users_tried(course: course2)
 
-    create :submission, user: users_c2[0], course: course2, exercise: e
+    create :submission, user: users_c2[0], course: course2, exercise: e, status: :wrong
 
     assert_equal 2, e.users_tried
     assert_equal 1, e.users_tried(course: course1)
     assert_equal 1, e.users_tried(course: course2)
 
-    create :submission, user: users_all[0], exercise: e
+    create :submission, user: users_all[0], exercise: e, status: :wrong
 
     assert_equal 3, e.users_tried
     assert_equal 1, e.users_tried(course: course1)
     assert_equal 1, e.users_tried(course: course2)
 
     users_c1.each do |user|
-      create :submission, user: user, course: course1, exercise: e
+      create :submission, user: user, course: course1, exercise: e, status: :wrong
     end
     assert_equal 7, e.users_tried
     assert_equal 5, e.users_tried(course: course1)
     assert_equal 1, e.users_tried(course: course2)
 
     users_c2.each do |user|
-      create :submission, user: user, course: course2, exercise: e
+      create :submission, user: user, course: course2, exercise: e, status: :wrong
     end
     assert_equal 11, e.users_tried
     assert_equal 5, e.users_tried(course: course1)
     assert_equal 5, e.users_tried(course: course2)
     users_all.each do |user|
-      create :submission, user: user, exercise: e
+      create :submission, user: user, exercise: e, status: :wrong
+    end
+    assert_equal 15, e.users_tried
+    assert_equal 5, e.users_tried(course: course1)
+    assert_equal 5, e.users_tried(course: course2)
+    users_all.each do |user|
+      create :submission, user: user, exercise: e, status: :running
     end
     assert_equal 15, e.users_tried
     assert_equal 5, e.users_tried(course: course1)

--- a/test/models/transient/exercise_summary.rb
+++ b/test/models/transient/exercise_summary.rb
@@ -282,6 +282,28 @@ module ExerciseSummaryTests
     end
   end
 
+  class NotYetJudged < ExerciseSummaryTest
+    setup do
+      submit status: :running
+    end
+
+    test 'should not have been submitted' do
+      assert_not summary.submitted?
+    end
+
+    test 'should not be solved' do
+      assert_not summary.solved?
+    end
+
+    test 'should not have been tried' do
+      assert_equal 0, summary.users_tried
+    end
+
+    test 'should not have been completed' do
+      assert_equal 0, summary.users_correct
+    end
+  end
+
   class ExercisesSummaryTest < ExerciseSummaryTest
     setup do
       @series.update deadline: Time.current

--- a/test/models/transient/series_summary_test.rb
+++ b/test/models/transient/series_summary_test.rb
@@ -1,0 +1,33 @@
+class SeriesSummaryTest < ActiveSupport::TestCase
+  setup do
+    @course = create :course
+    @series = create :series, course: @course, exercise_count: 5
+    @user = create :user, courses: [@course]
+  end
+
+  def summary
+    SeriesSummary.new(
+      user: @user,
+      series: @series,
+      exercises: @series.exercises
+    )
+  end
+end
+
+class RunningTest < SeriesSummaryTest
+  test 'should not have started yet' do
+    create :submission, user: @user, course: @course, exercise: @series.exercises.first, status: :running
+    assert_not summary.started?
+    assert_equal 0, summary.number_wrong
+    assert_equal 0, summary.number_solved
+  end
+
+  test 'should not change status if there is a previous submission' do
+    create :submission, user: @user, course: @course, exercise: @series.exercises.first, status: :correct, accepted: true
+    create :submission, user: @user, course: @course, exercise: @series.exercises.first, status: :running
+    assert_equal 'started', summary.progress_status
+    assert summary.started?
+    assert_equal 0, summary.number_wrong
+    assert_equal 1, summary.number_solved
+  end
+end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -166,6 +166,9 @@ class UserTest < ActiveSupport::TestCase
 
     create :wrong_submission, user: user, exercise: exercise3
     assert_user_exercises user, 3, 2, 1
+
+    create :submission, user: user, exercise: exercise3
+    assert_user_exercises user, 3, 2, 1
   end
 
   test 'only smartschool users can have blank email' do


### PR DESCRIPTION
Also fixes the `users_tried` and `attempted_exercises` to only take judged submissions into account.

- [x] Tests were added
- No relevant documentation.

Closes #1322.
