### PR TITLE
Preserve newlines when editing a submission

### DIFF
--- a/app/assets/javascripts/code_listing.ts
+++ b/app/assets/javascripts/code_listing.ts
@@ -87,8 +87,8 @@ export class CodeListing {
 
     getCode(): string {
         const submissionCode = [];
-        document.querySelectorAll(".lineno .rouge-code")
-            .forEach( codeLine => submissionCode.push(codeLine.textContent));
+        this.table.querySelectorAll(".lineno .rouge-code")
+            .forEach( codeLine => submissionCode.push(codeLine.textContent || "\n"));
         return submissionCode.join("");
     }
 }

--- a/app/assets/javascripts/code_listing.ts
+++ b/app/assets/javascripts/code_listing.ts
@@ -88,7 +88,7 @@ export class CodeListing {
     getCode(): string {
         const submissionCode = [];
         this.table.querySelectorAll(".lineno .rouge-code")
-            .forEach( codeLine => submissionCode.push(codeLine.textContent || "\n"));
-        return submissionCode.join("");
+            .forEach( codeLine => submissionCode.push(codeLine.textContent.replace(/\n$/, "")));
+        return submissionCode.join("\n");
     }
 }


### PR DESCRIPTION
Also scopes this to the current codeListing instead of the whole document

![image](https://user-images.githubusercontent.com/5099359/69899038-37f85b00-1361-11ea-8972-ccf585393705.png)



Closes #1526.
