### PR TITLE
send notification when a submission's status is changed to internal error

### DIFF
--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -36,6 +36,7 @@ class Submission < ApplicationRecord
   validate :not_rate_limited?, on: :create, unless: :skip_rate_limit_check?
 
   before_update :update_fs
+  before_save :report_if_internal_error
   after_create :evaluate_delayed, if: :evaluate?
   after_save :invalidate_caches
   after_destroy :invalidate_caches
@@ -330,5 +331,11 @@ class Submission < ApplicationRecord
 
     FileUtils.mkdir_p File.dirname new_path
     FileUtils.move old_path, new_path
+  end
+
+  def report_if_internal_error
+    return unless status_changed? && send(:"internal error?")
+
+    ExceptionNotifier.notify_exception(Exception.new("Submission(#{id}) status was changed to internal error"), data: { host: `hostname`, submission: self })
   end
 end

--- a/test/models/submission_test.rb
+++ b/test/models/submission_test.rb
@@ -261,4 +261,10 @@ class SubmissionTest < ActiveSupport::TestCase
     50.times { create :submission, created_at: Faker::Time.between(from: Time.current - 5.years, to: Time.current), course: course }
     assert_equal 50, Submission.old_heatmap_matrix(course: course)[:value].values.sum
   end
+
+  test 'update to internal error should send exception notification' do
+    submission = create :submission
+    ExceptionNotifier.expects(:notify_exception)
+    submission.update(status: :"internal error")
+  end
 end

--- a/test/runners/submission_runner_test.rb
+++ b/test/runners/submission_runner_test.rb
@@ -213,7 +213,7 @@ class SubmissionRunnerTest < ActiveSupport::TestCase
     Delayed::Backend::ActiveRecord::Job.delete_all
     Rails.env.stubs(:"production?").returns(true)
     Submission.any_instance.stubs(:judge).raises(STRIKE_ERROR)
-    ExceptionNotifier.stubs(:notify_exception).once
+    ExceptionNotifier.stubs(:notify_exception).twice
     Docker::Container.stubs(:create).returns(docker_mock)
     @submission.evaluate_delayed
     Delayed::Worker.max_attempts = 1


### PR DESCRIPTION
- [x] Tests were added 
- [x] No relevant documentation changes

Closes #1411.
