### PR TITLE
Generalize token generation

### DIFF
--- a/app/controllers/series_controller.rb
+++ b/app/controllers/series_controller.rb
@@ -102,15 +102,22 @@ class SeriesController < ApplicationController
 
   def reset_token
     type = params[:type].to_sym
-    @series.generate_token(type)
-    @series.save
     value =
       case type
       when :indianio_token
+        @series.generate_indianio_token
         @series.indianio_token
       when :access_token
+        @series.generate_access_token
         series_url(@series, token: @series.access_token)
+      else
+        # unknown token type
+        head :unacceptable
       end
+
+    return if performed?
+
+    @series.save
     render partial: 'application/token_field', locals: {
       container_name: :access_token_field,
       name: type,

--- a/app/models/concerns/tokenable.rb
+++ b/app/models/concerns/tokenable.rb
@@ -5,7 +5,7 @@ module Tokenable
     def token_generator(name, length: 16, unique: true)
       token_name = name.to_sym
       raise "Model does not have attribute '#{name}'" \
-        unless self.column_names.include? token_name.to_s
+        unless column_names.include? token_name.to_s
 
       generate_token_method_name = "generate_#{name}".to_sym
 
@@ -18,11 +18,11 @@ module Tokenable
       # with the same token.
       define_method generate_token_method_name do
         begin
-          new_token = SecureRandom
-            .urlsafe_base64(length)
-            .tr('1lL0oO', '')[0, length]
+          new_token = SecureRandom.urlsafe_base64(length)
+                                  .tr('1lL0oO', '')
+                                  .slice(0, length)
         end until (new_token.length == length) && \
-          (!unique || self.class.find_by({token_name => new_token}).nil?)
+          (!unique || self.class.find_by(token_name => new_token).nil?)
         self[token_name] = new_token
       end
     end

--- a/app/models/concerns/tokenable.rb
+++ b/app/models/concerns/tokenable.rb
@@ -4,9 +4,6 @@ module Tokenable
   class_methods do
     def token_generator(name, length: 16, unique: true)
       token_name = name.to_sym
-      raise "Model does not have attribute '#{name}'" \
-        unless column_names.include? token_name.to_s
-
       generate_token_method_name = "generate_#{name}".to_sym
 
       # Generate a random base64 string, but strip characters which might

--- a/app/models/concerns/tokenable.rb
+++ b/app/models/concerns/tokenable.rb
@@ -1,0 +1,30 @@
+module Tokenable
+  extend ActiveSupport::Concern
+
+  class_methods do
+    def token_generator(name, length: 16, unique: true)
+      token_name = name.to_sym
+      raise "Model does not have attribute '#{name}'" \
+        unless self.column_names.include? token_name.to_s
+
+      generate_token_method_name = "generate_#{name}".to_sym
+
+      # Generate a random base64 string, but strip characters which might
+      # look ambiguous.
+      # We then check if the token still has the desired
+      # length (base64 should generate a string with a length of 4/3 n, so
+      # this should almost always be OK).
+      # If the token needs to be unique, we also check if there is not a record
+      # with the same token.
+      define_method generate_token_method_name do
+        begin
+          new_token = SecureRandom
+            .urlsafe_base64(length)
+            .tr('1lL0oO', '')[0, length]
+        end until (new_token.length == length) && \
+          (!unique || self.class.find_by({token_name => new_token}).nil?)
+        self[token_name] = new_token
+      end
+    end
+  end
+end

--- a/app/models/concerns/tokenable.rb
+++ b/app/models/concerns/tokenable.rb
@@ -22,7 +22,7 @@ module Tokenable
                                   .tr('1lL0oO', '')
                                   .slice(0, length)
         end until (new_token.length == length) && \
-          (!unique || self.class.find_by(token_name => new_token).nil?)
+          !(unique && self.class.where(token_name => new_token).exists?)
         self[token_name] = new_token
       end
     end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -108,7 +108,7 @@ class Course < ApplicationRecord
   scope :by_institution, ->(institution) { where(institution: [institution, nil]) }
   default_scope { order(year: :desc, name: :asc) }
 
-  token_generator :secret, unique: false
+  token_generator :secret, unique: false, length: 5
 
   before_create :generate_secret
 

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -24,6 +24,7 @@ require 'csv'
 class Course < ApplicationRecord
   include Filterable
   include Cacheable
+  include Tokenable
   include ActionView::Helpers::SanitizeHelper
 
   SUBSCRIBED_MEMBERS_COUNT_CACHE_STRING = '/courses/%<id>d/subscribed_members_count'.freeze
@@ -107,6 +108,8 @@ class Course < ApplicationRecord
   scope :by_institution, ->(institution) { where(institution: [institution, nil]) }
   default_scope { order(year: :desc, name: :asc) }
 
+  token_generator :secret, unique: false
+
   before_create :generate_secret
 
   # Default year & enum values
@@ -140,10 +143,6 @@ class Course < ApplicationRecord
 
   def formatted_year
     Course.format_year year
-  end
-
-  def generate_secret
-    self.secret = SecureRandom.urlsafe_base64(5)
   end
 
   def secret_required?(user = nil)

--- a/app/models/exercise.rb
+++ b/app/models/exercise.rb
@@ -53,11 +53,12 @@ class Exercise < ApplicationRecord
 
   validates :path, uniqueness: { scope: :repository_id, case_sensitive: false }, allow_nil: true
 
-  token_generator :repository_token
+  token_generator :repository_token, length: 64
   token_generator :access_token
 
   before_create :generate_id
-  before_create :generate_repository_token
+  before_create :generate_repository_token,
+                if: ->(ex) { ex.repository_token.nil? }
   before_create :generate_access_token
   before_save :check_validity
   before_save :check_memory_limit

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -32,7 +32,7 @@ class Series < ApplicationRecord
   validates :name, presence: true
   validates :visibility, presence: true
 
-  token_generator :access_token
+  token_generator :access_token, length: 5
   token_generator :indianio_token
 
   before_create :generate_access_token

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -36,6 +36,7 @@ class Series < ApplicationRecord
   token_generator :indianio_token
 
   before_create :generate_access_token
+  before_save :regenerate_exercise_tokens, if: :visibility_changed?
 
   scope :visible, -> { where(visibility: :open) }
   scope :with_deadline, -> { where.not(deadline: nil) }
@@ -97,5 +98,12 @@ class Series < ApplicationRecord
       exercises: exercises,
       submissions: submission_hash
     }
