### PR TITLE
Remove long-running requests from the statistics controller

### DIFF
--- a/app/assets/javascripts/heatmap.ts
+++ b/app/assets/javascripts/heatmap.ts
@@ -21,7 +21,11 @@ function setToAYStart(day: moment.Moment): moment.Moment {
 
 function initHeatmap(url: string, oldestFirst: boolean, year: string | undefined): void {
     d3.select(selector).attr("class", "text-center").append("span").text(I18n.t("js.loading"));
-    d3.json(url).then(data => {
+    const processor = function (data): void {
+        if (data["status"] == "not available yet") {
+            setTimeout(() => d3.json(url).then(processor), 1000);
+            return;
+        }
         d3.select(`${selector} *`).remove();
 
         const keys = Object.keys(data).sort();
@@ -53,7 +57,8 @@ function initHeatmap(url: string, oldestFirst: boolean, year: string | undefined
             oldestFirst,
             year
         );
-    });
+    };
+    d3.json(url).then(processor);
 }
 
 function drawHeatmap(data: [moment.Moment, number][], oldestFirst: boolean, year: string | undefined): void {

--- a/app/assets/javascripts/punchcard.js
+++ b/app/assets/javascripts/punchcard.js
@@ -37,9 +37,15 @@ function initPunchcard(url, timezoneOffset) {
         .attr("y", innerHeight / 2)
         .style("text-anchor", "middle");
 
+    const processor = data => {
+        if (data["status"] === "not available yet") {
+            setTimeout(() => d3.json(url).then(processor), 1000);
+            return;
+        }
+        renderCard(d3.entries(applyTimezone(data, timezoneOffset)), unitSize, chart, x, y);
+    };
     d3.json(url)
-        .then(data => applyTimezone(data, timezoneOffset))
-        .then(data => renderCard(d3.entries(data), unitSize, chart, x, y));
+        .then(processor);
 
     const xAxis = d3.axisBottom(x)
         .ticks(24)

--- a/app/controllers/statistics_controller.rb
+++ b/app/controllers/statistics_controller.rb
@@ -4,13 +4,21 @@ class StatisticsController < ApplicationController
   def punchcard
     result = Submission.get_punchcard_matrix(@user, @course)
     Submission.delay(queue: 'statistics').update_punchcard_matrix(@user, @course)
-    render json: result[:matrix]
+    if result.present?
+      render json: result[:matrix]
+    else
+      render json: { status: 'not available yet' }, status: :accepted
+    end
   end
 
   def heatmap
     result = Submission.get_heatmap_matrix(@user, @course)
     Submission.delay(queue: 'statistics').update_heatmap_matrix(@user, @course)
-    render json: result[:matrix]
+    if result.present?
+      render json: result[:matrix]
+    else
+      render json: { status: 'not available yet' }, status: :accepted
+    end
   end
 
   private

--- a/config/initializers/exception_notification.rb
+++ b/config/initializers/exception_notification.rb
@@ -3,7 +3,7 @@ ExceptionNotifier.add_notifier :event_logger, ->(e, options) {
 }
 
 ActiveSupport::Notifications.subscribe "process_action.action_controller" do |name, start, finish, id, payload|
-  if finish - start > 2.seconds && payload[:controller] != "StatisticsController"
+  if finish - start > 2.seconds
     headers = payload.delete :headers
     ExceptionNotifier.notify_exception(
       Exception.new("A request took over 2 seconds"),


### PR DESCRIPTION
This pull request changes the actions in the statistics controller to no longer perform long requests. This is done by returning a special response that can be interpreted by the front-end to know that it should retry the request later. I've chosen `202 Accepted` as the HTTP status code for that response, since a job will be started ("accepted for processing") when the request is performed.

One potential issue is that a number of jobs will be created, since the front-end code checks if there is a result every second. I don't think this will be that much of a problem however, since the later jobs will only run for a very short time (they will query the database for submissions later than the latest result and there won't be any).

- No tests were added (there aren't any tests for the statistics controller yet).
- No relevant documentation changes.
