### PR TITLE
disallow "command" in full output json schema

### DIFF
--- a/public/schemas/judge_output.json
+++ b/public/schemas/judge_output.json
@@ -12,6 +12,11 @@
         "messages":    { "type": "array", "items": { "$ref": "#/definitions/message" } },
         "groups":      { "type": "array", "items": { "$ref": "#/definitions/tab" } },
         "annotations": { "type": "array", "items": { "$ref": "#/definitions/annotation" } }
+      },
+      "not": {
+        "properties": {
+          "command": { "type": "string" }
+        }
       }
     },
     "tab": {

--- a/public/schemas/judge_output.json
+++ b/public/schemas/judge_output.json
@@ -14,6 +14,7 @@
         "annotations": { "type": "array", "items": { "$ref": "#/definitions/annotation" } }
       },
       "not": {
+        "required": ["command"],
         "properties": {
           "command": { "type": "string" }
         }

--- a/public/schemas/judge_output.json
+++ b/public/schemas/judge_output.json
@@ -2,7 +2,7 @@
   "$ref": "#/definitions/feedback",
   "definitions": {
     "feedback": {
-      "description": "Root node of the test hierarchy that contains all tests of the submission.",
+      "description": "Root node of the test hierarchy that contains all tests of the submission. Cannot contain a command key with a string value to avoid confusion with the partial schema.",
       "type": "object",
       "required": ["accepted", "status"],
       "properties": {

--- a/test/runners/result_constructor_test.rb
+++ b/test/runners/result_constructor_test.rb
@@ -309,6 +309,21 @@ class ResultConstructorTest < ActiveSupport::TestCase
     assert_nil result[:groups][3][:permission]
   end
 
+  test 'wrong partial json is not confused with full json' do
+    assert_raises ResultConstructorError do
+      construct_result([
+        '{ "command": "start-judgement" }',
+        '{ "title": "Test", "command": "start-tab" }',
+        '{ "description": { "format": "code", "description": "..." }, "command": "start-context" }',
+        '{ "description": { "format": "plain", "description": "" }, "command": "start-testcase" }',
+        '{ "expected": "70", "command": "start-test" }',
+        # the entry below is an invalid partial json, but seems a valid full json
+        # the "command" key is therefore forbidden in full json
+        '{ "generated": "45", "status": "wrong", "accepted": false, "command": "close-test" }'
+      ])
+    end
+  end
+
   private
 
   def construct_result(food, locale: 'en', timeout: false)


### PR DESCRIPTION
So we avoid confusion with the partial output json schema, which
requires a "command" enum. This assumes there are no existing full
output json results with a "command" key in the json root.

- [x] Tests were added
- [x] No documentation update is required as it's mentioned nowhere you can use extra keys in the judge output.

Closes #1329.