### PR TITLE
Fix most navbar links showing up for logged out users

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -71,7 +71,7 @@ module ApplicationHelper
   end
 
   def navbar_link(options)
-    return if options.delete(:if) == false
+    return unless options.delete(:if)
 
     url = options.delete(:url)
     if current_page?(url)


### PR DESCRIPTION
The code checked for exact equality to false, but for logged out users the policy usually returns nil, not false. Now, we check for falsiness, instead of exact equality to false.

Closes #1708.