### PR TITLE
ignore exceptions from crawlers

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -113,6 +113,7 @@ Rails.application.configure do
   config.server_timings.enabled = false
 
   config.middleware.use ExceptionNotification::Rack,
+                        ignore_crawlers: %w[Googlebot bingbot],
                         ignore_if: ->(env, exception) {
                           env['action_controller.instance'].is_a?(PagesController) &&
                               env['action_controller.instance'].action_name == 'create_contact' &&


### PR DESCRIPTION
This pull request configures `exception_notification` to ignore requests from crawlers. Specifically this will make sure we don't get emails about bots trying the old SAML HoWest sign in method.
