### PR TITLE
Add navigation to other exercises in a series from the exercise page

### DIFF
--- a/app/assets/stylesheets/models/course.css.less
+++ b/app/assets/stylesheets/models/course.css.less
@@ -26,6 +26,7 @@
   }
 }
 
+.exercise-sidebar,
 .series-sidebar {
   padding: 0;
 

--- a/app/views/exercises/show.html.erb
+++ b/app/views/exercises/show.html.erb
@@ -20,6 +20,18 @@
       <%= description_iframe @exercise %>
     </div>
   </div>
+
+  <% if @series.present? %>
+    <nav class="col-md-1 hidden-xs hidden-sm hidden-print exercise-sidebar">
+      <ul class="nav affix" data-offset-bottom="80">
+        <li class="header ellipsis-overflow"><%= @series.name %></li>
+        <% @series.exercises.each do |exercise| %>
+          <li <%= 'class=active' if exercise.id == @exercise.id %>><%= link_to exercise.name, exercise_scoped_path(exercise: exercise, series: @series), class: 'ellipsis-overflow', title: exercise.name %> </li>
+        <% end %>
+      </ul>
+    </nav>
+  <% end %>
+
 </div>
 <div class="row hidden-print">
   <a class="anchor" id="submission-card"></a>

--- a/test/controllers/exercises_controller_test.rb
+++ b/test/controllers/exercises_controller_test.rb
@@ -415,11 +415,11 @@ class ExerciseDescriptionTest < ActionDispatch::IntegrationTest
     assert_includes response.body, 'exercise-sidebar'
   end
 
-    test 'exercise page without series should not contain extra navigation' do
+  test 'exercise page without series should not contain extra navigation' do
     course = create :course
     exercise = create :exercise
     other_exercise = create :exercise
-    series = create :series, course: course, exercises: [exercise, other_exercise]
+    create :series, course: course, exercises: [exercise, other_exercise]
 
     get exercise_url(exercise)
 

--- a/test/controllers/exercises_controller_test.rb
+++ b/test/controllers/exercises_controller_test.rb
@@ -402,4 +402,28 @@ class ExerciseDescriptionTest < ActionDispatch::IntegrationTest
 
     assert_not_includes response.body, 'What is your favorite colour?'
   end
+
+  test 'exercise page within series should contain extra navigation' do
+    course = create :course
+    exercise = create :exercise
+    other_exercise = create :exercise
+    series = create :series, course: course, exercises: [exercise, other_exercise]
+
+    get course_series_exercise_url(course, series, exercise)
+
+    assert_response :success
+    assert_includes response.body, 'exercise-sidebar'
+  end
+
+    test 'exercise page without series should not contain extra navigation' do
+    course = create :course
+    exercise = create :exercise
+    other_exercise = create :exercise
+    series = create :series, course: course, exercises: [exercise, other_exercise]
+
+    get exercise_url(exercise)
+
+    assert_response :success
+    assert_not_includes response.body, 'exercise-sidebar'
+  end
 end


### PR DESCRIPTION
This pull request adds navigation to other exercises in a series from the exercise page.

![image (1)](https://user-images.githubusercontent.com/481872/66486408-d4615800-eaaa-11e9-9d35-4ecd6b3990f7.png)
- [x] Tests were added
- no relevant documentation

A next version could include the exercise status.