### PR TITLE
Docker: don't limit device IO in development env

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -51,6 +51,12 @@ Rails/HelperInstanceVariable:
   Enabled: false
 Rails/OutputSafety:
   Enabled: false
+Rails/UnknownEnv:
+  Environments:
+    - development
+    - test
+    - production
+    - staging
 
 Style/ClassAndModuleChildren:
   Enabled: false

--- a/app/runners/submission_runner.rb
+++ b/app/runners/submission_runner.rb
@@ -87,11 +87,7 @@ class SubmissionRunner
     # fetch execution memory limit from submission configuration
     memory_limit = @config['memory_limit']
 
-    # process submission in docker container
-    # TODO: set user with the --user option
-    # TODO: set the workdir with the -w option
-    begin
-      container = Docker::Container.create(
+    docker_options = {
         # TODO: move entry point to docker container definition
         Cmd: ['/main.sh',
               # judge entry point
@@ -104,12 +100,19 @@ class SubmissionRunner
         HostConfig: {
           Memory: memory_limit,
           MemorySwap: memory_limit, # memory including swap
-          BlkioDeviceWriteBps: [{ Path: '/dev/sda', Rate: 1024 * 1024 }],
+          # WARNING: this will cause the container to hang if /dev/sda does not exist
+          BlkioDeviceWriteBps: [{ Path: '/dev/sda', Rate: 1024 * 1024 }].filter{|| Rails.env.production? || Rails.env.staging? },
           PidsLimit: 256,
           Binds: ["#{@mountsrc}:#{@mountdst}",
                   "#{@mountsrc + 'workdir'}:#{@config['workdir']}"]
         }
-      )
+    }
+
+    # process submission in docker container
+    # TODO: set user with the --user option
+    # TODO: set the workdir with the -w option
+    begin
+      container = Docker::Container.create(**docker_options)
     rescue StandardError => e
       return build_error 'internal error', 'internal error', [
         build_message("Error creating docker: #{e}", 'staff', 'plain'),

--- a/app/runners/submission_runner.rb
+++ b/app/runners/submission_runner.rb
@@ -88,24 +88,24 @@ class SubmissionRunner
     memory_limit = @config['memory_limit']
 
     docker_options = {
-        # TODO: move entry point to docker container definition
-        Cmd: ['/main.sh',
-              # judge entry point
-              (@mountdst + @hidden_path + 'judge' + 'run').to_path],
-        Image: @exercise.merged_config['evaluation']&.fetch('image', nil) || @judge.image,
-        name: "dodona-#{@submission.id}", # assuming unique during execution
-        OpenStdin: true,
-        StdinOnce: true, # closes stdin after first disconnect
-        NetworkDisabled: !@config['network_enabled'],
-        HostConfig: {
-          Memory: memory_limit,
-          MemorySwap: memory_limit, # memory including swap
-          # WARNING: this will cause the container to hang if /dev/sda does not exist
-          BlkioDeviceWriteBps: [{ Path: '/dev/sda', Rate: 1024 * 1024 }].filter{|| Rails.env.production? || Rails.env.staging? },
-          PidsLimit: 256,
-          Binds: ["#{@mountsrc}:#{@mountdst}",
-                  "#{@mountsrc + 'workdir'}:#{@config['workdir']}"]
-        }
+      # TODO: move entry point to docker container definition
+      Cmd: ['/main.sh',
+            # judge entry point
+            (@mountdst + @hidden_path + 'judge' + 'run').to_path],
+      Image: @exercise.merged_config['evaluation']&.fetch('image', nil) || @judge.image,
+      name: "dodona-#{@submission.id}", # assuming unique during execution
+      OpenStdin: true,
+      StdinOnce: true, # closes stdin after first disconnect
+      NetworkDisabled: !@config['network_enabled'],
+      HostConfig: {
+        Memory: memory_limit,
+        MemorySwap: memory_limit, # memory including swap
+        # WARNING: this will cause the container to hang if /dev/sda does not exist
+        BlkioDeviceWriteBps: [{ Path: '/dev/sda', Rate: 1024 * 1024 }].filter { Rails.env.production? || Rails.env.staging? },
+        PidsLimit: 256,
+        Binds: ["#{@mountsrc}:#{@mountdst}",
+                "#{@mountsrc + 'workdir'}:#{@config['workdir']}"]
+      }
     }
 
     # process submission in docker container


### PR DESCRIPTION
This pull request fixes a bug where container creation would hang on a device where there is no `/dev/sda` present. The current fix is to only limit IO to the `/dev/sda` block device in production and staging environments.
