### PR TITLE
Fix page jumps after an iframe resize

### DIFF
--- a/app/assets/javascripts/exercise.js
+++ b/app/assets/javascripts/exercise.js
@@ -353,5 +353,23 @@ function initExerciseShow(exerciseId, programmingLanguage, loggedIn, editorShown
     init();
 }
 
-export { initExerciseShow, initExerciseDescription, initLabelsEdit };
+function afterResize(details) {
+    /**
+     * If the page is loaded with a hash (#), the browser scrolls to the element
+     * with that id, but this happens before our iframe is loaded. After our
+     * iframe content is loaded, we resize its element to fit the content. If
+     * the item in the hash was below the iframe element, that item will
+     * possibly have 'jumped' away because of this.
+     *
+     * This function is called after such a resize to re-trigger the scroll-to
+     * behavior.
+     */
+    if (details.type === "init") {
+        const hash = location.hash;
+        location.hash = "#"; // some browsers only scroll after a change
+        location.hash = hash;
+    }
+}
+
+export { initExerciseShow, initExerciseDescription, initLabelsEdit, afterResize };
 

--- a/app/helpers/exercise_helper.rb
+++ b/app/helpers/exercise_helper.rb
@@ -22,7 +22,8 @@ module ExerciseHelper
                                    dark: dark).html_safe
     resizeframe = %{
       window.iFrameResize({
-          heightCalculationMethod: 'bodyScroll'
+          heightCalculationMethod: 'bodyScroll',
+          onResized: dodona.afterResize,
         },
         '##{id}')
     }

--- a/app/javascript/packs/exercise.js
+++ b/app/javascript/packs/exercise.js
@@ -1,7 +1,8 @@
-import { initExerciseShow, initLabelsEdit } from "exercise.js";
+import { initExerciseShow, initLabelsEdit, afterResize } from "exercise.js";
 
 window.dodona.initExerciseShow = initExerciseShow;
 window.dodona.initLabelsEdit = initLabelsEdit;
+window.dodona.afterResize = afterResize;
 
 // will automaticaly bind do window.iFrameResize()
 import { iframeResizer } from "iframe-resizer"; // eslint-disable-line no-unused-vars

--- a/yarn.lock
+++ b/yarn.lock
@@ -6826,7 +6826,7 @@ node-notifier@^5.4.2:
     shellwords "^0.1.1"
     which "^1.3.0"
 
-node-pre-gyp@*, node-pre-gyp@^0.14.0:
+node-pre-gyp@^0.14.0:
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.14.0.tgz#9a0596533b877289bcad4e143982ca3d904ddc83"
   integrity sha512-+CvDC7ZttU/sSt9rFjix/P05iS43qHCOOGzcr3Ry99bXG7VX953+vFyEuph/tfqoYu8dttBkE86JSKBO2OzcxA==


### PR DESCRIPTION
This pull request prevents the code editor from jumping out of view after the description was loaded.

Fixes #1603.
