### PR TITLE
implement safe exercise descriptions in API

### DIFF
--- a/app/views/exercises/_exercise.json.jbuilder
+++ b/app/views/exercises/_exercise.json.jbuilder
@@ -9,5 +9,6 @@ if current_user
   json.has_solution exercise.last_submission(current_user).present?
   json.has_correct_solution exercise.last_correct_submission(current_user).present?
 end
-json.description exercise.description_localized
+json.description 'Deprecated. Use description_url'
+json.description_url description_exercise_url(exercise, token: exercise.access_token)
 json.url exercise_scoped_url(exercise: exercise, series: series, course: course, options: { format: :json })

--- a/test/controllers/exercises_controller_test.rb
+++ b/test/controllers/exercises_controller_test.rb
@@ -433,4 +433,18 @@ class ExerciseDescriptionTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_not_includes response.body, 'exercise-sidebar'
   end
+
+  test 'json representation of exercise should contain the sandbox and access token in its description url' do
+    exercise = create :exercise
+
+    get exercise_url(exercise), params: { format: :json }
+
+    assert_response :success
+
+    exercise_json = JSON.parse response.body
+    description_url = exercise_json['description_url']
+
+    assert description_url.include?(Rails.configuration.sandbox_host)
+    assert description_url.include?(exercise.access_token)
+  end
 end


### PR DESCRIPTION
This pull request adds exercise descriptions to the API, via the sandbox.

**/exercise/x.json**
```json
{
"description": "http://sandbox.url/exercises/x/description/?token=some_token"
}
```

- [x] Tests were added
- [x] No relevant documentation updates
