### PR TITLE
Fix striped tables in dark mode

### DIFF
--- a/app/assets/stylesheets/theme/theme-dark.css.less
+++ b/app/assets/stylesheets/theme/theme-dark.css.less
@@ -54,6 +54,7 @@
 @alert-danger-bg: inherit;
 
 @table-border-color: @hairlinegray;
+@table-bg-accent: @body-bg;
 
 @nav-link-hover-bg: darken(@body-bg, 3%);
 @nav-tabs-border-color: @hairlinegray;


### PR DESCRIPTION
This pull request fixes the background color of striped tables (undocumented feature, but used in some exercise descriptions) in dark mode.

![image](https://user-images.githubusercontent.com/481872/66253370-888b7780-e767-11e9-864a-3b4585a4380a.png)
(the remaining artefact is an issue with the exercise description)

Closes #1356 
