### PR TITLE
fix synchronization issues around timeout detection

### DIFF
--- a/app/runners/submission_runner.rb
+++ b/app/runners/submission_runner.rb
@@ -123,7 +123,7 @@ class SubmissionRunner
     timeout_mutex = Mutex.new
     timeout = nil
 
-    Thread.new do
+    timer = Thread.new do
       while Time.zone.now - before_time < time_limit
         sleep 1
         next if Rails.env.test?
@@ -148,6 +148,7 @@ class SubmissionRunner
       stderr: true
     )
     timeout_mutex.synchronize do
+      timer.kill
       timeout = false if timeout.nil?
     end
 

--- a/app/runners/submission_runner.rb
+++ b/app/runners/submission_runner.rb
@@ -134,12 +134,10 @@ class SubmissionRunner
         # We check the maximum memory usage every second. This is obviously monotonic, but these stats aren't available after the container is/has stopped.
         memory = stats['memory_stats']['max_usage'] / (1024.0 * 1024.0) if stats['memory_stats']&.fetch('max_usage', nil)
       end
-      # :nocov:
       timeout_mutex.synchronize do
         container.stop
         timeout = true if timeout.nil?
       end
-      # :nocov:
     end
 
     outlines, errlines = container.tap(&:start).attach(

--- a/test/factories/exercises.rb
+++ b/test/factories/exercises.rb
@@ -65,7 +65,7 @@ FactoryBot.define do
     end
 
     after :build do |exercise|
-      exercise.stubs(:merged_config).returns('evaluation' => {})
+      exercise.stubs(:merged_config).returns('evaluation' => { 'time_limit' => 1 })
     end
 
     trait :nameless do

--- a/test/runners/submission_runner_test.rb
+++ b/test/runners/submission_runner_test.rb
@@ -175,20 +175,6 @@ class SubmissionRunnerTest < ActiveSupport::TestCase
                       accepted: false
   end
 
-  test 'dockers killed by 15 before timeout should result in memory limit exceeded' do
-    Thread.stubs(:new).returns(mock(kill: nil, value: nil))
-    evaluate_with_stubbed_docker output: nil, status_code: 128 + 15
-    assert_submission status: 'memory limit exceeded',
-                      accepted: false
-  end
-
-  test 'dockers killed by 15 at timeout should result in time limit exceeded' do
-    Thread.stubs(:new).returns(mock(kill: nil, value: true))
-    evaluate_with_stubbed_docker output: nil, status_code: 128 + 15
-    assert_submission status: 'time limit exceeded',
-                      accepted: false
-  end
-
   test 'error in docker creation should result in internal error' do
     Docker::Container.stubs(:create).raises(STRIKE_ERROR)
 


### PR DESCRIPTION
It seems that in most (all?) cases, the main thread continues when `container.stop` is called from the timer thread. This results in the timer thread not having finished yet (and therefore not having set its value to `true`). This made us misreport the reason the container was stopped.

By synchronizing around a mutex we can be sure the timer thread gets to set the `timeout` value if it was the reason the container stopped.

- [x] Tests were added
- [x] No relevant documentation changes

Closes #1120.
