### PR TITLE
set frame html and body height to fit-content

### DIFF
--- a/app/assets/stylesheets/layout.css.less
+++ b/app/assets/stylesheets/layout.css.less
@@ -8,6 +8,13 @@ body {
   font-family: @font-family-base;
 }
 
+// Set height of frame layout to fit-content to allow downsizing
+html.dodona-frame,
+html.dodona-frame > body {
+  height: fit-content;
+  background: @content-bg;
+}
+
 #main-container {
   // Prevent the main container from overflowing
   // when its content is too wide
@@ -37,8 +44,4 @@ body {
 iframe {
   width: 100%;
   border: none;
-}
-
-.dodona-frame {
-  background: @content-bg;
 }

--- a/app/views/layouts/frame.html.erb
+++ b/app/views/layouts/frame.html.erb
@@ -1,5 +1,8 @@
 <!DOCTYPE html>
-<html prefix="og: http://ogp.me/ns#" lang="<%= I18n.locale.to_s %>">
+<html
+  prefix="og: http://ogp.me/ns#"
+  lang="<%= I18n.locale.to_s %>"
+  class="dodona-frame">
 <head>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
@@ -26,7 +29,7 @@
   <%= javascript_include_tag 'application' %>
   <%= yield :javascripts %>
 </head>
-<body class="dodona-frame">
+<body>
 <%# Open links in the parent window %>
 <base target="_parent">
   <%= yield %>


### PR DESCRIPTION
A `height: 100%` on the `html` and `body` tag was preventing the frame content from downsizing.

This was fixed by overriding the height with `fit-content` within the frame layout.

Closes #1426 .
