### PR TITLE
Optimize feedback table

### DIFF
--- a/app/helpers/renderers/feedback_table_renderer.rb
+++ b/app/helpers/renderers/feedback_table_renderer.rb
@@ -276,7 +276,7 @@ class FeedbackTableRenderer
       @builder.span(class: "code highlighter-rouge #{m[:format]}") do
         formatter = Rouge::Formatters::HTML.new(wrap: false)
         lexer = (Rouge::Lexer.find(m[:format].downcase) || Rouge::Lexers::PlainText).new
-        @builder << safe(formatter.format(lexer.lex(m[:description])))
+        @builder << formatter.format(lexer.lex(m[:description]))
       end
     end
   end

--- a/app/helpers/renderers/lcs_html_differ.rb
+++ b/app/helpers/renderers/lcs_html_differ.rb
@@ -7,7 +7,14 @@ class LCSHtmlDiffer
     @generated_linecount = generated&.lines&.count || 0
     @expected_linecount = expected&.lines&.count || 0
     @simplified_table = @generated_linecount > 200 || @expected_linecount > 200
-    @diff = Diff::LCS.sdiff(@generated.split("\n", -1), @expected.split("\n", -1)) unless @simplified_table
+    @diff = unless @simplified_table
+              Diff::LCS.sdiff(@generated.split("\n", -1), @expected.split("\n", -1)).map do |chunk|
+                return chunk unless chunk.action == '!'
+
+                gen_result, exp_result = diff_strings(chunk.old_element, chunk.new_element)
+                Diff::LCS::ContextChange.new('!', chunk.old_position, gen_result, chunk.new_position, exp_result)
+              end
+            end
   end
 
   def unified
@@ -134,14 +141,15 @@ class LCSHtmlDiffer
         end
       end
     when '!'
-      gen_result, exp_result = diff_strings(chunk.old_element, chunk.new_element)
+      # The new_element and old_element fields have been preprocessed
+      # in the constructor and therefore don't need to be escaped.
       builder.tr do
         builder.td(class: 'line-nr') do
           builder << (chunk.old_position + 1).to_s
         end
         builder.td(class: 'line-nr')
         builder.td(class: 'del') do
-          builder << gen_result
+          builder << chunk.old_element
         end
       end
       builder.tr do
@@ -150,7 +158,7 @@ class LCSHtmlDiffer
           builder << (chunk.new_position + 1).to_s
         end
         builder.td(class: 'ins') do
-          builder << exp_result
+          builder << chunk.new_element
         end
       end
     end
@@ -213,26 +221,27 @@ class LCSHtmlDiffer
         end
       end
     when '!'
-      gen_result, exp_result = diff_strings(chunk.old_element, chunk.new_element)
+      # The new_element and old_element fields have been preprocessed
+      # in the constructor and therefore don't need to be escaped.
       builder.tr do
         builder.td(class: 'line-nr') do
           builder << (chunk.old_position + 1).to_s
         end
         builder.td(class: 'del') do
-          builder << gen_result
+          builder << chunk.old_element
         end
         builder.td(class: 'line-nr') do
           builder << (chunk.new_position + 1).to_s
         end
         builder.td(class: 'ins') do
-          builder << exp_result
+          builder << chunk.new_element
         end
       end
     end
   end
 
   def diff_strings(generated, expected)
-    return [CGI.escape_html(generated), CGI.escape_html(expected)] if generated.length > 200 || expected.length > 200
+    return [CGI.escape_html(generated), CGI.escape_html(expected)] if generated.length > 100 || expected.length > 100
 
     exp_result = ''
     gen_result = ''


### PR DESCRIPTION
This pull request optimizes the feedback table renderer. Optimizations performed:
 * Don't sanitize Rouge formatter output, this should be safe
 * Only do the `diff_strings` operation once for each changed line in the diff output (this used to happen once in `split` and once in `unified`)
 * Reduce the number of characters required to stop diffing changed lines

The resulting profiling flamegraph can be seen here (zip because GH doesn't allow SVG uploads). I don't see more (obvious) opportunities for optimization.
[rbspy-2019-10-08-5Y6VB1dZ9H.flamegraph.svg.zip](https://github.com/dodona-edu/dodona/files/3701744/rbspy-2019-10-08-5Y6VB1dZ9H.flamegraph.svg.zip)

These changes reduced the rendering time of the offending submissions from ~8s to ~1s on my machine.

Closes #1379.
