### PR TITLE
send better emails when submission status changes to internal error

### DIFF
--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -336,6 +336,13 @@ class Submission < ApplicationRecord
   def report_if_internal_error
     return unless status_changed? && send(:"internal error?")
 
-    ExceptionNotifier.notify_exception(Exception.new("Submission(#{id}) status was changed to internal error"), data: { host: `hostname`, submission: self })
+    ExceptionNotifier.notify_exception(
+      Exception.new("Submission(#{id}) status was changed to internal error"),
+      data: {
+        host: `hostname`,
+        submission: inspect,
+        url: Rails.application.routes.url_helpers.submission_url('en', self, host: Rails.application.config.default_host)
+      }
+    )
   end
 end

--- a/test/models/submission_test.rb
+++ b/test/models/submission_test.rb
@@ -264,7 +264,7 @@ class SubmissionTest < ActiveSupport::TestCase
 
   test 'update to internal error should send exception notification' do
     submission = create :submission
-    ExceptionNotifier.expects(:notify_exception)
+    ExceptionNotifier.expects(:notify_exception).with { |_e, data| data[:data][:url].present? }
     submission.update(status: :"internal error")
   end
 end


### PR DESCRIPTION
- [x] Tests were added
- [x] No relevant documentation changes
