### PR TITLE
Remove annotations table from schema

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,19 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_17_211919) do
-
-  create_table "annotations", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.integer "line_nr"
-    t.integer "submission_id"
-    t.integer "user_id"
-    t.text "annotation_text"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.string "markdown_content", null: false
-    t.index ["submission_id"], name: "index_annotations_on_submission_id"
-    t.index ["user_id"], name: "index_annotations_on_user_id"
-  end
+ActiveRecord::Schema.define(version: 2019_11_06_142529) do
 
   create_table "api_tokens", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "user_id"
@@ -272,8 +260,6 @@ ActiveRecord::Schema.define(version: 2019_11_17_211919) do
     t.index ["username"], name: "index_users_on_username"
   end
 
-  add_foreign_key "annotations", "submissions"
-  add_foreign_key "annotations", "users"
   add_foreign_key "course_labels", "courses", on_delete: :cascade
   add_foreign_key "course_membership_labels", "course_labels", on_delete: :cascade
   add_foreign_key "course_membership_labels", "course_memberships", on_delete: :cascade


### PR DESCRIPTION
This pull request removes the annotations table from `schema.rb`, accidentally committed with https://github.com/dodona-edu/dodona/commit/3ea62345ed93a840bb73e5680c2ecb7112eaab4b.

This shouldn't be a problem for our production instances (because they don't directly rely on `schema.rb`), but could cause issues when developing locally. In that case  a `rails db:reset` should fix any issues.
