### PR TITLE
Remove doubly-defined test

### DIFF
--- a/test/models/submission_test.rb
+++ b/test/models/submission_test.rb
@@ -267,10 +267,4 @@ class SubmissionTest < ActiveSupport::TestCase
     ExceptionNotifier.expects(:notify_exception)
     submission.update(status: :"internal error")
   end
-
-  test 'update to internal error should send exception notification' do
-    submission = create :submission
-    ExceptionNotifier.expects(:notify_exception)
-    submission.update(status: :"internal error")
-  end
 end


### PR DESCRIPTION
This pull request removes a test that was defined twice.
