### PR TITLE
Change color of syntax highlighting of Generic.Output in dark mode

### DIFF
--- a/app/assets/stylesheets/theme/rouge-dark.css.less
+++ b/app/assets/stylesheets/theme/rouge-dark.css.less
@@ -126,7 +126,7 @@
 
 /* Generic.Output */
 .highlighter-rouge .go {
-  color: #44475a
+  color: #808080
 }
 
 /* Generic.Prompt */


### PR DESCRIPTION
This pull request changes the color of Generic.Output tags for dark mode

![image](https://user-images.githubusercontent.com/5099359/70388262-9354c980-19af-11ea-8a1f-95e8779a77bf.png)

Closes #1559 .
