### PR TITLE
exclude a few lines from test coverage reporting

### DIFF
--- a/app/runners/submission_runner.rb
+++ b/app/runners/submission_runner.rb
@@ -146,8 +146,10 @@ class SubmissionRunner
         # We check the maximum memory usage every second. This is obviously monotonic, but these stats aren't available after the container is/has stopped.
         memory = stats['memory_stats']['max_usage'] / (1024.0 * 1024.0) if stats['memory_stats']&.fetch('max_usage', nil)
       end
+      # :nocov:
       container.stop
       true
+      # :nocov:
     end
     outlines, errlines = container.tap(&:start).attach(
       stdin: StringIO.new(@config.to_json),


### PR DESCRIPTION
This pull request excludes 2 lines from test coverage reporting to prevent random variation in coverage when running the tests.