### PR TITLE
Don't open error emails with letter opener for local requests

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -38,9 +38,9 @@ Rails.application.configure do
 
     config.action_mailer.perform_caching = false
 
-    config.cache_store = :mem_cache_store, {namespace: :"1"}
+    config.cache_store = :mem_cache_store, { namespace: :"1" }
     config.public_file_server.headers = {
-        'Cache-Control' => "public, max-age=#{2.days.to_i}"
+      'Cache-Control': "public, max-age=#{2.days.to_i}"
     }
   else
     config.action_controller.perform_caching = false
@@ -89,11 +89,11 @@ Rails.application.configure do
   # config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
   config.middleware.use ExceptionNotification::Rack,
-                        ignore_if: ->(env, _exception) {env['HTTP_HOST'] == 'localhost:3000'},
+                        ignore_if: ->(env, _exception) { env['HTTP_HOST'] == 'localhost:3000' || env['HTTP_HOST'] == 'dodona.localhost:3000' },
                         email: {
-                            email_prefix: '[Dodona-dev] ',
-                            sender_address: %("Dodona" <dodona@ugent.be>),
-                            exception_recipients: %w[dodona@ugent.be]
+                          email_prefix: '[Dodona-dev] ',
+                          sender_address: %("Dodona" <dodona@ugent.be>),
+                          exception_recipients: %w[dodona@ugent.be]
                         }
   config.action_mailer.delivery_method = :letter_opener
   # Defaults to:


### PR DESCRIPTION
Since using `dodona.localhost:3000` is now how we recommend local development, turn off letter opener for foreground errors. It was annoying me.