### PR TITLE
Fix login for Smartschool users

### DIFF
--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -83,7 +83,7 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
 
   def create_institution
     institution = Institution.from_identifier(institution_identifier)
-    return if institution.present?
+    return institution if institution.present?
 
     institution = Institution.new(name: Institution::NEW_INSTITUTION_NAME,
                                   short_name: Institution::NEW_INSTITUTION_NAME,


### PR DESCRIPTION
This PR fixes a very subtle bug where the `create_institution` method in `OmniauthCallbacksController` would return nil if the institution already existed.