### PR TITLE
Fix asymmetry of brand logo

### DIFF
--- a/app/assets/stylesheets/layout/navbar.css.less
+++ b/app/assets/stylesheets/layout/navbar.css.less
@@ -88,6 +88,10 @@
       font-size: 18px;
       padding-left: 18px;
 
+      &:focus {
+        outline: none;
+      }
+
       i {
         line-height: @navbar-height;
         @media (min-width: @navbar-collapse-width) {


### PR DESCRIPTION
This pull request hides the focus outline which would reveal asymmetry in the brand logo.