+  end
+
+  def regenerate_exercise_tokens
+    exercises.each do |exercise|
+      exercise.generate_access_token
+      exercise.save
+    end
   end
 end

--- a/app/models/series_membership.rb
+++ b/app/models/series_membership.rb
@@ -21,8 +21,14 @@ class SeriesMembership < ApplicationRecord
   validates :series_id, uniqueness: { scope: :exercise_id }
   after_create :invalidate_caches
   after_destroy :invalidate_caches
+  after_destroy :regenerate_exercise_token
 
   def invalidate_caches
     course.invalidate_exercises_count_cache
+  end
+
+  def regenerate_exercise_token
+    exercise.generate_access_token
+    exercise.save
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -275,7 +275,7 @@ class User < ApplicationRecord
     if institution.present?
       self.token = nil
     elsif token.blank?
-      self.token = generate_token
+      generate_token
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -23,6 +23,7 @@ class User < ApplicationRecord
   include Filterable
   include StringHelper
   include Cacheable
+  include Tokenable
   include ActiveModel::Dirty
 
   ATTEMPTED_EXERCISES_CACHE_STRING = '/courses/%<course_id>s/user/%<id>s/attempted_exercises'.freeze
@@ -99,6 +100,8 @@ class User < ApplicationRecord
   validates :username, uniqueness: { case_sensitive: false, allow_blank: true, scope: :institution }
   validates :email, uniqueness: { case_sensitive: false, allow_blank: true }
   validate :email_only_blank_if_smartschool
+
+  token_generator :token
 
   before_save :set_token
   before_save :set_time_zone
@@ -272,7 +275,7 @@ class User < ApplicationRecord
     if institution.present?
       self.token = nil
     elsif token.blank?
-      self.token = SecureRandom.urlsafe_base64(16)
+      self.token = generate_token
     end
   end
 

--- a/db/migrate/20181113103618_add_access_token_to_all_series.rb
+++ b/db/migrate/20181113103618_add_access_token_to_all_series.rb
@@ -2,7 +2,7 @@ class AddAccessTokenToAllSeries < ActiveRecord::Migration[5.2]
   def change
     Series.find_each do |s|
       if s.access_token.blank?
-        s.generate_token :access_token
+        s.generate_access_token
       end
     end
   end

