### PR TITLE
point sidebar link to new docs website

### DIFF
--- a/app/views/layouts/_drawer.html.erb
+++ b/app/views/layouts/_drawer.html.erb
@@ -141,7 +141,7 @@
           <% end %>
         </li>
         <li>
-          <%= link_to 'https://dodona.readthedocs.io/', class: 'drawer-list-item' do %>
+          <%= link_to 'https://dodona-edu.github.io', class: 'drawer-list-item' do %>
             <i class="mdi mdi-help-circle mdi-24"></i>
             <%= t('layout.menu.manual') %>
           <% end %>


### PR DESCRIPTION
This pull request changes the sidebar documentation link to the github pages website instead of the read the docs website. The home page of the read the docs website still contains a link to read the docs.
