### PR TITLE
Exercise info page improvements

### DIFF
--- a/app/assets/stylesheets/models/exercises.css.less
+++ b/app/assets/stylesheets/models/exercises.css.less
@@ -128,4 +128,12 @@ center img {
   }
 }
 
-
+// reduce padding for tabs for sample solutions
+.sample-solutions {
+  .card-title {
+    padding-bottom: 0;
+  }
+  .card-supporting-text {
+    padding-top: 0;
+  }
+}

--- a/app/assets/stylesheets/models/exercises.css.less
+++ b/app/assets/stylesheets/models/exercises.css.less
@@ -104,6 +104,9 @@ center img {
 .exercise-info {
   .labels {
     margin-bottom: 1em;
+    a:hover {
+      text-decoration: none;
+    }
   }
 
   .repo-details {

--- a/app/controllers/exercises_controller.rb
+++ b/app/controllers/exercises_controller.rb
@@ -77,11 +77,7 @@ class ExercisesController < ApplicationController
       authorize @edit_submission, :edit?
     end
     if params[:from_solution]
-      begin
-        @solution = @exercise.solutions[Pathname.new(params[:from_solution])]
-      rescue ArgumentError # ignored, the pathname is invalid.
-        @solution = nil
-      end
+      @solution = @exercise.solutions[params[:from_solution]]
       authorize @exercise, :info?
     end
 

--- a/app/controllers/exercises_controller.rb
+++ b/app/controllers/exercises_controller.rb
@@ -89,10 +89,12 @@ class ExercisesController < ApplicationController
   def info
     @title = @exercise.name
     @repository = @exercise.repository
-    @courses_series = policy_scope(@exercise.series).group_by(&:course)
     @config = @exercise.merged_config
     @config_locations = @exercise.merged_config_locations
     @crumbs << [@exercise.name, helpers.exercise_scoped_path(exercise: @exercise, series: @series, course: @course)] << [I18n.t('crumbs.info'), '#']
+    @courses_series = policy_scope(@exercise.series).group_by(&:course).sort do |a, b|
+      [b.first.year, a.first.name] <=> [a.first.year, b.first.name]
+    end
   end
 
   def edit

--- a/app/controllers/exercises_controller.rb
+++ b/app/controllers/exercises_controller.rb
@@ -76,6 +76,16 @@ class ExercisesController < ApplicationController
       @edit_submission = Submission.find(params[:edit_submission])
       authorize @edit_submission, :edit?
     end
+    if params[:from_solution]
+      begin
+        @solution = @exercise.solutions[Pathname.new(params[:from_solution])]
+      rescue ArgumentError # ignored, the pathname is invalid.
+        @solution = nil
+      end
+      authorize @exercise, :info?
+    end
+
+    @code = @edit_submission.try(:code) || @solution || @exercise.boilerplate
     @title = @exercise.name
     @crumbs << [@exercise.name, '#']
   end

--- a/app/helpers/exercise_helper.rb
+++ b/app/helpers/exercise_helper.rb
@@ -85,7 +85,7 @@ module ExerciseHelper
   end
 
   def starts_with_solution?(item)
-    item.first.basename.to_s.starts_with?('solution')
+    item.first.starts_with?('solution')
   end
 
   def compare_solutions(a, b)

--- a/app/models/exercise.rb
+++ b/app/models/exercise.rb
@@ -101,7 +101,7 @@ class Exercise < ApplicationRecord
     (full_path + SOLUTION_DIR)
       .yield_self { |path| path.directory? ? path.children : [] }
       .filter { |path| path.file? && path.readable? }
-      .map { |path| [path.basename, path.read(SOLUTION_MAX_BYTES)&.force_encoding('UTF-8')&.scrub || ''] }
+      .map { |path| [path.basename.to_s, path.read(SOLUTION_MAX_BYTES)&.force_encoding('UTF-8')&.scrub || ''] }
       .to_h
   end
 

--- a/app/views/exercises/_form.html.erb
+++ b/app/views/exercises/_form.html.erb
@@ -29,18 +29,6 @@
     <div class="col-sm-6 col-xs-12"><%= f.text_field :labels, class: 'form-control', disable: !f.permission?(:labels), value: exercise.labels.map(&:name).join(','), placeholder: t(".labels") %></div>
     <span class="help-block col-sm-offset-3 col-sm-6 col-xs-12"><%= t '.labels_delimiter' %></span>
   </div>
-  <div class="field form-group">
-    <label class="col-sm-3 col-xs-12 control-label"><%= Exercise.human_attribute_name("repository") %></label>
-    <div class="col-sm-6 col-xs-12 form-control-static"><%= link_to exercise.repository.name, exercise.repository %></div>
-  </div>
-  <div class="field form-group">
-    <label class="col-sm-3 col-xs-12 control-label"><%= Exercise.human_attribute_name("judge") %></label>
-    <div class="col-sm-6 col-xs-12 form-control-static"><%= link_to exercise.judge.name, exercise.judge %></div>
-  </div>
-  <div class="field form-group">
-    <label class="col-sm-3 col-xs-12 control-label"><%= t ".edit_exercise" %></label>
-    <div class="col-sm-6 col-xs-12 form-control-static"><%= link_to t(".open_on_github"), exercise.github_url, target: '_blank', rel: 'noopener' %></div>
-  </div>
 <% end %>
 <script>
     dodona.initLabelsEdit(<%= raw render template: 'labels/index', formats: :json %>, <%= raw (exercise.merged_dirconfig['labels'] || []).to_json %>);

--- a/app/views/exercises/_form.html.erb
+++ b/app/views/exercises/_form.html.erb
@@ -33,6 +33,10 @@
     <label class="col-sm-3 col-xs-12 control-label"><%= t ".edit_exercise" %></label>
     <div class="col-sm-6 col-xs-12 form-control-static"><%= link_to t(".open_on_github"), exercise.github_url, target: '_blank', rel: 'noopener' %></div>
   </div>
+  <div class="field form-group">
+    <label class="col-sm-3 col-xs-12 control-label"><%= t ".info" %></label>
+    <div class="col-sm-6 col-xs-12 form-control-static"><%= link_to t(".info_description"), info_exercise_scoped_path(exercise: @exercise, course: @course, series: @series), rel: 'noopener' %></div>
+  </div>
 <% end %>
 <script>
     dodona.initLabelsEdit(<%= raw render template: 'labels/index', formats: :json %>, <%= raw (exercise.merged_dirconfig['labels'] || []).to_json %>);

--- a/app/views/exercises/_form.html.erb
+++ b/app/views/exercises/_form.html.erb
@@ -29,6 +29,10 @@
     <div class="col-sm-6 col-xs-12"><%= f.text_field :labels, class: 'form-control', disable: !f.permission?(:labels), value: exercise.labels.map(&:name).join(','), placeholder: t(".labels") %></div>
     <span class="help-block col-sm-offset-3 col-sm-6 col-xs-12"><%= t '.labels_delimiter' %></span>
   </div>
+  <div class="field form-group">
+    <label class="col-sm-3 col-xs-12 control-label"><%= t ".edit_exercise" %></label>
+    <div class="col-sm-6 col-xs-12 form-control-static"><%= link_to t(".open_on_github"), exercise.github_url, target: '_blank', rel: 'noopener' %></div>
+  </div>
 <% end %>
 <script>
     dodona.initLabelsEdit(<%= raw render template: 'labels/index', formats: :json %>, <%= raw (exercise.merged_dirconfig['labels'] || []).to_json %>);

--- a/app/views/exercises/_navbar_links.html.erb
+++ b/app/views/exercises/_navbar_links.html.erb
@@ -22,6 +22,6 @@
 
   <%= navbar_link url: info_exercise_scoped_path(exercise: @exercise, course: @course, series: @series),
                   title: t('.info'),
-                  icon: 'information-outline',
+                  icon: 'information',
                   if: policy(@exercise).info? %>
 <% end %>

--- a/app/views/exercises/info.html.erb
+++ b/app/views/exercises/info.html.erb
@@ -167,8 +167,11 @@
                 <div class="tab-pane active">
                   <span class="text-muted"><%= t '.sample_solutions_hint' %></span>
                 </div>
-                <% solutions.map(&:last).each_with_index do |code, i| %>
-                  <div id="solution-<%= i %>" class="tab-pane">
+                <% solutions.each_with_index do |(fname, code), i| %>
+                  <div id="solution-<%= i %>" class="tab-pane feedback-table">
+                    <div class="feedback-table-options">
+                      <%= link_to t('.sample_solution_submit'), exercise_url(@exercise, from_solution: fname), class: "btn btn-default btn-secondary" %>
+                    </div>
                     <div class="code-table">
                       <%= raw FeedbackCodeRenderer.new(code, @exercise.programming_language.name).parse.html %>
                     </div>

--- a/app/views/exercises/info.html.erb
+++ b/app/views/exercises/info.html.erb
@@ -148,41 +148,39 @@
 
 <div class="row">
   <div class="col-sm-10 col-sm-offset-1 col-xs-12">
-    <div class="card">
+    <div class="card sample-solutions">
       <div class="card-title">
         <h3><%= t ".sample_solutions" %></h3>
       </div>
-      <div class="card-supporting-text row">
-        <div class="col-xs-12">
-          <% if solutions.any? %>
-            <div class="card-tab">
-              <ul class="nav nav-tabs">
-                <% solutions.map(&:first).each_with_index do |fname, i| %>
-                  <li>
-                    <a href="#solution-<%= i %>" data-toggle="tab" aria-expanded="false"><%= fname %></a>
-                  </li>
-                <% end %>
-              </ul>
-              <div class="tab-content">
-                <div class="tab-pane active">
-                  <span class="text-muted"><%= t '.sample_solutions_hint' %></span>
-                </div>
-                <% solutions.each_with_index do |(fname, code), i| %>
-                  <div id="solution-<%= i %>" class="tab-pane feedback-table">
-                    <div class="feedback-table-options">
-                      <%= link_to t('.sample_solution_submit'), exercise_url(@exercise, from_solution: fname), class: "btn btn-default btn-secondary" %>
-                    </div>
-                    <div class="code-table">
-                      <%= raw FeedbackCodeRenderer.new(code, @exercise.programming_language.name).parse.html %>
-                    </div>
-                  </div>
-                <% end %>
+      <div class="card-supporting-text">
+        <% if solutions.any? %>
+          <div class="card-tab">
+            <ul class="nav nav-tabs">
+              <% solutions.map(&:first).each_with_index do |fname, i| %>
+                <li>
+                  <a href="#solution-<%= i %>" data-toggle="tab" aria-expanded="false"><%= fname %></a>
+                </li>
+              <% end %>
+            </ul>
+            <div class="tab-content">
+              <div class="tab-pane active">
+                <span class="text-muted"><%= t '.sample_solutions_hint' %></span>
               </div>
+              <% solutions.each_with_index do |(fname, code), i| %>
+                <div id="solution-<%= i %>" class="tab-pane feedback-table">
+                  <div class="feedback-table-options">
+                    <%= link_to t('.sample_solution_submit'), exercise_url(@exercise, from_solution: fname), class: "btn btn-default btn-secondary" %>
+                  </div>
+                  <div class="code-table">
+                    <%= raw FeedbackCodeRenderer.new(code, @exercise.programming_language.name).parse.html %>
+                  </div>
+                </div>
+              <% end %>
             </div>
-          <% else %>
-            <span class="text-muted"><%= t '.no_solutions' %></span>
-          <% end %>
-        </div>
+          </div>
+        <% else %>
+          <span class="text-muted"><%= t '.no_solutions' %></span>
+        <% end %>
       </div>
     </div>
   </div>

--- a/app/views/exercises/info.html.erb
+++ b/app/views/exercises/info.html.erb
@@ -27,10 +27,19 @@
             <div class="row">
               <div class="col-xs-12 repo-details">
                 <div class="row">
-                  <div class="col-xs-12">
+                  <div class="col-sm-12 col-xs-6">
                     <p title="<%= t '.contact' %>">
                     <i class="mdi mdi-account-box mdi-24"></i>
                     <%= mail_to(@config['contact'] || @repository.first_admin&.pretty_email) %>
+                  </div>
+                  <div class="col-sm-12 col-xs-6">
+                    <p title="<%= t '.judge' %>">
+                    <i class="mdi mdi-gavel mdi-24"></i>
+                    <% if policy(@exercise.judge).show? %>
+                      <%= link_to @exercise.judge.name, judge_path(@exercise.judge) %>
+                    <% else %>
+                      <%= @exercise.judge.name %>
+                    <% end %>
                   </div>
                   <div class="col-sm-12 col-xs-6">
                     <p title="<%= t '.repository' %>">
@@ -40,6 +49,8 @@
                     <% else %>
                       <%= @repository.name %>
                     <% end %>
+                  </div>
+                  <div class="col-sm-12 col-xs-6">
                     <% if current_user&.repository_admin?(@repository) %>
                     <p title="<%= t '.repository_path' %>">
                     <i class="mdi mdi-file-search mdi-24"></i>
@@ -52,6 +63,8 @@
                     <span title="<%= l @exercise.created_at, format: :long %>">
                     <%= time_ago_in_words(@exercise.created_at) %> <%= t '.ago' %>.
                     </span>
+                  </div>
+                  <div class="col-sm-12 col-xs-6">
                     <p title="<%= t '.updated' %>">
                     <i class="mdi mdi-update mdi-24"></i>
                     <span title="<%= l @exercise.updated_at, format: :long %>">

--- a/app/views/exercises/info.html.erb
+++ b/app/views/exercises/info.html.erb
@@ -208,7 +208,7 @@
                   <% @courses_series.each do |course, series| %>
                     <tr>
                       <td title="<%= course.name %>" class="text">
-                        <span><%= link_to course.name, course, target: '_blank' %></span>
+                        <span><%= link_to course.name, course %></span>
                       </td>
                       <td class="text">
                         <%= raw series.map{ |s| link_to(s.name, s, class: "course-link", title: s.name).html_safe }.to_sentence %>

--- a/app/views/exercises/info.html.erb
+++ b/app/views/exercises/info.html.erb
@@ -98,7 +98,7 @@
                 <%= network_config_name %>
               </div>
               <div title="<%= t '.submission_details', correct: @exercise.submissions.correct.count, total: @exercise.submissions.count, users: @exercise.users_tried %>" class="col-md-4 col-sm-6 col-xs-4 exercise-detail">
-                <h1><%= @exercise.submissions.count %></h1>
+                <h1><%= number_with_delimiter @exercise.submissions.count, delimiter: " " %></h1>
                 <%= t '.submission_count' %>
               </div>
             </div>

--- a/app/views/exercises/info.html.erb
+++ b/app/views/exercises/info.html.erb
@@ -117,7 +117,7 @@
             </div>
           </div>
           <div class="col-xs-12">
-            <span class="small text-muted"><%= raw t('.config_info', here: link_to(t('.here'), 'https://dodona-edu.github.io/references/exercise-config/')) %></span>
+            <span class="small text-muted"><%= raw t('.config_info', doc_site: link_to(t('.doc_site'), 'https://dodona-edu.github.io/references/exercise-config/')) %></span>
           </div>
         </div>
       </div>

--- a/app/views/exercises/info.html.erb
+++ b/app/views/exercises/info.html.erb
@@ -131,7 +131,7 @@
               <span class="text-muted"><%= t '.no_about_present' %></span>
               <% if current_user&.repository_admin?(@repository) && @repository.github_url.present? %>
                 <%= github_link @repository,
-                  @exercise.path + "?filename=about.#{I18n.locale.to_s}.md",
+                  "?filename=#{@exercise.path}/about.#{I18n.locale.to_s}.md",
                   name: t('.click_here_to_create_one'),
                   mode: 'new' %>
               <% end %>

--- a/app/views/exercises/info.html.erb
+++ b/app/views/exercises/info.html.erb
@@ -27,11 +27,13 @@
             <div class="row">
               <div class="col-xs-12 repo-details">
                 <div class="row">
-                  <div class="col-sm-12 col-xs-6">
-                    <p title="<%= t '.contact' %>">
-                    <i class="mdi mdi-account-box mdi-24"></i>
-                    <%= mail_to(@config['contact'] || @repository.first_admin&.pretty_email) %>
-                  </div>
+                  <% if (contact_info = @config['contact'] || @repository.first_admin&.pretty_email) %>
+                    <div class="col-sm-12 col-xs-6">
+                      <p title="<%= t '.contact' %>">
+                        <i class="mdi mdi-account-box mdi-24"></i>
+                        <%= mail_to(contact_info) %>
+                    </div>
+                  <% end %>
                   <div class="col-sm-12 col-xs-6">
                     <p title="<%= t '.judge' %>">
                     <i class="mdi mdi-gavel mdi-24"></i>

--- a/app/views/exercises/info.html.erb
+++ b/app/views/exercises/info.html.erb
@@ -77,25 +77,25 @@
           </div>
           <div class="col-md-8 col-md-pull-4 col-sm-6 col-sm-pull-6 col-xs-12">
             <div class="row exercise-details">
-              <div title="<%= exercise_config_explanation 'programming_language' %>" class="col-md-4 col-sm-6 col-xs-4 exercise-detail">
+              <div title="<%= exercise_config_explanation 'programming_language' %>" class="col-md-4 col-sm-6 col-xs-6 exercise-detail">
                 <h1><%= @exercise.programming_language.name.titlecase %></h1>
                 <%= t '.programming_language' %>
               </div>
-              <div title="<%= t '.description_files', path: './' + @exercise.path + '/' + Exercise::DESCRIPTION_DIR  + '/' %>" class="col-md-4 col-sm-6 col-xs-4 exercise-detail">
+              <div title="<%= t '.description_files', path: './' + @exercise.path + '/' + Exercise::DESCRIPTION_DIR  + '/' %>" class="col-md-4 col-sm-6 col-xs-6 exercise-detail">
                 <h1><%= @exercise.description_languages.join(', ') %></h1>
                 <%= t '.natural_language' %>
               </div>
-              <div class="col-md-4 col-sm-6 col-xs-4 exercise-detail" title="<%= exercise_config_explanation 'evaluation', 'time_limit' %>">
+              <div class="col-md-4 col-sm-6 col-xs-6 exercise-detail" title="<%= exercise_config_explanation 'evaluation', 'time_limit' %>">
                 <h1><%= @config.dig('evaluation', 'time_limit') || SubmissionRunner.default_config['time_limit']  %>s</h1>
                 <%= t '.time_limit' %>
               </div>
-              <div title="<%= exercise_config_explanation 'evaluation', 'memory_limit' %>" class="col-md-4 col-sm-6 col-xs-4 exercise-detail">
+              <div title="<%= exercise_config_explanation 'evaluation', 'memory_limit' %>" class="col-md-4 col-sm-6 col-xs-6 exercise-detail">
                 <h1>
                   <%= human_bytes (@config.dig('evaluation', 'memory_limit') || SubmissionRunner.default_config['memory_limit']).to_i %>
                 </h1>
                 <%= t '.memory_limit' %>
               </div>
-              <div title="<%= exercise_config_explanation 'network_enabled' %>" class="col-md-4 col-sm-6 col-xs-4 exercise-detail">
+              <div title="<%= exercise_config_explanation 'network_enabled' %>" class="col-md-4 col-sm-6 col-xs-6 exercise-detail">
                 <%
                     if @config['network_enabled']
                       network_icon = 'mdi-wan'
@@ -110,7 +110,7 @@
                 </h1>
                 <%= network_config_name %>
               </div>
-              <div title="<%= t '.submission_details', correct: @exercise.submissions.correct.count, total: @exercise.submissions.count, users: @exercise.users_tried %>" class="col-md-4 col-sm-6 col-xs-4 exercise-detail">
+              <div title="<%= t '.submission_details', correct: @exercise.submissions.correct.count, total: @exercise.submissions.count, users: @exercise.users_tried %>" class="col-md-4 col-sm-6 col-xs-6 exercise-detail">
                 <h1><%= number_with_delimiter @exercise.submissions.count, delimiter: " " %></h1>
                 <%= t '.submission_count' %>
               </div>

--- a/app/views/exercises/info.html.erb
+++ b/app/views/exercises/info.html.erb
@@ -61,14 +61,14 @@
                     <p title="<%= t '.created' %>">
                     <i class="mdi mdi-clock-outline mdi-24"></i>
                     <span title="<%= l @exercise.created_at, format: :long %>">
-                    <%= time_ago_in_words(@exercise.created_at) %> <%= t '.ago' %>.
+                    <%= time_ago_in_words(@exercise.created_at) %> <%= t '.ago' %>
                     </span>
                   </div>
                   <div class="col-sm-12 col-xs-6">
                     <p title="<%= t '.updated' %>">
                     <i class="mdi mdi-update mdi-24"></i>
                     <span title="<%= l @exercise.updated_at, format: :long %>">
-                    <%= time_ago_in_words(@exercise.updated_at) %> <%= t '.ago' %>.
+                    <%= time_ago_in_words(@exercise.updated_at) %> <%= t '.ago' %>
                     </span>
                   </div>
                 </div>

--- a/app/views/exercises/info.html.erb
+++ b/app/views/exercises/info.html.erb
@@ -172,7 +172,7 @@
               <% solutions.each_with_index do |(fname, code), i| %>
                 <div id="solution-<%= i %>" class="tab-pane feedback-table">
                   <div class="feedback-table-options">
-                    <%= link_to t('.sample_solution_submit'), exercise_url(@exercise, from_solution: fname), class: "btn btn-default btn-secondary" %>
+                    <%= link_to t('.sample_solution_submit'), exercise_url(@exercise, from_solution: fname), class: "btn-text" %>
                   </div>
                   <div class="code-table">
                     <%= raw FeedbackCodeRenderer.new(code, @exercise.programming_language.name).parse.html %>

--- a/app/views/exercises/info.html.erb
+++ b/app/views/exercises/info.html.erb
@@ -87,16 +87,19 @@
                 <h1><%= @exercise.description_languages.join(', ') %></h1>
                 <%= t '.natural_language' %>
               </div>
+              <div class="clearfix visible-sm-block"></div>
               <div class="col-md-4 col-sm-6 col-xs-6 exercise-detail" title="<%= exercise_config_explanation 'evaluation', 'time_limit' %>">
                 <h1><%= @config.dig('evaluation', 'time_limit') || SubmissionRunner.default_config['time_limit']  %>s</h1>
                 <%= t '.time_limit' %>
               </div>
+              <div class="clearfix visible-md-block"></div>
               <div title="<%= exercise_config_explanation 'evaluation', 'memory_limit' %>" class="col-md-4 col-sm-6 col-xs-6 exercise-detail">
                 <h1>
                   <%= human_bytes (@config.dig('evaluation', 'memory_limit') || SubmissionRunner.default_config['memory_limit']).to_i %>
                 </h1>
                 <%= t '.memory_limit' %>
               </div>
+              <div class="clearfix visible-sm-block"></div>
               <div title="<%= exercise_config_explanation 'network_enabled' %>" class="col-md-4 col-sm-6 col-xs-6 exercise-detail">
                 <%
                     if @config['network_enabled']

--- a/app/views/exercises/show.html.erb
+++ b/app/views/exercises/show.html.erb
@@ -90,7 +90,7 @@
                 </div>
               <% end %>
               <div id="editor-window" class='tex2jax_ignore'>
-                <div id="editor-text"><%= @edit_submission.try(:code) || @exercise.boilerplate %></div>
+                <div id="editor-text"><%= @code %></div>
               </div>
               <span class="header-info-text"><i class="mdi mdi-information mdi-18"></i> <%= t ".hand_in_info" %></span>
             <% end %>

--- a/config/locales/views/exercises/en.yml
+++ b/config/locales/views/exercises/en.yml
@@ -19,6 +19,8 @@ en:
       open_on_github: Open on GitHub
       labels_delimiter: "Use a comma to delimit labels"
       labels: New label
+      info: Information
+      info_description: Go to the information about this exercise
     index:
       title: Exercises
       exercise: Exercise

--- a/config/locales/views/exercises/en.yml
+++ b/config/locales/views/exercises/en.yml
@@ -97,5 +97,5 @@ en:
       config_set_by: "This value was set by %{file}"
       config_default: "This is the default value."
       description_files: "We found files for these languages in the descriptions folder %{path}"
-      config_info: 'For more information about configuring exercises, you can take a look at our documentation site %{here}.'
-      here: 'here'
+      config_info: 'Take a look at the %{doc_site} for more information about configuring exercises.'
+      doc_site: 'documentation site'

--- a/config/locales/views/exercises/en.yml
+++ b/config/locales/views/exercises/en.yml
@@ -79,6 +79,7 @@ en:
       submission_details: "This exercises has %{total} submissions by %{users} unique users. Of these submissions, %{correct} were correct."
       sample_solutions: Sample solutions
       sample_solutions_hint: Click on one of the tabs above to view a sample solution.
+      sample_solution_submit: Submit sample solution
       no_solutions: This exercise does not yet have a sample solution.
       no_solutions_admin: Add your sample solutions to the repository and they will be shown here.
       usage: Usage

--- a/config/locales/views/exercises/en.yml
+++ b/config/locales/views/exercises/en.yml
@@ -20,7 +20,7 @@ en:
       labels_delimiter: "Use a comma to delimit labels"
       labels: New label
       info: Information
-      info_description: Go to the information about this exercise
+      info_description: Go to the information page of this exercise
     index:
       title: Exercises
       exercise: Exercise
@@ -81,7 +81,7 @@ en:
       submission_details: "This exercises has %{total} submissions by %{users} unique users. Of these submissions, %{correct} were correct."
       sample_solutions: Sample solutions
       sample_solutions_hint: Click on one of the tabs above to view a sample solution.
-      sample_solution_submit: Submit sample solution
+      sample_solution_submit: Submit this solution
       no_solutions: This exercise does not yet have a sample solution.
       no_solutions_admin: Add your sample solutions to the repository and they will be shown here.
       usage: Usage

--- a/config/locales/views/exercises/en.yml
+++ b/config/locales/views/exercises/en.yml
@@ -87,6 +87,7 @@ en:
         one: "This exercise is used by 1 course."
         other: "This exercise is used by %{count} courses."
       contact: Contact information
+      judge: Judge
       repository: Repository containing this exercise
       repository_path: Path within this repository
       created: Created

--- a/config/locales/views/exercises/en.yml
+++ b/config/locales/views/exercises/en.yml
@@ -75,7 +75,7 @@ en:
       memory_limit: Memory limit
       network_enabled: Network enabled
       network_disabled: Network disabled
-      submission_count: Submission count
+      submission_count: Submitted solutions
       submission_details: "This exercises has %{total} submissions by %{users} unique users. Of these submissions, %{correct} were correct."
       sample_solutions: Sample solutions
       sample_solutions_hint: Click on one of the tabs above to view a sample solution.

--- a/config/locales/views/exercises/nl.yml
+++ b/config/locales/views/exercises/nl.yml
@@ -75,7 +75,7 @@ nl:
       memory_limit: Geheugenlimitiet
       network_enabled: Netwerk ingeschakeld
       network_disabled: Netwerk uitgeschakeld
-      submission_count: Aantal oplossingen
+      submission_count: Ingediende oplossingen
       submission_details: "Deze oefening heeft %{total} inzendingen door %{users} unieke gebruikers, hiervan waren %{correct} inzendingen correct."
       sample_solutions: Voorbeeldoplossingen
       sample_solutions_hint: Klik op een tab hierboven om een voorbeeldoplossing te bekijken.

--- a/config/locales/views/exercises/nl.yml
+++ b/config/locales/views/exercises/nl.yml
@@ -20,7 +20,7 @@ nl:
       labels_delimiter: "Gebruik een komma om labels te scheiden"
       labels: Nieuw label
       info: Informatie
-      info_description: Ga naar de informative over deze oefening
+      info_description: Ga naar de informatiepagina van deze oefening
     index:
       title: Oefeningen
       exercise: Oefening
@@ -81,7 +81,7 @@ nl:
       submission_details: "Deze oefening heeft %{total} inzendingen door %{users} unieke gebruikers, hiervan waren %{correct} inzendingen correct."
       sample_solutions: Voorbeeldoplossingen
       sample_solutions_hint: Klik op een tab hierboven om een voorbeeldoplossing te bekijken.
-      sample_solution_submit: Voorbeeldoplossing indienen
+      sample_solution_submit: Deze oplossing indienen
       no_solutions: Deze oefening heeft nog geen voorbeeldoplossingen.
       no_solutions_admin: Voeg je voorbeeldoplossingen toe aan de repository om ze hier te laten verschijnen.
       usage: Gebruik

--- a/config/locales/views/exercises/nl.yml
+++ b/config/locales/views/exercises/nl.yml
@@ -88,6 +88,7 @@ nl:
         other: "Deze oefening wordt gebruikt door %{count} cursussen."
       not_used_in_courses: Deze oefening wordt nog niet gebruikt.
       contact: Contactinformatie
+      judge: Judge
       repository: Repository waar deze oefening zich in bevindt
       repository_path: Bestandslocatie binnen deze repository
       created: Aangemaakt

--- a/config/locales/views/exercises/nl.yml
+++ b/config/locales/views/exercises/nl.yml
@@ -98,5 +98,5 @@ nl:
       config_set_by: "Deze waarde werd ingesteld door %{file}"
       config_default: "Dit is de standaardwaarde."
       description_files:   "We hebben bestanden gevonden met een beschrijving voor deze talen in de beschrijvingsmap %{path}"
-      config_info: 'Voor meer informatie over het configureren van oefeningen kun je %{here} een kijkje nemen op onze documentatiesite.'
-      here: 'hier'
+      config_info: 'Neem een kijkje op de %{doc_site} voor meer informatie over het configureren van oefeningen.'
+      doc_site: 'documentatiesite'

--- a/config/locales/views/exercises/nl.yml
+++ b/config/locales/views/exercises/nl.yml
@@ -19,6 +19,8 @@ nl:
       open_on_github: Open op GitHub
       labels_delimiter: "Gebruik een komma om labels te scheiden"
       labels: Nieuw label
+      info: Informatie
+      info_description: Ga naar de informative over deze oefening
     index:
       title: Oefeningen
       exercise: Oefening

--- a/config/locales/views/exercises/nl.yml
+++ b/config/locales/views/exercises/nl.yml
@@ -79,6 +79,7 @@ nl:
       submission_details: "Deze oefening heeft %{total} inzendingen door %{users} unieke gebruikers, hiervan waren %{correct} inzendingen correct."
       sample_solutions: Voorbeeldoplossingen
       sample_solutions_hint: Klik op een tab hierboven om een voorbeeldoplossing te bekijken.
+      sample_solution_submit: Voorbeeldoplossing indienen
       no_solutions: Deze oefening heeft nog geen voorbeeldoplossingen.
       no_solutions_admin: Voeg je voorbeeldoplossingen toe aan de repository om ze hier te laten verschijnen.
       usage: Gebruik

--- a/test/controllers/exercises_controller_test.rb
+++ b/test/controllers/exercises_controller_test.rb
@@ -213,7 +213,7 @@ class ExercisesControllerTest < ActionDispatch::IntegrationTest
 
   test 'should get solution with show' do
     solutions = {}
-    solutions.expects(:[]).with(Pathname.new('test')).returns("content")
+    solutions.expects(:[]).with(Pathname.new('test')).returns('content')
     Exercise.any_instance.expects(:solutions).returns(solutions)
 
     get exercise_url(@instance),

--- a/test/controllers/exercises_controller_test.rb
+++ b/test/controllers/exercises_controller_test.rb
@@ -211,6 +211,32 @@ class ExercisesControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test 'should get solution with show' do
+    solutions = {}
+    solutions.expects(:[]).with(Pathname.new('test')).returns("content")
+    Exercise.any_instance.expects(:solutions).returns(solutions)
+
+    get exercise_url(@instance),
+        params: { from_solution: 'test' }
+    assert_response :success
+  end
+
+  test 'should not get solution as student' do
+    student = create :student
+    sign_out :user
+    sign_in student
+
+    get exercise_url(@instance, format: :json),
+        params: { from_solution: 'test' }
+    assert_response :forbidden
+  end
+
+  test 'should rescue illegal filename for solution' do
+    get exercise_url(@instance),
+        params: { from_solution: "(/\\:*?\"<>|\0" }
+    assert_response :success
+  end
+
   test 'should list all exercises within series' do
     exercises = create_list :exercise, 10, repository: @instance.repository
     exercises_in_series = exercises.take(5)

--- a/test/controllers/exercises_controller_test.rb
+++ b/test/controllers/exercises_controller_test.rb
@@ -213,7 +213,7 @@ class ExercisesControllerTest < ActionDispatch::IntegrationTest
 
   test 'should get solution with show' do
     solutions = {}
-    solutions.expects(:[]).with(Pathname.new('test')).returns('content')
+    solutions.expects(:[]).with('test').returns('content')
     Exercise.any_instance.expects(:solutions).returns(solutions)
 
     get exercise_url(@instance),
@@ -229,12 +229,6 @@ class ExercisesControllerTest < ActionDispatch::IntegrationTest
     get exercise_url(@instance, format: :json),
         params: { from_solution: 'test' }
     assert_response :forbidden
-  end
-
-  test 'should rescue illegal filename for solution' do
-    get exercise_url(@instance),
-        params: { from_solution: "(/\\:*?\"<>|\0" }
-    assert_response :success
   end
 
   test 'should list all exercises within series' do

--- a/test/controllers/exercises_controller_test.rb
+++ b/test/controllers/exercises_controller_test.rb
@@ -29,6 +29,8 @@ class ExercisesControllerTest < ActionDispatch::IntegrationTest
 
   test 'should show exercise info' do
     stub_all_exercises!
+    # Attach exercise to courses to test sorting
+    create_list(:course, 5).each { |s| s.series << create(:series, exercises: [@instance]) }
     get info_exercise_url(@instance)
     assert_response :success
   end

--- a/test/models/exercise_test.rb
+++ b/test/models/exercise_test.rb
@@ -502,8 +502,8 @@ class ExerciseRemoteTest < ActiveSupport::TestCase
 
   test 'should have solutions' do
     assert_equal @exercise.solutions,
-                 Pathname.new('solution.py') => "print(input())\n",
-                 Pathname.new('empty.py') => ''
+                 'solution.py' => "print(input())\n",
+                 'empty.py' => ''
   end
 
   test 'should update access in config file' do

--- a/test/testhelpers/stub_helper.rb
+++ b/test/testhelpers/stub_helper.rb
@@ -18,7 +18,7 @@ module StubHelper
     config = { 'evaluation' => { 'time_limit' => 1 } }.freeze
     config_locations = { 'evaluation' => { 'time_limit' => 'config.json' } }.freeze
     description = 'ᕕ(ಠ_ಠ)ᕗ'
-    solutions = { 'solution.py' => 'print(input())' }
+    solutions = { 'solution.en.py' => 'print(input())', 'solution.nl.py' => 'print(input())' }
     Exercise.any_instance.stubs(:solutions).returns(solutions)
     Exercise.any_instance.stubs(:config).returns(config)
     Exercise.any_instance.stubs(:config_locations).returns(config_locations)


### PR DESCRIPTION
This pull request fixes some minor (styling) issues with the exercise info page.

- [x] Fix labels being underlined on hover  
- [x] Better display of big numbers (e.g. submission count)
- [x] Better display of 'courses using this exercise' (the ISBN exercises are very crowded)
    - sort by academic year?
    - add some pagination
---
- [x] Move static information from exercise edit page to info page
- [ ] split "submission count" into multiple stats (correct, users, total, ...)
- [ ] possibly a pie chart with exercise statuses
---
- [x] remove dot at the end of the `Created` and `Last edited` fields
- [x] replace "submission count" by "submitted solutions" (or just solutions"); "Ingediende oplossingen" in Dutch; "Submitted solutions"/"Ingediende oplossingen" is also how this statistic is named on the course page
- [x] avoid using "here" as an anchor for linking to the documentation; sentence can be rephrased as "See [documentation](url) for information about configuring exercises."
- [x] link to create about information, creates about page at the wrong location in the GitHub repository; the markdown file is created in the parent directory, while it should at least create it in the exercise directory itself; why do we put the markdown file in the root of the exercise directory, and not in the `description` directory where we also put the descriptions and boilerplate?
- [x] in the "Usage" table, links to courses open in a new tab, but there seems no reason for it
- [x] I can't say why, but the icon for the info page in the navigation button does not seem to fit with the other icons surrounding it may it's because it's an open circle, where a filled circle with an inserted letter "i" may look better; or to be more consistent, we could use the same "stats" icon as used for courses
- [x] statistics tiles are not always properly aranged in a grid (may have something to do with the fact that "Programming language" is split into two lines"

![image](https://user-images.githubusercontent.com/5736113/75604770-abcf0e80-5adc-11ea-9887-55d8d0413334.png)
---
- [x] option to allow submitting the selected sample solution directly from the exercise info page
- [ ] option to copy the selected sample solution to the clipboard
---
- [x] Fix spacing between solutions title and tabs




Closes #1732.
