### PR TITLE
Fix rubocop warning: unused variable

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -89,4 +89,4 @@ jobs:
       env:
         RAILS_ENV: "test"
       run: |
-        bundle exec rubocop -c  .rubocop.yml app
+        bundle exec rubocop -c  .rubocop.yml

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,6 +17,8 @@ Layout/FirstArrayElementIndentation:
   EnforcedStyle: consistent
 Layout/FirstHashElementIndentation:
   EnforcedStyle: consistent
+Layout/LineLength:
+  Enabled: false
 
 Lint/Loop:
   Enabled: false
@@ -30,8 +32,6 @@ Metrics/BlockNesting:
 Metrics/ClassLength:
   Enabled: false
 Metrics/CyclomaticComplexity:
-  Enabled: false
-Metrics/LineLength:
   Enabled: false
 Metrics/MethodLength:
   Enabled: false

--- a/test/controllers/submissions_controller_test.rb
+++ b/test/controllers/submissions_controller_test.rb
@@ -78,7 +78,7 @@ class SubmissionsControllerTest < ActionDispatch::IntegrationTest
     course = create :course
     cm = CourseMembership.create(user: u1, course: course, status: :student)
     CourseMembership.create(user: u2, course: course, status: :student)
-    cl = CourseLabel.create(name: 'test', course_memberships: [cm], course: course)
+    CourseLabel.create(name: 'test', course_memberships: [cm], course: course)
     create :submission, status: :correct, user: u1, course: course
     create :submission, status: :wrong, user: u2, course: course
     get course_submissions_url course, params: { course_labels: ['test'], format: :json }


### PR DESCRIPTION
This pull request enables linting for files in the `test/` folder and fixes a warning in that folder.
