### PR TITLE
Element type of tr, not class tr

### DIFF
--- a/app/assets/javascripts/code_listing.ts
+++ b/app/assets/javascripts/code_listing.ts
@@ -75,7 +75,7 @@ export class CodeListing {
     }
 
     clearHighlights(): void {
-        const markedAnnotations = this.table.querySelectorAll(`.tr.lineno.${this.markingClass}`);
+        const markedAnnotations = this.table.querySelectorAll(`tr.lineno.${this.markingClass}`);
         markedAnnotations.forEach(markedAnnotation => {
             markedAnnotation.classList.remove(this.markingClass);
         });


### PR DESCRIPTION
This pull request fixes a tiny bug with clearing the highlights.
The code was looking for a tr class element instead of elements of type tr

- [ ] Tests were added
- [ ] Documentation update can be found at dodona-edu/dodona-edu.github.io#

Closes #1601  .
