### PR TITLE
Fix searching for courses

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -11,7 +11,6 @@ class CoursesController < ApplicationController
   has_scope :by_course_labels, as: 'course_labels', type: :array, only: :scoresheet do |controller, scope, value|
     scope.by_course_labels(value, Series.find(controller.params[:id]).course_id)
   end
-  has_scope :by_filter, as: 'filter', only: :scoresheet
 
   # GET /courses
   # GET /courses.json


### PR DESCRIPTION
This functionality was broken [here](https://github.com/dodona-edu/dodona/pull/1499/files#diff-d2e818b3752c6fe016738995c4176307R14). I copy-pasted the `has_scope` lines required for the series scoresheet, without thinking about the fact that the course controller already had a `filter` scope. My bad.