### PR TITLE
remove double yarn install

### DIFF
--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -36,16 +36,4 @@ namespace :deploy do
       end
     end
   end
-
-  namespace :assets do
-    before :precompile, :yarn_install do
-      on release_roles(fetch(:assets_roles)) do
-        within release_path do
-          with rails_env: fetch(:rails_env) do
-            execute :yarn, "install"
-          end
-        end
-      end
-    end
-  end
 end


### PR DESCRIPTION
#1234 also re-added the yarn install part of the staging deploy, resulting in it doubly showing up.

- [x] No relevant tests.
- [x] No relevant documentation.
