### PR TITLE
Fix double newline by overriding the copy behaviour of browsers

### DIFF
--- a/app/assets/javascripts/code_listing.ts
+++ b/app/assets/javascripts/code_listing.ts
@@ -19,6 +19,11 @@ export class CodeListing {
         if (this.table === null) {
             console.error("The code listing could not be found");
         }
+
+        this.table.addEventListener("copy", function (e) {
+            e.clipboardData.setData("text/plain", window.dodona.codeListing.getSelectededCode());
+            e.preventDefault();
+        });
     }
 
     addAnnotations(messages: Message[]): void {
@@ -61,7 +66,7 @@ export class CodeListing {
         annotationCell.setAttribute("id", `annotation-id-${message.id}`);
         annotationCell.setAttribute("title", message.type[0].toUpperCase() + message.type.substring(1));
 
-        const textNode: Text = document.createTextNode(message.text.split("\n").filter(s => ! s.match("^--*$")).join("\n"));
+        const textNode: Text = document.createTextNode(message.text.split("\n").filter(s => !s.match("^--*$")).join("\n"));
         annotationCell.classList.add(message.type);
         annotationCell.appendChild(textNode);
 
@@ -89,7 +94,29 @@ export class CodeListing {
     getCode(): string {
         const submissionCode = [];
         this.table.querySelectorAll(".lineno .rouge-code")
-            .forEach( codeLine => submissionCode.push(codeLine.textContent.replace(/\n$/, "")));
+            .forEach(codeLine => submissionCode.push(codeLine.textContent.replace(/\n$/, "")));
         return submissionCode.join("\n");
+    }
+
+    private getSelectededCode(): string {
+        const selection = window.getSelection();
+        const strings = [];
+
+        for (let rangeIndex = 0; rangeIndex < selection.rangeCount; rangeIndex++) {
+            const documentFragment = selection.getRangeAt(rangeIndex).cloneContents();
+            const fullNodes = documentFragment.querySelectorAll("td.rouge-code");
+            fullNodes.forEach((v, _n, _l) => {
+                strings.push(v.textContent.trimRight());
+            });
+        }
+
+        // TODO: Fix this other way
+        // Somewhat hacky way to circumvent the bad filtering in Firefox
+        const documentFragment1 = selection.getRangeAt(selection.rangeCount - 1).cloneContents();
+        if (documentFragment1.firstElementChild.tagName == "PRE") {
+            strings.push(documentFragment1.textContent);
+        }
+
+        return strings.join("\n");
     }
 }

--- a/app/assets/stylesheets/components/code_listing.css.less
+++ b/app/assets/stylesheets/components/code_listing.css.less
@@ -1,5 +1,10 @@
 .code-listing {
 
+  user-select: none;
+  display: block;
+  overflow-x: auto;
+  white-space: nowrap;
+
   // Override the normal pre padding & coloring
   pre {
     padding: 0;
@@ -24,6 +29,7 @@
 
   .rouge-code {
     padding-left: 5px;
+    user-select: text;
     white-space: pre-wrap;
     word-break: break-word;
   }
@@ -49,7 +55,6 @@
     .annotation-cell {
       .annotation {
         font-family: @font-family-monospace;
-        user-select: none;
         margin: 3px 5px 3px 10px;
         padding: 2px 10px;
         border-radius: 0 5px 5px 0;


### PR DESCRIPTION
This pull request attempts to fix the double newline that is introduced by some browser for some odd reason.

Tested browsers:
 * Firefox Developer Edition 72.0b11 (64-bit) on Arch Linux
 * Chromium 79.0.3945.88 on Arch Linux

- [ ] Tests were added
No testing available with Jest since the Selection & Range API are required
- [ ] Documentation update can be found at dodona-edu/dodona-edu.github.io#

Closes #1581 .
