### PR TITLE
Update gemfile to avoid yanked version of httparty

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -105,7 +105,7 @@ gem 'rails-i18n', '~> 6.0.0'
 
 # email exceptions
 gem 'exception_notification', '~> 4.4.0'
-gem 'httparty', '~> 0.17.2'
+gem 'httparty', '~> 0.17.3'
 gem 'slack-notifier', '~> 2.3.2'
 
 # css styles for emails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -170,7 +170,7 @@ GEM
       activesupport (>= 4.1)
     hashie (3.6.0)
     htmlentities (4.3.4)
-    httparty (0.17.2)
+    httparty (0.17.3)
       mime-types (~> 3.0)
       multi_xml (>= 0.5.2)
     i18n (1.7.0)
@@ -439,7 +439,7 @@ DEPENDENCIES
   faker (~> 2.8.1)
   foreman!
   has_scope (~> 0.7.2)
-  httparty (~> 0.17.2)
+  httparty (~> 0.17.3)
   i18n-js (~> 3.5.0)
   image_processing (~> 1.9.2)
   jbuilder (~> 2.9.1)
@@ -490,4 +490,4 @@ RUBY VERSION
    ruby 2.6.5p114
 
 BUNDLED WITH
-   2.0.2
+   2.1.0


### PR DESCRIPTION
This pull request skips version 0.17.2 of Httparty, since that has been removed from rubygems.org
