### PR TITLE
Remove CSP report endpoint

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,7 +1,4 @@
 class PagesController < ApplicationController
-  skip_before_action :verify_authenticity_token, only: %i[csp_report]
-  skip_before_action :redirect_to_default_host, only: %i[csp_report]
-
   content_security_policy only: %i[contact] do |policy|
     policy.script_src(*(%w[https://www.recaptcha.net https://www.gstatic.com
                            https://www.google.com] + policy.script_src))
@@ -55,31 +52,6 @@ class PagesController < ApplicationController
       flash[:error] = @contact_form.errors.full_messages.to_sentence
       render :contact
     end
-  end
-
-  def csp_report
-    if request.content_type == 'application/csp-report'
-      raw_report = request.raw_post
-      begin
-        report = JSON.parse(raw_report)['csp-report']
-        message = "CSP Violation Report: blocked '#{report['blocked-uri']}' on page '#{report['document-uri']}' which violated '#{report['violated-directive']}'"
-      rescue JSON::ParserError, NoMethodError => e
-        report = {
-          'error': 'could not parse CSP report',
-          'raw_report': raw_report,
-          'error_message': e.message
-        }
-        message = "Could not parse CSP Violation Report: '#{raw_report}'"
-      end
-      ExceptionNotifier.notify_exception(
-        Exception.new(message.truncate(254)),
-        env: request.env,
-        data: {
-          report: report
-        }
-      )
-    end
-    head :ok
   end
 
   private

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,6 @@ Rails.application.routes.draw do
   end
 
   get '/:locale' => 'pages#home', locale: /(en)|(nl)/
-  post '/csp-report' => 'pages#csp_report'
 
   scope '(:locale)', locale: /en|nl/ do
     get '/sign_in(/:idp)' => 'pages#sign_in_page', as: 'sign_in'

--- a/test/controllers/pages_controller_test.rb
+++ b/test/controllers/pages_controller_test.rb
@@ -45,46 +45,4 @@ class PagesControllerTest < ActionDispatch::IntegrationTest
     end
     assert_redirected_to root_url
   end
-
-  def csp_report
-    %q(
-    {
-      "csp-report": {
-        "document-uri": "http://example.com/signup.html",
-        "referrer": "",
-        "blocked-uri": "http://example.com/css/style.css",
-        "violated-directive": "style-src cdn.example.com",
-        "original-policy": "default-src 'none'; style-src cdn.example.com; report-uri /_/csp-reports"
-      }
-    }
-    )
-  end
-
-  test 'CSP report' do
-    assert_changes 'Event.count', +1 do
-      post csp_report_url,
-           headers: { 'Content-Type': 'application/csp-report' },
-           env: { 'RAW_POST_DATA': csp_report }
-      assert_response :success
-    end
-    assert Event.last.message.start_with?('CSP Violation Report:')
-  end
-
-  test 'Unparsable CSP report' do
-    assert_changes 'Event.count', +1 do
-      post csp_report_url,
-           headers: { 'Content-Type': 'application/csp-report' },
-           env: { 'RAW_POST_DATA': '♥' }
-      assert_response :success
-    end
-    assert Event.last.message.start_with?('Could not parse CSP Violation Report')
-  end
-
-  test 'post to CSP route with wrong content type' do
-    assert_no_changes 'Event.count' do
-      post csp_report_url,
-           env: { 'RAW_POST_DATA': csp_report }
-      assert_response :success
-    end
-  end
 end


### PR DESCRIPTION
This pull request removes the CSP reporting route.

- [X] Tests were removed.

