### PR TITLE
Encode with universal newline

### DIFF
--- a/app/helpers/renderers/feedback_code_renderer.rb
+++ b/app/helpers/renderers/feedback_code_renderer.rb
@@ -15,7 +15,7 @@ class FeedbackCodeRenderer
     table_formatter = Rouge::Formatters::HTMLLineTable.new line_formatter, table_class: 'code-listing highlighter-rouge'
 
     lexer = (Rouge::Lexer.find(@programming_language) || Rouge::Lexers::PlainText).new
-    lexed_c = lexer.lex(@code)
+    lexed_c = lexer.lex(@code.encode(universal_newline: true))
 
     only_errors = @messages.select { |message| message[:type] == :error || message[:type] == 'error' }
     @compress = !only_errors.empty? && only_errors.size != @messages.size

--- a/test/renderers/feedback_code_renderer_test.rb
+++ b/test/renderers/feedback_code_renderer_test.rb
@@ -1,0 +1,25 @@
+require 'test_helper'
+require 'builder'
+
+class FeedbackCodeRendererTest < ActiveSupport::TestCase
+  include Rails.application.routes.url_helpers
+  include ApplicationHelper
+
+  test 'No weird carriage return or linefeeds in the generated html' do
+    code_orig = "print(x)\nprint(y)\n"
+    programming_language = 'python'
+    renderer_orig = FeedbackCodeRenderer.new(code_orig, programming_language)
+    gen_html_orig = renderer_orig.parse.html
+
+    code = code_orig.encode(crlf_newline: true)
+    renderer_crlf = FeedbackCodeRenderer.new(code, programming_language)
+    gen_html_crlf = renderer_crlf.parse.html
+
+    code = code_orig.encode(cr_newline: true)
+    renderer_cr = FeedbackCodeRenderer.new(code, programming_language)
+    gen_html_cr = renderer_cr.parse.html
+
+    assert_equal gen_html_orig, gen_html_crlf
+    assert_equal gen_html_orig, gen_html_cr
+  end
+end

--- a/test/renderers/feedback_code_renderer_test.rb
+++ b/test/renderers/feedback_code_renderer_test.rb
@@ -2,9 +2,7 @@ require 'test_helper'
 require 'builder'
 
 class FeedbackCodeRendererTest < ActiveSupport::TestCase
-
   test 'No weird carriage return or linefeeds in the generated html' do
-
     programming_language = 'python'
     examples = [
       "print(x)\nprint(y)\n",

--- a/test/renderers/feedback_code_renderer_test.rb
+++ b/test/renderers/feedback_code_renderer_test.rb
@@ -2,24 +2,31 @@ require 'test_helper'
 require 'builder'
 
 class FeedbackCodeRendererTest < ActiveSupport::TestCase
-  include Rails.application.routes.url_helpers
-  include ApplicationHelper
 
   test 'No weird carriage return or linefeeds in the generated html' do
-    code_orig = "print(x)\nprint(y)\n"
+
     programming_language = 'python'
-    renderer_orig = FeedbackCodeRenderer.new(code_orig, programming_language)
-    gen_html_orig = renderer_orig.parse.html
+    examples = [
+      "print(x)\nprint(y)\n",
+      "# First line comment\nprint(5)\nprint(6)",
+      "# Doctest\n\"\"\"\n>>> 5 + 4\n9\n\"\"\"",
+      "def plus(n, m):\n\treturn n+m\n\nprint(plus(5, 4))"
+    ]
 
-    code = code_orig.encode(crlf_newline: true)
-    renderer_crlf = FeedbackCodeRenderer.new(code, programming_language)
-    gen_html_crlf = renderer_crlf.parse.html
+    examples.each do |code_orig|
+      renderer_orig = FeedbackCodeRenderer.new(code_orig, programming_language)
+      gen_html_orig = renderer_orig.parse.html
 
-    code = code_orig.encode(cr_newline: true)
-    renderer_cr = FeedbackCodeRenderer.new(code, programming_language)
-    gen_html_cr = renderer_cr.parse.html
+      code = code_orig.encode(crlf_newline: true)
+      renderer_crlf = FeedbackCodeRenderer.new(code, programming_language)
+      gen_html_crlf = renderer_crlf.parse.html
 
-    assert_equal gen_html_orig, gen_html_crlf
-    assert_equal gen_html_orig, gen_html_cr
+      code = code_orig.encode(cr_newline: true)
+      renderer_cr = FeedbackCodeRenderer.new(code, programming_language)
+      gen_html_cr = renderer_cr.parse.html
+
+      assert_equal gen_html_orig, gen_html_crlf
+      assert_equal gen_html_orig, gen_html_cr
+    end
   end
 end


### PR DESCRIPTION
Encodes each string to have a universal newline
Should solve the issue of high comment lines when code is inputted with Windows newlines