### PR TITLE
add the request UUID and user to ExceptionNotifier

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -22,6 +22,8 @@ class ApplicationController < ActionController::Base
 
   before_action :set_time_zone_offset
 
+  before_action :prepare_exception_notifier
+
   impersonates :user
 
   def after_sign_in_path_for(_resource)
@@ -150,5 +152,12 @@ class ApplicationController < ActionController::Base
 
   def set_time_zone_offset
     @time_zone_offset = Time.zone.now.utc_offset / -60
+  end
+
+  def prepare_exception_notifier
+    request.env['exception_notifier.exception_data'] = {
+      uuid: request.uuid,
+      user: current_user&.id
+    }
   end
 end


### PR DESCRIPTION
This adds a "data" section to sent out exceptions containing
- the UUID of the request and
- and the user causing the error

This will help finding the correct logs.

example data section:
```
-------------------------------
Data:
-------------------------------

  * data: {:uuid=>"5e11a338-8323-42b4-8c11-e2834caafdbb",
   :user=> 1
   :action=>"index",
   :params=>{"controller"=>"judges", "action"=>"index", "locale"=>"nl"},
   :format=>:html,
   :method=>"GET",
   :path=>"/nl/judges",
   :status=>200,
   :view_runtime=>1668.9224310011923,
   :db_runtime=>6.766159995095222}
```

<!-- If there are visual changes, add a screenshot -->

- [ ] Tests were added
- [ ] Documentation update can be found at dodona-edu/dodona-edu.github.io# (not needed)