--- a/test/controllers/exercises_controller_test.rb
+++ b/test/controllers/exercises_controller_test.rb
@@ -479,6 +479,7 @@ class ExerciseDescriptionTest < ActionDispatch::IntegrationTest
 
     @exercise = create :exercise, :valid, description_format: 'md'
     Exercise.any_instance.stubs(:description_localized).returns(desciption_md)
+    Exercise.any_instance.stubs(:update_config)
     stub_status(Exercise.any_instance, 'ok')
   end
 

--- a/test/controllers/export_controller_test.rb
+++ b/test/controllers/export_controller_test.rb
@@ -2,6 +2,7 @@ require 'test_helper'
 
 class ExportControllerTest < ActionDispatch::IntegrationTest
   setup do
+    stub_all_exercises!
     @course = create :course
     @students = [create(:student), create(:student), create(:student)]
     @course.enrolled_members.concat(@students)

--- a/test/controllers/series_controller_test.rb
+++ b/test/controllers/series_controller_test.rb
@@ -96,6 +96,7 @@ class SeriesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should add exercise to series' do
+    stub_all_exercises!
     exercise = create(:exercise)
     post add_exercise_series_path(@instance),
          params: {
@@ -103,7 +104,7 @@ class SeriesControllerTest < ActionDispatch::IntegrationTest
            exercise_id: exercise.id
          }
     assert_response :success
-    assert @instance.exercises.include? exercise
+    assert @instance.reload.exercises.include? exercise
   end
 
   test 'should remove exercise from series' do
@@ -265,6 +266,7 @@ end
 
 class SeriesIndianioDownloadControllerTest < ActionDispatch::IntegrationTest
   setup do
+    stub_all_exercises!
     @student = create :student
     @series = create :series,
                      :with_submissions,
@@ -278,6 +280,7 @@ class SeriesIndianioDownloadControllerTest < ActionDispatch::IntegrationTest
                                 email: @student.email
                               }
     assert_response :success
+    @series.reload
     assert_zip response.body,
                with_info: true,
                solution_count: @series.exercises.count,

--- a/test/controllers/submissions_controller_test.rb
+++ b/test/controllers/submissions_controller_test.rb
@@ -6,6 +6,7 @@ class SubmissionsControllerTest < ActionDispatch::IntegrationTest
   crud_helpers Submission, attrs: %i[code exercise_id]
 
   setup do
+    stub_all_exercises!
     @instance = create :submission
     @zeus = create(:zeus)
     sign_in @zeus
@@ -154,7 +155,7 @@ class SubmissionsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should rejudge exercise submissions' do
-    series = create(:series, :with_submissions)
+    series = create :series, :with_submissions
     exercise = series.exercises.sample
     assert_jobs_enqueued(exercise.submissions.count) do
       rejudge_submissions exercise_id: exercise.id

--- a/test/factories/series.rb
+++ b/test/factories/series.rb
@@ -48,6 +48,7 @@ FactoryBot.define do
                submission_count: e.exercise_submission_count,
                submission_users: e.exercise_submission_users
       end
+      series.reload
     end
 
     trait :with_submissions do

--- a/test/helpers/stub_helper.rb
+++ b/test/helpers/stub_helper.rb
@@ -14,6 +14,15 @@ module StubHelper
     end
   end
 
+  def stub_all_exercises!
+    config = { 'evaluation' => { 'time_limit' => 1} }.freeze
+    description = 'ᕕ(ಠ_ಠ)ᕗ'
+    Exercise.any_instance.stubs(:config).returns(config)
+    Exercise.any_instance.stubs(:update_config)
+    Exercise.any_instance.stubs(:merged_config).returns(config)
+    Exercise.any_instance.stubs(:description_localized).returns(description)
+  end
+
   refine FactoryBot::SyntaxRunner do
     include StubHelper
   end

--- a/test/models/exercise_test.rb
+++ b/test/models/exercise_test.rb
@@ -448,6 +448,12 @@ class ExerciseTest < ActiveSupport::TestCase
     @exercise.update(access: :private)
     assert_not_equal @exercise.reload.access_token, old_token
   end
+
+  test 'access token should not change when something else changes' do
+    old_token = @exercise.access_token
+    @exercise.update(name_en: 'Wubba Lubba dub-dub')
+    assert_equal @exercise.reload.access_token, old_token
+  end
 end
 
 class ExerciseRemoteTest < ActiveSupport::TestCase

