### PR TITLE
Add release-drafter action

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,15 @@
+categories:
+  - title: "✨ New Features"
+    label: "feature"
+  - title: "🐛 Bug Fixes"
+    label: "bug fix"
+  - title: "🧰 Maintenance"
+    label: "chore"
+exclude-labels:
+  - "dependencies"
+template: |
+  $CHANGES
+change-template: "- $TITLE (#$NUMBER)"
+branches:
+  - feature/release-drafter
+  - develop

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,17 @@
+name: Release Drafter
+
+on:
+  push:
+    # branches to consider in the event; optional, defaults to all
+    #branches:
+    #  - develop
+
+jobs:
+  update_draft_release:
+    name: Update Draft Release
+    runs-on: ubuntu-latest
+    steps:
+      # Drafts next release notes as Pull Requests are merged into "develop"
+      - uses: toolmantim/release-drafter@v5.2.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request adds a release drafter action to automatically draft release notes based on pull requests. This is probably only part 1 since there needs to be a config file on develop to get it working.

<!-- If there are visual changes, add a screenshot -->

- no tests
- no documentation
