### PR TITLE
Fix info page crash

### DIFF
--- a/app/helpers/renderers/feedback_code_renderer.rb
+++ b/app/helpers/renderers/feedback_code_renderer.rb
@@ -1,10 +1,10 @@
 class FeedbackCodeRenderer
   require 'json'
 
-  def initialize(code, programming_language, messages, builder = nil)
+  def initialize(code, programming_language, messages = nil, builder = nil)
     @code = code
     @programming_language = programming_language
-    @messages = messages
+    @messages = messages || []
     @builder = builder || Builder::XmlMarkup.new
 
     @compress = false

--- a/test/helpers/stub_helper.rb
+++ b/test/helpers/stub_helper.rb
@@ -18,6 +18,8 @@ module StubHelper
     config = { 'evaluation' => { 'time_limit' => 1 } }.freeze
     config_locations = { 'evaluation' => { 'time_limit' => 'config.json' } }.freeze
     description = 'ᕕ(ಠ_ಠ)ᕗ'
+    solutions = { 'solution.py' => 'print(input())' }
+    Exercise.any_instance.stubs(:solutions).returns(solutions)
     Exercise.any_instance.stubs(:config).returns(config)
     Exercise.any_instance.stubs(:config_locations).returns(config_locations)
     Exercise.any_instance.stubs(:update_config)

--- a/test/models/exercise_test.rb
+++ b/test/models/exercise_test.rb
@@ -500,6 +500,11 @@ class ExerciseRemoteTest < ActiveSupport::TestCase
     JSON.parse(File.read(@exercise.config_file))
   end
 
+  test 'should have solutions' do
+    assert_equal @exercise.solutions,
+                 Pathname.new('solution.py') => "print(input())\n"
+  end
+
   test 'should update access in config file' do
     @exercise.update access: 'private'
     assert_equal 'private', config['access']

--- a/test/remotes/exercises/echo/echo/solution/solution.py
+++ b/test/remotes/exercises/echo/echo/solution/solution.py
@@ -1,0 +1,1 @@
+print(input())


### PR DESCRIPTION
The `FeedbackCodeRenderer` API was changed by #1541, crashing the info page when trying to render an exercise info page with solutions.

This PR makes the added `messages` argument optional, defaulting to an empty array.

This bug was not detected because there were no exercises tested with solutions. This PR also adds solutions to stubbed and on-disk exercises.
