### PR TITLE
simplify diff tables when output is too large

### DIFF
--- a/app/assets/stylesheets/models/submissions.css.less
+++ b/app/assets/stylesheets/models/submissions.css.less
@@ -85,6 +85,7 @@
     }
     td.line-nr {
       text-align: right;
+      white-space: pre-wrap;
     }
     th {
       font-weight: normal;

--- a/app/helpers/renderers/feedback_table_renderer.rb
+++ b/app/helpers/renderers/feedback_table_renderer.rb
@@ -245,18 +245,11 @@ class FeedbackTableRenderer
   end
 
   def diff(t)
+    differ = LCSHtmlDiffer.new(t[:generated], t[:expected])
     @builder.div(class: "diffs show-#{@diff_type}") do
-      diff_split(t)
-      diff_unified(t)
+      @builder << differ.split
+      @builder << differ.unified
     end
-  end
-
-  def diff_unified(t)
-    @builder << LCSHtmlDiffer.new(t[:generated], t[:expected]).unified
-  end
-
-  def diff_split(t)
-    @builder << LCSHtmlDiffer.new(t[:generated], t[:expected]).split
   end
 
   def message(m)


### PR DESCRIPTION
This pull request changes the rendering of the diff tables to only have one or two rows (depending on unified/split) if the number of lines in either the expected or the generated output is larger than 200. For unified, one row containing the generated line numbers and content is added and one containing expected line numbers and content. For split, one row containing everything is added. The result can be seen in the screenshots below.

##### Unified
![image](https://user-images.githubusercontent.com/42220376/66044642-550bdb80-e522-11e9-8871-5ab9ff679de9.png)
##### Split
![Screenshot_2019-10-02 Oplossing](https://user-images.githubusercontent.com/42220376/66044658-5b9a5300-e522-11e9-9ff4-114aca5f319a.png)

These changes made the page load a lot faster on my machine (~4s to ~400ms).

- No tests were added (not really sure how to test, I'm open to ideas).
- No relevant documentation changes.
