### PR TITLE
Fix broken description links (lightboxes, videos, ...)

### DIFF
--- a/app/assets/javascripts/exercise.js
+++ b/app/assets/javascripts/exercise.js
@@ -355,14 +355,12 @@ function initExerciseShow(exerciseId, programmingLanguage, loggedIn, editorShown
 }
 
 function contextualizeMediaPaths(parentClass, exercisePath, token) {
-    const attrs = ["src", "href", "action", "cite", "data", "formaction",
-        "longdesc", "manifest", "poster"];
-    const query = attrs.map(attr => `[${attr}^='media/'],[${attr}^='./media/']`).join(",");
     const tokenPart = token ? `?token=${token}` : "";
+    const query = "a[href^='media'],a[href^='./media']";
     Array.from(document.getElementsByClassName(parentClass)).forEach(parent => {
         parent.querySelectorAll(query).forEach(element => {
             Array.from(element.attributes).forEach(attribute => {
-                if (attrs.includes(attribute.name)) {
+                if (attribute.name == "href") {
                     const value = attribute.value;
                     if (value.startsWith("./media/")) {
                         attribute.value = exercisePath + "/media/" +

--- a/app/controllers/exercises_controller.rb
+++ b/app/controllers/exercises_controller.rb
@@ -5,7 +5,7 @@ class ExercisesController < ApplicationController
   before_action :ensure_trailing_slash, only: :show
   before_action :allow_iframe, only: %i[description]
   skip_before_action :verify_authenticity_token, only: [:media]
-  skip_before_action :redirect_to_default_host, only: %i[description media]
+  skip_before_action :redirect_to_default_host, only: %i[description]
 
   has_scope :by_filter, as: 'filter'
   has_scope :by_labels, as: 'labels', type: :array, if: ->(this) { this.params[:labels].is_a?(Array) }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -85,8 +85,11 @@ Rails.application.routes.draw do
 
     resources :exercises, only: %i[index show edit update], concerns: %i[mediable submitable] do
       member do
-        constraints host: Rails.configuration.sandbox_host do
-          get 'description'
+        scope 'description' do
+          constraints host: Rails.configuration.sandbox_host do
+            root to: 'exercises#description', as: 'description'
+          end
+          get 'media/*media', to: 'exercises#media', constraints: {media: /.*/}, as: 'description_media'
         end
       end
     end


### PR DESCRIPTION
Fixed by only rewriting anchors, because that is the only way a student
needs to copy a link to download locally. Additionaly we route
'/exercises/:id/description/media' to `exercises#media` such that the
normal routes don't need to be translated.

Fixes #1525.
