### PR TITLE
allow words to be broken in feedbacktable if there is no other option

### DIFF
--- a/app/assets/stylesheets/models/submissions.css.less
+++ b/app/assets/stylesheets/models/submissions.css.less
@@ -68,6 +68,7 @@
     font-family: @font-family-monospace;
     font-size: 13px;
     white-space: pre-wrap;
+    overflow-wrap: break-word;
   }
   table.diff {
     overflow: auto;


### PR DESCRIPTION
According to [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-wrap) words will only be broken if there are no other break targets, which seems like a fine compromise to me.

![image](https://user-images.githubusercontent.com/42220376/68768176-4edd4480-0622-11ea-9404-64c40d6363c1.png)

Closes #1486.