--- a/test/models/exercise_test.rb
+++ b/test/models/exercise_test.rb
@@ -681,3 +681,15 @@ class LasagneConfigTest < ActiveSupport::TestCase
     assert_equal 500_000_000, @exercise.config['evaluation']['memory_limit']
   end
 end
+
+class ExerciseStubTest < ActiveSupport::TestCase
+  setup do
+    stub_all_exercises!
+    @exercise = create :exercise
+  end
+
+  test 'exercise should be valid and ok' do
+    assert @exercise.valid?, 'Exercise was not valid'
+    assert_equal @exercise.status, 'ok', 'Exercise was not ok'
+  end
+end

--- a/test/models/exercise_test.rb
+++ b/test/models/exercise_test.rb
@@ -454,6 +454,30 @@ class ExerciseTest < ActiveSupport::TestCase
     @exercise.update(name_en: 'Wubba Lubba dub-dub')
     assert_equal @exercise.reload.access_token, old_token
   end
+
+  test 'access token should change when containing series changes visibility' do
+    series = create :series, exercises: [@exercise], visibility: :open
+    old_token = @exercise.access_token
+
+    series.update(visibility: :hidden)
+    hidden_token = @exercise.reload.access_token
+    assert_not_equal hidden_token, old_token
+
+    series.update(visibility: :closed)
+    closed_token = @exercise.reload.access_token
+    assert_not_equal closed_token, hidden_token
+  end
+
+  test 'access token should change when removed from series' do
+    old_token = @exercise.access_token
+
+    series = create :series, visibility: :open
+    series.exercises << @exercise
+    assert_equal old_token, @exercise.reload.access_token, 'access token should not change when added to series'
+
+    series.exercises.destroy(@exercise)
+    assert_not_equal old_token, @exercise.reload.access_token
+  end
 end
 
 class ExerciseRemoteTest < ActiveSupport::TestCase

--- a/test/models/series_test.rb
+++ b/test/models/series_test.rb
@@ -21,6 +21,7 @@ require 'test_helper'
 
 class SeriesTest < ActiveSupport::TestCase
   setup do
+    stub_all_exercises!
     @series = create :series
   end
 

--- a/test/models/series_test.rb
+++ b/test/models/series_test.rb
@@ -94,18 +94,12 @@ class SeriesTest < ActiveSupport::TestCase
   test 'generate_token should generate a new token' do
     indianio = 'indianio'
     access = 'access'
-    @series.update(indianio_token: 'indianio', access_token: 'access')
-    @series.generate_token :indianio_token
+    @series.update(indianio_token: indianio, access_token: access)
+    @series.generate_indianio_token
     assert_not_equal indianio, @series.indianio_token
 
-    @series.generate_token :access_token
-    assert_not_equal access, @series.indianio_token
-  end
-
-  test 'generating token for unkown type should give an error' do
-    assert_raises 'unknown token type' do
-      @series.generate_token :unknown_token
-    end
+    @series.generate_access_token
+    assert_not_equal access, @series.access_token
   end
 
   test 'access_token should always be set' do

--- a/test/models/transient/series_summary_test.rb
+++ b/test/models/transient/series_summary_test.rb
@@ -12,9 +12,7 @@ class SeriesSummaryTest < ActiveSupport::TestCase
       exercises: @series.exercises
     )
   end
-end
 
-class RunningTest < SeriesSummaryTest
   test 'should not have started yet' do
     create :submission, user: @user, course: @course, exercise: @series.exercises.first, status: :running
     assert_not summary.started?


### PR DESCRIPTION
This pull request centralized token generation to a `Tokenable` concern. Tokens are base58-ish (base64 without the characters 'oO0l1i') and we make sure a token is unique (unless explicitly mentioned not to).

Token generation changes:
 - `Course.secret` length stays 5 characters because students need to be able to type it over.
 - `Series.access_token` length changed to 5 characters because students need to be able to type it over.
 - `Exercise.access_token` will now be 16 characters instead of 12 in order to be consistent.
 - `Exercise.access_token` will now only be regenerated when:
    - `Exercise.access` has been changed,
    - `Series.visibility` has been changed (of a series containing the exercise),
    - The exercise is removed from an exercise (an associated `SeriesMembership` has been deleted).

- [x] Tests were added

Closes #1233 and fixes #1634.
