### PR TITLE
fix users being unable to subscribe to hidden courses

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -23,7 +23,7 @@ class CoursesController < ApplicationController
   # GET /courses/1
   # GET /courses/1.json
   def show
-    if @course.hidden? || (@course.visible_for_institution? && current_user&.institution != @course.institution)
+    if @course.secret_required?(current_user)
       redirect_unless_secret_correct
       return if performed?
     end
@@ -179,7 +179,7 @@ class CoursesController < ApplicationController
   end
 
   def subscribe
-    redirect_unless_secret_correct if @course.hidden?
+    redirect_unless_secret_correct if @course.secret_required?(current_user)
     return if performed? # return if redirect happenned
 
     respond_to do |format|

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -145,6 +145,13 @@ class Course < ApplicationRecord
     self.secret = SecureRandom.urlsafe_base64(5)
   end
 
+  def secret_required?(user = nil)
+    return false if visible_for_all?
+    return false if visible_for_institution? && user&.institution == institution
+
+    true
+  end
+
   def invalidate_subscribed_members_count_cache
     Rails.cache.delete(format(SUBSCRIBED_MEMBERS_COUNT_CACHE_STRING, id: id))
   end

--- a/app/views/courses/_not_a_member_card.html.erb
+++ b/app/views/courses/_not_a_member_card.html.erb
@@ -13,7 +13,7 @@
       <% end %>
     <% end %>
     <% unless @course.closed? %>
-      <%= registration_action_for course: @course, membership: @current_membership, secret: (@course.secret unless @course.open_for_all?) %>
+      <%= registration_action_for course: @course, membership: @current_membership, secret: (@course.secret if @course.secret_required?(current_user)) %>
     <% end %>
   </div>
 </div>

--- a/test/controllers/courses_controller_test.rb
+++ b/test/controllers/courses_controller_test.rb
@@ -469,4 +469,31 @@ class CoursesPermissionControllerTest < ActionDispatch::IntegrationTest
     post courses_url, params: { course: { name: new_course.name, description: new_course.description, visibility: new_course.visibility, registration: new_course.registration, teacher: new_course.teacher }, copy_options: { base_id: course.id }, format: :json }
     assert_equal 0, Course.find(JSON.parse(response.body)['id']).series.count
   end
+
+  test 'hidden course page shown to unsubscribed student should include registration url with secret' do
+    @course.update(visibility: :hidden)
+    user = @externals.first
+    sign_in user
+    get course_url(@course, secret: @course.secret)
+    assert response.body.include?(subscribe_course_path(@course, secret: @course.secret))
+  end
+
+  test 'visible_for_institution course page shown to unsubscribed student of different institution should include registration url with secret' do
+    @course.update(visibility: :visible_for_institution, institution: (create :institution))
+    user = @externals.first
+    user.update(institution: (create :institution))
+    sign_in user
+    get course_url(@course, secret: @course.secret)
+    assert response.body.include?(subscribe_course_path(@course, secret: @course.secret))
+  end
+
+  test 'visible_for_institution course page shown to unsubscribed student of same institution should not include registration url with secret' do
+    @course.update(visibility: :visible_for_institution, institution: (create :institution))
+    user = @externals.first
+    user.update(institution: @course.institution)
+    sign_in user
+    get course_url(@course, secret: @course.secret)
+    assert_not response.body.include?(subscribe_course_path(@course, secret: @course.secret))
+  end
+
 end

--- a/test/models/course_test.rb
+++ b/test/models/course_test.rb
@@ -31,4 +31,41 @@ class CourseTest < ActiveSupport::TestCase
     course = create :course, year: '2017 - 2018'
     assert_equal '2017–2018', course.formatted_year
   end
+
+  test 'hidden course should always require secret' do
+    course = create :course, institution: (create :institution), visibility: :hidden
+    user1 = create :user, institution: nil
+    user2 = create :user, institution: course.institution
+    user3 = create :user, institution: (create :institution)
+
+    assert course.secret_required?
+    assert course.secret_required?(user1)
+    assert course.secret_required?(user2)
+    assert course.secret_required?(user3)
+  end
+
+  test 'visible_for_institution course should not require secret for user of institution' do
+    course = create :course, institution: (create :institution), visibility: :visible_for_institution
+    user1 = create :user, institution: nil
+    user2 = create :user, institution: course.institution
+    user3 = create :user, institution: (create :institution)
+
+    assert course.secret_required?
+    assert course.secret_required?(user1)
+    assert_not course.secret_required?(user2)
+    assert course.secret_required?(user3)
+  end
+
+  test 'visible_for_all course should never require secret' do
+    course = create :course, institution: (create :institution), visibility: :visible_for_all
+    user1 = create :user, institution: nil
+    user2 = create :user, institution: course.institution
+    user3 = create :user, institution: (create :institution)
+
+    assert_not course.secret_required?
+    assert_not course.secret_required?(user1)
+    assert_not course.secret_required?(user2)
+    assert_not course.secret_required?(user3)
+  end
+
 end


### PR DESCRIPTION
The condition for adding the secret token to the URL was wrong, resulting in the secret not being added on courses that were open and hidden. This fixes the condition for the secret. The condition for the checking of the secret was also wrong, so I updated that one as well.

- [x] Tests were added
- No relevant documentation changes.
