### PR TITLE
redirect_to_default_host should not throw away query parameters

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -87,7 +87,8 @@ class ApplicationController < ActionController::Base
   private
 
   def redirect_to_default_host
-    redirect_to host: Rails.configuration.default_host
+    redirect_to host: Rails.configuration.default_host,
+                params: request.query_parameters
   end
 
   def user_not_authorized


### PR DESCRIPTION
This fixes a bug where a media object was inaccessible because when redirecting to the `default_host`, the token was thrown away.

- [X] Tests were added

