### PR TITLE
Style zeus/staff messages in the output table

### DIFF
--- a/app/assets/stylesheets/models/submissions.css.less
+++ b/app/assets/stylesheets/models/submissions.css.less
@@ -206,14 +206,14 @@
   }
   .message-zeus, .message-staff {
     border-left: 3px solid @text-secondary;
+    padding-left: 25px
   }
   .message-zeus:before, .message-staff:before {
     font: normal normal normal 24px/1 "Material Design Icons";
     color: @text-secondary;
     font-size: 18px;
-    margin-left: 3px;
-    width: 22px;
-    display: inline-block;
+    position: absolute;
+    left: 22px;
   }
   .message-zeus:before {
     content: "\F032";

--- a/app/assets/stylesheets/models/submissions.css.less
+++ b/app/assets/stylesheets/models/submissions.css.less
@@ -204,6 +204,27 @@
     margin-left: 1em;
     margin-right: 1em;
   }
+  .message-zeus, .message-staff {
+    border-left: 3px solid @text-secondary;
+  }
+  .message-zeus:before, .message-staff:before {
+    font: normal normal normal 24px/1 "Material Design Icons";
+    color: @text-secondary;
+    font-size: 18px;
+    margin-left: 3px;
+    width: 22px;
+    display: inline-block;
+  }
+  .message-zeus:before {
+    content: "\F032";
+  }
+  .message-staff:before {
+    content: "\F474";
+  }
+  .message-zeus+.message-zeus:before,
+  .message-staff+.message-staff:before {
+    content: '';
+  }
   .tab-link-marker {
     background: @brand-warning !important;
   }

--- a/app/helpers/renderers/feedback_table_renderer.rb
+++ b/app/helpers/renderers/feedback_table_renderer.rb
@@ -222,7 +222,7 @@ class FeedbackTableRenderer
 
     @builder.div(class: 'messages') do
       msgs.each do |msg|
-        @builder.div(class: 'message') do
+        @builder.div(class: "message message-#{msg.is_a?(Hash) && msg.key?(:permission) ? msg[:permission] : "student"}") do
           message(msg)
         end
       end

--- a/app/helpers/renderers/feedback_table_renderer.rb
+++ b/app/helpers/renderers/feedback_table_renderer.rb
@@ -222,7 +222,15 @@ class FeedbackTableRenderer
 
     @builder.div(class: 'messages') do
       msgs.each do |msg|
-        @builder.div(class: "message message-#{msg.is_a?(Hash) && msg.key?(:permission) ? msg[:permission] : "student"}") do
+        permission = msg.is_a?(Hash) && msg.key?(:permission) ? msg[:permission] : 'student'
+        tooltip = if permission == 'zeus'
+                    I18n.t('submissions.show.message_zeus')
+                  elsif permission == 'staff'
+                    I18n.t('submissions.show.message_staff')
+                  else
+                    ''
+                  end
+        @builder.div(class: "message message-#{permission}", title: tooltip) do
           message(msg)
         end
       end

--- a/config/locales/views/submissions/en.yml
+++ b/config/locales/views/submissions/en.yml
@@ -51,3 +51,5 @@ en:
         hidden: Hide correct tests
       judge_output_too_long: "The judge generated too much output. This usually happens when the submission itself generates too much output. Try to reduce how much output your submission generates."
       reading_failed: "Something went wrong while loading your results. Try again later or resubmit your solution if the problem persists."
+      message_staff: This message is only visible for course admins
+      message_zeus: This message is only visible for administrators

--- a/config/locales/views/submissions/nl.yml
+++ b/config/locales/views/submissions/nl.yml
@@ -51,3 +51,5 @@ nl:
         hidden: Verberg correcte tests
       judge_output_too_long: "De judge heeft te veel uitvoer gegenereerd. Dit gebeurt meestal als je ingediende oplossing zelf te veel output genereerde. Probeer de hoeveelheid uitvoer van je ingediende oplossing te verminderen."
       reading_failed: "Er ging iets fout bij het laden van je resultaten. Probeer later opnieuw of dien je oplossing opnieuw in."
+      message_staff: Dit bericht is enkel zichtbaar voor cursusbeheerders
+      message_zeus: Dit bericht is enkel zichtbaar voor admins


### PR DESCRIPTION
This pull request adds styling to staff-only or zeus-only messages in the feedback table. There is also a tooltip added to the entire message using the title tag. (a tooltip to only the before element is not possible)

![image](https://user-images.githubusercontent.com/481872/73926200-88df7f00-48cf-11ea-8fce-86756ddf058c.png)
![image](https://user-images.githubusercontent.com/481872/73928029-bda10580-48d2-11ea-8549-63611308b52b.png)

Closes #1671 
