### PR TITLE
Fix inaccessible private hidden exercise media

### DIFF
--- a/app/assets/javascripts/exercise.js
+++ b/app/assets/javascripts/exercise.js
@@ -105,11 +105,10 @@ function initMathJax() {
     }
 }
 
-function initExerciseDescription(parentId, exercisePath, token) {
+function initExerciseDescription() {
     initLightboxes();
     centerImagesAndTables();
     initMathJax();
-    contextualizeMediaPaths(parentId, exercisePath, token);
 }
 
 
@@ -354,26 +353,5 @@ function initExerciseShow(exerciseId, programmingLanguage, loggedIn, editorShown
     init();
 }
 
-function contextualizeMediaPaths(parentClass, exercisePath, token) {
-    const tokenPart = token ? `?token=${token}` : "";
-    const query = "a[href^='media'],a[href^='./media']";
-    Array.from(document.getElementsByClassName(parentClass)).forEach(parent => {
-        parent.querySelectorAll(query).forEach(element => {
-            Array.from(element.attributes).forEach(attribute => {
-                if (attribute.name == "href") {
-                    const value = attribute.value;
-                    if (value.startsWith("./media/")) {
-                        attribute.value = exercisePath + "/media/" +
-                            value.substr(8) + tokenPart;
-                    } else if (value.startsWith("media/")) {
-                        attribute.value = exercisePath + "/media/" +
-                            value.substr(6) + tokenPart;
-                    }
-                }
-            });
-        });
-    });
-}
-
-export { initExerciseShow, initExerciseDescription, initLabelsEdit, contextualizeMediaPaths };
+export { initExerciseShow, initExerciseDescription, initLabelsEdit };
 

--- a/app/assets/javascripts/submission.js
+++ b/app/assets/javascripts/submission.js
@@ -1,5 +1,4 @@
 import { logToGoogle } from "util.js";
-import { contextualizeMediaPaths } from "exercise.js";
 
 function initSubmissionShow(parentClass, mediaPath, token) {
     function init() {
@@ -64,6 +63,27 @@ function initSubmissionShow(parentClass, mediaPath, token) {
     }
 
     init();
+}
+
+function contextualizeMediaPaths(parentClass, exercisePath, token) {
+    const tokenPart = token ? `?token=${token}` : "";
+    const query = "a[href^='media'],a[href^='./media']";
+    Array.from(document.getElementsByClassName(parentClass)).forEach(parent => {
+        parent.querySelectorAll(query).forEach(element => {
+            Array.from(element.attributes).forEach(attribute => {
+                if (attribute.name == "href") {
+                    const value = attribute.value;
+                    if (value.startsWith("./media/")) {
+                        attribute.value = exercisePath + "/media/" +
+                            value.substr(8) + tokenPart;
+                    } else if (value.startsWith("media/")) {
+                        attribute.value = exercisePath + "/media/" +
+                            value.substr(6) + tokenPart;
+                    }
+                }
+            });
+        });
+    });
 }
 
 export { initSubmissionShow };

--- a/app/controllers/exercises_controller.rb
+++ b/app/controllers/exercises_controller.rb
@@ -114,9 +114,7 @@ class ExercisesController < ApplicationController
 
   def media
     if params.key?(:token)
-      # Only allow token authentication on sandbox
-      raise Pundit::NotAuthorizedError, 'Not allowed' \
-        unless @exercise.access_token == params[:token] && sandbox?
+      raise Pundit::NotAuthorizedError, 'Not allowed' unless @exercise.access_token == params[:token]
     elsif !@exercise.accessible?(current_user, @course)
       raise Pundit::NotAuthorizedError, 'Not allowed'
     end

--- a/app/controllers/exercises_controller.rb
+++ b/app/controllers/exercises_controller.rb
@@ -114,7 +114,9 @@ class ExercisesController < ApplicationController
 
   def media
     if params.key?(:token)
-      raise Pundit::NotAuthorizedError, 'Not allowed' unless @exercise.access_token == params[:token]
+      # Only allow token authentication on sandbox
+      raise Pundit::NotAuthorizedError, 'Not allowed' \
+        unless @exercise.access_token == params[:token] && sandbox?
     elsif !@exercise.accessible?(current_user, @course)
       raise Pundit::NotAuthorizedError, 'Not allowed'
     end

--- a/app/controllers/exercises_controller.rb
+++ b/app/controllers/exercises_controller.rb
@@ -5,7 +5,7 @@ class ExercisesController < ApplicationController
   before_action :ensure_trailing_slash, only: :show
   before_action :allow_iframe, only: %i[description]
   skip_before_action :verify_authenticity_token, only: [:media]
-  skip_before_action :redirect_to_default_host, only: %i[description]
+  skip_before_action :redirect_to_default_host, only: %i[description media]
 
   has_scope :by_filter, as: 'filter'
   has_scope :by_labels, as: 'labels', type: :array, if: ->(this) { this.params[:labels].is_a?(Array) }

--- a/app/controllers/exercises_controller.rb
+++ b/app/controllers/exercises_controller.rb
@@ -1,6 +1,6 @@
 class ExercisesController < ApplicationController
   before_action :set_exercise, only: %i[show description edit update media]
-  before_action :set_course, only: %i[show edit update]
+  before_action :set_course, only: %i[show edit update media]
   before_action :set_series, only: %i[show edit update]
   before_action :ensure_trailing_slash, only: :show
   before_action :allow_iframe, only: %i[description]

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -99,7 +99,7 @@ class SubmissionsController < ApplicationController
   end
 
   def media
-    redirect_to media_exercise_url(@submission.exercise, params[:media])
+    redirect_to media_exercise_url(@submission.exercise, params[:media], token: params[:token])
   end
 
   def mass_rejudge

--- a/app/helpers/renderers/pythia_renderer.rb
+++ b/app/helpers/renderers/pythia_renderer.rb
@@ -90,7 +90,7 @@ class PythiaRenderer < FeedbackTableRenderer
     return super(tc) unless tc[:data] && tc[:data][:files]
 
     jsonfiles = tc[:data][:files].to_a.map do |key, value|
-      value[:content] = "#{value[:content]}?token=#{@exercise.access_token}" if @exercise.access_private? && value[:location] == 'href'
+      value[:content] = "#{value[:content]}?token=#{@exercise.access_token}" if value[:location] == 'href'
       [key, value]
     end.to_h.to_json
     @builder.div(class: "testcase #{tc[:accepted] ? 'correct' : 'wrong'} contains-file", "data-files": jsonfiles) do

--- a/app/helpers/renderers/pythia_renderer.rb
+++ b/app/helpers/renderers/pythia_renderer.rb
@@ -90,7 +90,7 @@ class PythiaRenderer < FeedbackTableRenderer
     return super(tc) unless tc[:data] && tc[:data][:files]
 
     jsonfiles = tc[:data][:files].to_a.map do |key, value|
-      value[:content] = "#{value[:content]}?token=#{@exercise.access_token}" if value[:location] == 'href'
+      value[:content] = "#{value[:content]}?token=#{@exercise.access_token}" if value&.dig(:location) == 'href'
       [key, value]
     end.to_h.to_json
     @builder.div(class: "testcase #{tc[:accepted] ? 'correct' : 'wrong'} contains-file", "data-files": jsonfiles) do

--- a/app/helpers/renderers/pythia_renderer.rb
+++ b/app/helpers/renderers/pythia_renderer.rb
@@ -90,7 +90,8 @@ class PythiaRenderer < FeedbackTableRenderer
     return super(tc) unless tc[:data] && tc[:data][:files]
 
     jsonfiles = tc[:data][:files].to_a.map do |key, value|
-      value[:content] = "#{value[:content]}?token=#{@exercise.access_token}" if value&.dig(:location) == 'href'
+      value[:content] = "#{value[:content]}?token=#{@exercise.access_token}" \
+        if @exercise.access_private? && value&.dig(:location) == 'href'
       [key, value]
     end.to_h.to_json
     @builder.div(class: "testcase #{tc[:accepted] ? 'correct' : 'wrong'} contains-file", "data-files": jsonfiles) do

--- a/app/models/exercise.rb
+++ b/app/models/exercise.rb
@@ -226,7 +226,7 @@ class Exercise < ApplicationRecord
   end
 
   def usable_by?(course)
-    access_public? || course.usable_repositories.include?(repository)
+    access_public? || course.usable_repositories.pluck(:id).include?(repository.id)
   end
 
   def accessible?(user, course)
@@ -237,7 +237,8 @@ class Exercise < ApplicationRecord
         return false unless course.visible_exercises.pluck(:id).include? id
       end
       return true if user&.repository_admin? repository
-      return false unless access_public? || repository.allowed_courses.include?(course)
+      return false unless access_public? \
+        || repository.allowed_courses.pluck(:id).include?(course&.id)
       return true if user&.member_of? course
       return false if course.moderated && access_private?
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -166,7 +166,7 @@ class User < ApplicationRecord
   end
 
   def repository_admin?(repository)
-    zeus? || repositories.include?(repository)
+    zeus? || repositories.pluck(:id).include?(repository.id)
   end
 
   def attempted_exercises(options)
@@ -218,11 +218,11 @@ class User < ApplicationRecord
   end
 
   def member_of?(course)
-    subscribed_courses.include? course
+    course.present? && subscribed_courses.pluck(:id).include?(course.id)
   end
 
   def admin_of?(course)
-    administrating_courses.include?(course)
+    course.present? && administrating_courses.pluck(:id).include?(course.id)
   end
 
   def membership_status_for(course)

--- a/app/policies/course_policy.rb
+++ b/app/policies/course_policy.rb
@@ -123,6 +123,10 @@ class CoursePolicy < ApplicationPolicy
     statistics?
   end
 
+  def media?
+    show?
+  end
+
   def permitted_attributes
     # record is the Course class on create
     if course_admin? || (record == Course && user&.admin?)

--- a/app/views/exercises/description.html.erb
+++ b/app/views/exercises/description.html.erb
@@ -28,5 +28,5 @@
 </div>
 </div>
 <script>
-$(function(){window.dodona.initExerciseDescription('exercise-description', <%= raw "'#{exercise_path(@exercise)}'" %>, <%= raw @exercise.access_private? ? "'#{@exercise.access_token}'" : 'undefined' %>) ;});
+$(function(){window.dodona.initExerciseDescription();
 </script>

--- a/app/views/exercises/description.html.erb
+++ b/app/views/exercises/description.html.erb
@@ -28,5 +28,5 @@
 </div>
 </div>
 <script>
-$(function(){window.dodona.initExerciseDescription();
+$(function(){window.dodona.initExerciseDescription();});
 </script>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -114,12 +114,12 @@ Rails.application.routes.draw do
       end
     end
 
-    resources :submissions, only: %i[index show create edit], concerns: :mediable do
+    resources :submissions, only: %i[index show create edit] do
       post 'mass_rejudge', on: :collection
       member do
         get 'download'
         get 'evaluate'
-        get 'media/*media', to: 'submissions#media', constraints: {media: /.*/}
+        get 'media/*media', to: 'submissions#media', constraints: {media: /.*/}, as: 'media'
       end
     end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,7 +24,9 @@ Rails.application.routes.draw do
 
     concern :mediable do
       member do
-        get 'media/*media', to: 'exercises#media', constraints: {media: /.*/}, as: 'media'
+        constraints host: Rails.configuration.default_host do
+          get 'media/*media', to: 'exercises#media', constraints: {media: /.*/}, as: 'media'
+        end
       end
     end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -85,11 +85,14 @@ Rails.application.routes.draw do
 
     resources :exercises, only: %i[index show edit update], concerns: %i[mediable submitable] do
       member do
-        scope 'description' do
+        scope 'description/:token/' do
           constraints host: Rails.configuration.sandbox_host do
             root to: 'exercises#description', as: 'description'
+            get 'media/*media',
+                to: 'exercises#media',
+                constraints: {media: /.*/},
+                as: 'description_media'
           end
-          get 'media/*media', to: 'exercises#media', constraints: {media: /.*/}, as: 'description_media'
         end
       end
     end

--- a/test/controllers/exercises_controller_test.rb
+++ b/test/controllers/exercises_controller_test.rb
@@ -354,6 +354,23 @@ class ExercisesPermissionControllerTest < ActionDispatch::IntegrationTest
     assert_equal response.content_type, 'image/png'
   end
 
+  test 'should get media of private exercise in course' do
+    @instance = create(:exercise, :description_html, access: 'private')
+    series = create :series, visibility: :hidden
+    series.exercises << @instance
+    series.course.enrolled_members << @user
+    @instance.repository.allowed_courses << series.course
+    Exercise.any_instance.stubs(:media_path).returns(Pathname.new('public'))
+
+    get course_series_exercise_url(series.course, series, @instance)
+    assert_response :success, 'should have access to exercise'
+
+    get media_course_series_exercise_url(series.course, series, @instance, media: 'icon.png')
+
+    assert_response :success, 'should have access to exercise media'
+    assert_equal response.content_type, 'image/png'
+  end
+
   test 'should get redirected from exercise media to root_url because user has no submissions and exercise is not ok' do
     @instance = create(:exercise, :description_html)
     Exercise.any_instance.stubs(:ok?).returns(false)

--- a/test/controllers/exercises_controller_test.rb
+++ b/test/controllers/exercises_controller_test.rb
@@ -394,9 +394,18 @@ class ExercisesPermissionControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to root_url
   end
 
-  test 'should access exercise media on default host with token' do
+  test 'should access public exercise media on default host with token' do
     sign_out :user
     @instance = create(:exercise, :description_html)
+    Exercise.any_instance.stubs(:media_path).returns(Pathname.new('public'))
+    get media_exercise_url(@instance, media: 'icon.png', token: @instance.access_token)
+
+    assert_response :success
+  end
+
+  test 'should access private exercise media on default host with token' do
+    sign_out :user
+    @instance = create(:exercise, :description_html, access: :private)
     Exercise.any_instance.stubs(:media_path).returns(Pathname.new('public'))
     get media_exercise_url(@instance, media: 'icon.png', token: @instance.access_token)
 

--- a/test/controllers/exercises_controller_test.rb
+++ b/test/controllers/exercises_controller_test.rb
@@ -75,7 +75,7 @@ class ExercisesControllerTest < ActionDispatch::IntegrationTest
     Exercise.any_instance.stubs(:media_path).returns(Pathname.new('public'))
     @instance.update access: :private
 
-    get media_exercise_url(@instance, host: 'sandbox.example.com', media: 'icon.png', token: @instance.access_token)
+    get description_media_exercise_url(@instance, host: 'sandbox.example.com', media: 'icon.png', token: @instance.access_token)
 
     assert_response :success
   end
@@ -83,7 +83,7 @@ class ExercisesControllerTest < ActionDispatch::IntegrationTest
   test 'should not get media with wrong token on sandbox_host' do
     Exercise.any_instance.stubs(:media_path).returns(Pathname.new('public'))
 
-    get media_exercise_url(@instance, host: 'sandbox.example.com', media: 'icon.png', token: 'blargh')
+    get description_media_exercise_url(@instance, host: 'sandbox.example.com', media: 'icon.png', token: 'blargh')
 
     assert_response :forbidden
   end
@@ -394,12 +394,13 @@ class ExercisesPermissionControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to root_url
   end
 
-  test 'should not access exercise media on default host with token' do
+  test 'should access exercise media on default host with token' do
+    sign_out :user
     @instance = create(:exercise, :description_html)
     Exercise.any_instance.stubs(:media_path).returns(Pathname.new('public'))
     get media_exercise_url(@instance, media: 'icon.png', token: @instance.access_token)
 
-    assert_redirected_to root_url
+    assert_response :success
   end
 
   def create_exercises_return_valid

--- a/test/controllers/submissions_controller_test.rb
+++ b/test/controllers/submissions_controller_test.rb
@@ -112,6 +112,11 @@ class SubmissionsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to media_exercise_path(@instance.exercise, 'dank_meme.jpg')
   end
 
+  test 'submission media should redirect to exercise media and keep token' do
+    get media_submission_path(@instance, 'dank_meme.jpg', token: @instance.exercise.access_token)
+    assert_redirected_to media_exercise_path(@instance.exercise, 'dank_meme.jpg', token: @instance.exercise.access_token)
+  end
+
   def rejudge_submissions(**params)
     post mass_rejudge_submissions_path, params: params
     assert_response :success


### PR DESCRIPTION
The `@course` was not set when checking whether a student could access a private exercise within a course. This PR fixes this and solves a few other problems:
- There were two routes defined for `/submisssions/:id/media/`, I removed the route that was overridden by the 'actual' route (the one going to `submissions#media`).
- Rails' ActiveRecord `include?` sometimes returns `false` even when a record is part of the relation. This is because two objects representing the same record are sometimes not equal to each other. I have fixed this by checking if their id's match.

- [X] Tests were added


Fixes #1588.
