### PR TITLE
Show image popups on parent page

### DIFF
--- a/app/assets/javascripts/exercise.js
+++ b/app/assets/javascripts/exercise.js
@@ -55,9 +55,17 @@ function initLabelsEdit(labels, undeletableLabels) {
     });
 }
 
-function initLightboxes() {
-    initStrip();
+function showLightbox(content) {
+    Strip.show(content.images, { side: "top" }, content.index);
+}
 
+function onFrameMessage(event) {
+    if (event.message.type === "lightbox") {
+        showLightbox(event.message.content);
+    }
+}
+
+function initLightboxes() {
     let index = 1;
     const images = [];
     $(".exercise-description img, a.dodona-lightbox").each(function () {
@@ -73,9 +81,14 @@ function initLightboxes() {
     });
 
     $(".exercise-description img, a.dodona-lightbox").click(function () {
-        Strip.show(images, {
-            side: "top",
-        }, $(this).data("image_index"));
+        const index = $(this).data("image_index");
+        window.parentIFrame.sendMessage({
+            type: "lightbox",
+            content: {
+                images: images,
+                index: index,
+            }
+        });
         return false;
     });
 }
@@ -121,6 +134,7 @@ function initExerciseShow(exerciseId, programmingLanguage, loggedIn, editorShown
         if (editorShown) {
             initEditor();
         }
+        initStrip();
         swapActionButtons();
         initDeadlineTimeout();
         enableSubmissionTableLinks();
@@ -371,5 +385,8 @@ function afterResize(details) {
     }
 }
 
-export { initExerciseShow, initExerciseDescription, initLabelsEdit, afterResize };
+export {
+    initExerciseShow, initExerciseDescription, initLabelsEdit, afterResize,
+    onFrameMessage
+};
 

--- a/app/helpers/exercise_helper.rb
+++ b/app/helpers/exercise_helper.rb
@@ -49,6 +49,7 @@ module ExerciseHelper
       window.iFrameResize({
           heightCalculationMethod: 'bodyScroll',
           onResized: dodona.afterResize,
+          onMessage: dodona.onFrameMessage,
         },
         '##{id}')
     }

--- a/app/javascript/packs/exercise.js
+++ b/app/javascript/packs/exercise.js
@@ -1,8 +1,9 @@
-import { initExerciseShow, initLabelsEdit, afterResize } from "exercise.js";
+import { initExerciseShow, initLabelsEdit, afterResize, onFrameMessage } from "exercise.js";
 
 window.dodona.initExerciseShow = initExerciseShow;
 window.dodona.initLabelsEdit = initLabelsEdit;
 window.dodona.afterResize = afterResize;
+window.dodona.onFrameMessage = onFrameMessage;
 
-// will automaticaly bind do window.iFrameResize()
+// will automaticaly bind to window.iFrameResize()
 import { iframeResizer } from "iframe-resizer"; // eslint-disable-line no-unused-vars


### PR DESCRIPTION
Images in exercise descriptions can be highlighted using [stripjs lightboxes](http://www.stripjs.com/). However, since the description iframes PR #1234, these lightboxes are rendered within the iframe which was not ideal.

With this PR we leverage the message sending functionality of [iframe-resizer](https://github.com/davidjbradshaw/iframe-resizer/blob/master/docs/iframed_page/methods.md#sendmessagemessagetargetorigin) to ask the parent page to show our images in a lightbox.

Fixes #1376.
