### PR TITLE
remove iframe centering outside iframes on series overview

### DIFF
--- a/app/views/series/overview.html.erb
+++ b/app/views/series/overview.html.erb
@@ -35,9 +35,4 @@
       </div>
     </div>
   <% end %>
-  <script type="text/javascript">
-      $(function () {
-          dodona.initExerciseDescription();
-      });
-  </script>
 </div>


### PR DESCRIPTION
This pull request removes the exercise initialization outside the description iframes on the series overview page. This was already done on the exercise show page to work around a firefox bug, but was seemingly forgotten on the series overview.

- [x] No relevant tests
- [x] No relevant documentation changes