### PR TITLE
Correct counting problem with hidden annotations

### DIFF
--- a/app/assets/javascripts/code_listing/code_listing.ts
+++ b/app/assets/javascripts/code_listing/code_listing.ts
@@ -151,6 +151,10 @@ export class CodeListing {
 
     public createHiddenMessage(count: number): HTMLSpanElement {
         const span = document.createElement("span");
+        if (count === 0) {
+            return null;
+        }
+
         const spanText: Text = document.createTextNode(I18n.t("js.annotation.were_hidden.first") + " ");
         span.appendChild(spanText);
 

--- a/app/assets/javascripts/code_listing/code_listing.ts
+++ b/app/assets/javascripts/code_listing/code_listing.ts
@@ -152,7 +152,7 @@ export class CodeListing {
     public createHiddenMessage(count: number): HTMLSpanElement {
         const span = document.createElement("span");
         if (count === 0) {
-            return null;
+            return span;
         }
 
         const spanText: Text = document.createTextNode(I18n.t("js.annotation.were_hidden.first") + " ");

--- a/app/assets/javascripts/code_listing/code_listing.ts
+++ b/app/assets/javascripts/code_listing/code_listing.ts
@@ -67,9 +67,13 @@ export class CodeListing {
             this.annotationsWereHidden.classList.remove("hide");
         }
 
-        const nonErrorAnnotationCount = this.createHiddenMessage(this.annotations.filter(m => m.type !== "error").length);
-        this.annotationsWereHidden.innerHTML = "";
-        this.annotationsWereHidden.appendChild(nonErrorAnnotationCount);
+
+        const errorCount = this.annotations.filter(m => m.type !== "error").length;
+        if (errorCount > 0) {
+            const nonErrorAnnotationCount = this.createHiddenMessage(errorCount);
+            this.annotationsWereHidden.innerHTML = "";
+            this.annotationsWereHidden.appendChild(nonErrorAnnotationCount);
+        }
     }
 
     compressAnnotations(): void {
@@ -151,9 +155,6 @@ export class CodeListing {
 
     public createHiddenMessage(count: number): HTMLSpanElement {
         const span = document.createElement("span");
-        if (count === 0) {
-            return span;
-        }
 
         const spanText: Text = document.createTextNode(I18n.t("js.annotation.were_hidden.first") + " ");
         span.appendChild(spanText);
@@ -161,6 +162,10 @@ export class CodeListing {
         const link: HTMLAnchorElement = document.createElement("a");
         const data: string = I18n.t(`js.annotation.were_hidden.second.${count > 1 ? "plural" : "single"}`).replace(/{count}/g, String(count));
         const linkText: Text = document.createTextNode(data);
+        link.href = "#";
+        link.addEventListener("click", function (ev) {
+            ev.preventDefault();
+        });
         link.appendChild(linkText);
         span.appendChild(link);
         return span;

--- a/app/assets/javascripts/code_listing/code_listing.ts
+++ b/app/assets/javascripts/code_listing/code_listing.ts
@@ -47,8 +47,6 @@ export class CodeListing {
         this.hideAllButton.addEventListener("click", () => this.hideAllAnnotations());
 
         this.showOnlyErrorButton.addEventListener("click", () => this.compressAnnotations());
-
-        this.annotationsWereHidden.addEventListener("click", () => this.showAllButton.click());
     }
 
     addAnnotations(annotations: AnnotationData[]): void {
@@ -163,8 +161,9 @@ export class CodeListing {
         const data: string = I18n.t(`js.annotation.were_hidden.second.${count > 1 ? "plural" : "single"}`).replace(/{count}/g, String(count));
         const linkText: Text = document.createTextNode(data);
         link.href = "#";
-        link.addEventListener("click", function (ev) {
+        link.addEventListener("click", ev => {
             ev.preventDefault();
+            this.showAllButton.click();
         });
         link.appendChild(linkText);
         span.appendChild(link);

--- a/app/assets/stylesheets/components/code_listing.css.less
+++ b/app/assets/stylesheets/components/code_listing.css.less
@@ -2,6 +2,10 @@
 
 .code-table {
 
+  #annotations-were-hidden a {
+    cursor: pointer;
+  }
+
   .code-listing {
 
     user-select: none;

--- a/app/assets/stylesheets/components/code_listing.css.less
+++ b/app/assets/stylesheets/components/code_listing.css.less
@@ -2,10 +2,6 @@
 
 .code-table {
 
-  #annotations-were-hidden a {
-    cursor: pointer;
-  }
-
   .code-listing {
 
     user-select: none;

--- a/config/locales/views/submissions/en.yml
+++ b/config/locales/views/submissions/en.yml
@@ -51,7 +51,7 @@ en:
         hidden: Hide correct tests
       annotations:
         title: Annotations
-        show_all: Show annotations
+        show_all: Show all annotations
         hide_all: Hide annotations
         show_errors: Only show errors
         hidden: Hidden annotations

--- a/config/locales/views/submissions/en.yml
+++ b/config/locales/views/submissions/en.yml
@@ -52,7 +52,7 @@ en:
       annotations:
         title: Annotations
         show_all: Show all annotations
-        hide_all: Hide annotations
+        hide_all: Hide all annotations
         show_errors: Only show errors
         hidden: Hidden annotations
       judge_output_too_long: "The judge generated too much output. This usually happens when the submission itself generates too much output. Try to reduce how much output your submission generates."

--- a/config/locales/views/submissions/nl.yml
+++ b/config/locales/views/submissions/nl.yml
@@ -51,7 +51,7 @@ nl:
         hidden: Verberg correcte tests
       annotations:
         title: Annotaties
-        show_all: Toon annotaties
+        show_all: Toon alle annotaties
         hide_all: Verberg annotaties
         show_errors: Enkel errors tonen
         hidden: Verborgen annotaties

--- a/config/locales/views/submissions/nl.yml
+++ b/config/locales/views/submissions/nl.yml
@@ -52,7 +52,7 @@ nl:
       annotations:
         title: Annotaties
         show_all: Toon alle annotaties
-        hide_all: Verberg annotaties
+        hide_all: Verberg alle annotaties
         show_errors: Enkel errors tonen
         hidden: Verborgen annotaties
       judge_output_too_long: "De judge heeft te veel uitvoer gegenereerd. Dit gebeurt meestal als je ingediende oplossing zelf te veel output genereerde. Probeer de hoeveelheid uitvoer van je ingediende oplossing te verminderen."

--- a/test/javascript/code_listing.test.ts
+++ b/test/javascript/code_listing.test.ts
@@ -210,7 +210,7 @@ test("correct buttons & elements are hidden and unhidden", () => {
     expect(document.querySelectorAll("#diff-switch-prefix.hide").length).toBe(0);
     expect(document.querySelectorAll("#diff-switch-prefix:not(.hide)").length).toBe(1);
 
-    const annotationsWereHidden: HTMLSpanElement = document.querySelector("span#annotations-were-hidden") as HTMLSpanElement;
+    const annotationsWereHidden: HTMLSpanElement = document.querySelector("span#annotations-were-hidden a") as HTMLSpanElement;
     annotationsWereHidden.click();
 
     expect(document.querySelectorAll("#annotations-were-hidden").length).toBe(0);

--- a/test/javascript/code_listing.test.ts
+++ b/test/javascript/code_listing.test.ts
@@ -218,3 +218,13 @@ test("correct buttons & elements are hidden and unhidden", () => {
     expect(document.querySelectorAll("#show_all_annotations.active.hide").length).toBe(0);
     expect(document.querySelectorAll("#show_all_annotations.active:not(.hide)").length).toBe(1);
 });
+
+test("Dont show a message when there is only an error", () => {
+    codeListing.addAnnotation({
+        type: "error",
+        text: "Replace with oneliner",
+        row: 1
+    });
+
+    expect(document.querySelector("#annotations-were-hidden").textContent).toBe("");
+});


### PR DESCRIPTION
This pull request fixes the issues laid out in #1733 

- Count was incorrect due to only checking if > 1 when choosing 1 or many.
- Added specific css to make the link portion a cursor: pointer
- Locale was modified to be "Show all annotations" & "Toon alle annotaties"

- [x] Tests were added

Closes #1733  .
