### PR TITLE
Set charset to utf-8 if sending plaintext media

### DIFF
--- a/app/controllers/exercises_controller.rb
+++ b/app/controllers/exercises_controller.rb
@@ -123,8 +123,11 @@ class ExercisesController < ApplicationController
     file = File.join(@exercise.repository.media_path, params[:media]) unless File.file? file
     raise ActionController::RoutingError, 'Not Found' unless File.file? file
 
+    type = Mime::Type.lookup_by_extension File.extname(file)[1..]
+    type = 'text/plain; charset=utf-8' if type.nil? || type == 'text/plain'
+
     # Support If-Modified-Since caching
-    send_file file, disposition: 'inline' \
+    send_file file, disposition: 'inline', type: type \
       if stale? last_modified: File.mtime(file)
   end
 

--- a/test/controllers/exercises_controller_test.rb
+++ b/test/controllers/exercises_controller_test.rb
@@ -289,7 +289,17 @@ class ExercisesPermissionControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to root_url
   end
 
-  test 'should get exercise media because recond is ok' do
+  test 'should get plaintext exercise media with charset=utf-8' do
+    @instance = create(:exercise, :description_html)
+    Exercise.any_instance.stubs(:media_path).returns(Pathname.new('public'))
+
+    get media_exercise_url(@instance, media: 'robots.txt')
+
+    assert_response :success
+    assert_equal response.content_type, 'text/plain; charset=utf-8'
+  end
+
+  test 'should get exercise media because record is ok' do
     @instance = create(:exercise, :description_html)
     Exercise.any_instance.stubs(:media_path).returns(Pathname.new('public'))
 


### PR DESCRIPTION
This pull request fixes plaintext files containing UTF-8 not being correctly displayed by the browser.

- [X] Tests were added
