### PR TITLE
Fix mocha deprecation warning by making sure the timer thread is always killed

### DIFF
--- a/app/runners/submission_runner.rb
+++ b/app/runners/submission_runner.rb
@@ -147,14 +147,17 @@ class SubmissionRunner
       end
     end
 
-    outlines, errlines = container.tap(&:start).attach(
-      stdin: StringIO.new(@config.to_json),
-      stdout: true,
-      stderr: true
-    )
-    timeout_mutex.synchronize do
-      timer.kill
-      timeout = false if timeout.nil?
+    begin
+      outlines, errlines = container.tap(&:start).attach(
+        stdin: StringIO.new(@config.to_json),
+        stdout: true,
+        stderr: true
+      )
+    ensure
+      timeout_mutex.synchronize do
+        timer.kill
+        timeout = false if timeout.nil?
+      end
     end
 
     after_time = Time.zone.now


### PR DESCRIPTION
Offending test case was 'random errors should be caught' in  `test/runners/submission_runner_test.rb:188`.
