### PR TITLE
CSP: Allow all images over https

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -26,7 +26,7 @@ Rails.application.config.content_security_policy do |policy|
   policy.font_src    :self, 'https://fonts.gstatic.com',
                      'https://cdn.materialdesignicons.com'
 
-  policy.img_src     :self, :data, 'https://www.google-analytics.com'
+  policy.img_src     :self, :data, 'https://'
 
   policy.object_src  :none
 


### PR DESCRIPTION
This pull request allows the inclusion of images in Dodona as long as they are server over https.

Fixes #1527.

I confirmed this works:
![image](https://user-images.githubusercontent.com/3226995/69899472-d0450e80-1366-11ea-9592-17a91292791d.png)

