### PR TITLE
Tell capistrano-rvm about our custom rvm location

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -10,6 +10,9 @@ set :repo_url, 'git@github.com:dodona-edu/dodona.git'
 # Default deploy_to directory is /var/www/my_app_name
 set :deploy_to, '/home/dodona/rails'
 
+# RVM is installed globally using apt
+set :rvm_custom_path, '/usr/share/rvm'
+
 # Default value for :scm is :git
 # set :scm, :git
 


### PR DESCRIPTION
`capistrano-rvm` usually autodetects system installs of rvm but looks for it in `/usr/local/share/rvm` instead of our `/usr/share/rvm`. This tells `capistrano-rvm` the correct location.
