### PR TITLE
notify us if there are requests that take over 2 seconds

### DIFF
--- a/config/initializers/exception_notification.rb
+++ b/config/initializers/exception_notification.rb
@@ -1,3 +1,14 @@
 ExceptionNotifier.add_notifier :event_logger, ->(e, options) {
   Event.create(event_type: :error, user: Current.user, message: e.message)
 }
+
+ActiveSupport::Notifications.subscribe "process_action.action_controller" do |name, start, finish, id, payload|
+  if finish - start > 2.seconds && payload[:controller] != "StatisticsController"
+    headers = payload.delete :headers
+    ExceptionNotifier.notify_exception(
+      Exception.new("A request took over 2 seconds"),
+      env: headers.env,
+      data: payload
+    )
+  end
+end


### PR DESCRIPTION
The StatisticsController is excluded since we know that there are long-running requests there. (This is something that should probably be fixed.)

- No tests were added.
- No relevant documentation changes.
