### PR TITLE
use same styling for .test.output as for .code

### DIFF
--- a/app/assets/stylesheets/models/submissions.css.less
+++ b/app/assets/stylesheets/models/submissions.css.less
@@ -63,12 +63,7 @@
       }
     }
   }
-  .test {
-    .output {
-      font-family: @font-family-monospace;
-      white-space: pre-wrap;
-    }
-  }
+  .test .output,
   .code {
     font-family: @font-family-monospace;
     font-size: 13px;


### PR DESCRIPTION
The styling of a `.test.output`  and a `.code` element was almost identical, except that `.test.output` did not set a font size explicitly. This pull request makes their styling shared.

Closes #1465 .
