### PR TITLE
staging environment changes

### DIFF
--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -25,4 +25,16 @@ namespace :deploy do
       end
     end
   end
+
+  namespace :assets do
+    before :precompile, :yarn_install do
+      on release_roles(fetch(:assets_roles)) do
+        within release_path do
+          with rails_env: fetch(:rails_env) do
+            execute :yarn, "install"
+          end
+        end
+      end
+    end
+  end
 end

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -30,25 +30,15 @@ Rails.application.configure do
   # Creates IllegalStateError on simultaneous requests (see https://github.com/dpogue/rails_server_timings/issues/6)
   config.server_timings.enabled = false
 
-  # Enable/disable caching. By default caching is disabled.
-  # Run rails dev:cache to toggle caching.
-  if Rails.root.join('tmp', 'caching-dev.txt').exist?
-    config.action_controller.perform_caching = true
-    config.action_controller.enable_fragment_cache_logging = true
+  config.action_controller.perform_caching = true
+  config.action_controller.enable_fragment_cache_logging = true
 
-    config.action_mailer.perform_caching = false
+  config.action_mailer.perform_caching = false
 
-    config.cache_store = :mem_cache_store, {namespace: :"1"}
-    config.public_file_server.headers = {
-        'Cache-Control' => "public, max-age=#{2.days.to_i}"
-    }
-  else
-    config.action_controller.perform_caching = false
-
-    config.action_mailer.perform_caching = false
-
-    config.cache_store = :null_store
-  end
+  config.cache_store = :mem_cache_store, {namespace: :"1"}
+  config.public_file_server.headers = {
+      'Cache-Control' => "public, max-age=#{2.days.to_i}"
+  }
 
   # Store uploaded files on the local file system (see config/storage.yml for options)
   config.active_storage.service = :local


### PR DESCRIPTION
This pull request changes the configuration and deployment of the staging environment. The `yarn install` step is re-introduced and caching is (always) enabled instead of requiring a specific file to be present.

- No relevant tests.
- No relevant documentation changes.