### PR TITLE
Fix chrome not making a cell 100% wide when using min-width.

### DIFF
--- a/app/assets/stylesheets/components/code_listing.css.less
+++ b/app/assets/stylesheets/components/code_listing.css.less
@@ -79,7 +79,7 @@
     .annotation-set {
       .annotation-cell {
 
-        min-width: 100%;
+        width: 100%;
 
         .annotation {
           font-family: @font-family-monospace;

--- a/app/assets/stylesheets/components/code_listing.css.less
+++ b/app/assets/stylesheets/components/code_listing.css.less
@@ -26,6 +26,7 @@
     }
 
     .rouge-code {
+      width: 100%;
       padding-left: 5px;
       user-select: text;
       white-space: pre-wrap;


### PR DESCRIPTION
This pull request makes it so that `width` is used instead of `min-width` for the table cells. Chrome seemingly does not follow the min-width rule in this usecase

Closes #1735 .
