### PR TITLE
more explicit active toggle button

### DIFF
--- a/app/assets/stylesheets/theme/theme-light.css.less
+++ b/app/assets/stylesheets/theme/theme-light.css.less
@@ -105,7 +105,7 @@
 @btn-active-background: @grey-100;
 @toggle-btn-border: @grey-300;
 @toggle-btn-active-border: @grey-400;
-@toggle-btn-active-bg: @grey-200;
+@toggle-btn-active-bg: @grey-300;
 @toggle-btn-bg: default;
 
 @danger-fg: @danger-800;


### PR DESCRIPTION
This pull request makes the active button in a set of toggle buttons more explicit.

![image](https://user-images.githubusercontent.com/481872/76703800-a1179a80-66d4-11ea-8ad5-eef5ae0594ee.png)
