### PR TITLE
Clean up index action of annotations controller

### DIFF
--- a/app/controllers/annotations_controller.rb
+++ b/app/controllers/annotations_controller.rb
@@ -1,10 +1,13 @@
 class AnnotationsController < ApplicationController
-  before_action :set_submission, only: %i[create index]
+  before_action :set_submission, only: %i[create]
   before_action :set_annotation, only: %i[show update destroy]
+
+  has_scope :by_submission, as: :submission_id
+  has_scope :by_user, as: :user_id
 
   def index
     authorize Annotation
-    @annotations = policy_scope(@submission.annotations)
+    @annotations = apply_scopes(policy_scope(Annotation.all))
   end
 
   def show; end

--- a/app/models/annotation.rb
+++ b/app/models/annotation.rb
@@ -11,6 +11,9 @@ class Annotation < ApplicationRecord
     greater_than_or_equal_to: 0
   }, if: ->(attr) { attr.line_nr.present? }
 
+  scope :by_submission, ->(submission_id) { where(submission_id: submission_id) }
+  scope :by_user, ->(user_id) { where(user_id: user_id) }
+
   after_create :create_notification
 
   private

--- a/app/policies/annotation_policy.rb
+++ b/app/policies/annotation_policy.rb
@@ -21,7 +21,7 @@ class AnnotationPolicy < ApplicationPolicy
   end
 
   def show?
-    policy(record.submission).show?
+    SubmissionPolicy.new(user, record.submission).show?
   end
 
   def update?

--- a/app/views/annotations/_annotation.json.jbuilder
+++ b/app/views/annotations/_annotation.json.jbuilder
@@ -1,5 +1,6 @@
-json.extract! annotation, :id, :line_nr, :annotation_text, :created_at, :updated_at
+json.extract! annotation, :id, :line_nr, :annotation_text, :user_id, :submission_id, :created_at, :updated_at
 json.rendered_markdown markdown(annotation.annotation_text)
+json.submission_url submission_url(annotation.submission, format: :json)
 json.url annotation_url(annotation, format: :json)
 json.user do
   json.name annotation.user.full_name

--- a/test/controllers/annotations_controller_test.rb
+++ b/test/controllers/annotations_controller_test.rb
@@ -19,7 +19,7 @@ class AnnotationControllerTest < ActionDispatch::IntegrationTest
     assert_response :created
   end
 
-  test 'submission index should contain all annotations user can see' do
+  test 'annotation index should contain all annotations user can see' do
     user = create :user
     other_user = create :user
     course = create :course
@@ -42,6 +42,23 @@ class AnnotationControllerTest < ActionDispatch::IntegrationTest
     sign_in user
     get annotations_url(format: :json)
     assert_equal 3, JSON.parse(response.body).count
+  end
+
+  test 'annotation index should be filterable by user' do
+    user = create :user
+    other_user = create :user
+
+    create :annotation, user: user, submission: (create :submission, user: user)
+    create :annotation, user: user, submission: (create :submission, user: user)
+    create :annotation, user: user, submission: (create :submission, user: user)
+    create :annotation, user: other_user, submission: (create :submission, user: other_user)
+    create :annotation, user: other_user, submission: (create :submission, user: other_user)
+
+    get annotations_url(format: :json, user_id: user.id)
+    assert_equal 3, JSON.parse(response.body).count
+
+    get annotations_url(format: :json, user_id: other_user.id)
+    assert_equal 2, JSON.parse(response.body).count
   end
 
   test 'user who created submission should be able to see the annotation' do

--- a/test/controllers/annotations_controller_test.rb
+++ b/test/controllers/annotations_controller_test.rb
@@ -19,10 +19,51 @@ class AnnotationControllerTest < ActionDispatch::IntegrationTest
     assert_response :created
   end
 
-  test 'can update annotation, but only the content' do
-    @annotation = create :annotation, submission: @submission, user: @zeus
+  test 'submission index should contain all annotations user can see' do
+    user = create :user
+    other_user = create :user
+    course = create :course
+    course_admin = create :user
+    course_admin.update(administrating_courses: [course])
 
-    put annotation_url(@annotation), params: {
+    create :annotation, user: user, submission: (create :submission, user: user, course: course)
+    create :annotation, user: user, submission: (create :submission, user: user, course: course)
+    create :annotation, user: user, submission: (create :submission, user: user)
+    create :annotation, user: other_user, submission: (create :submission, user: other_user, course: course)
+    create :annotation, user: other_user, submission: (create :submission, user: other_user)
+
+    get annotations_url(format: :json)
+    assert_equal 5, JSON.parse(response.body).count
+
+    sign_in course_admin
+    get annotations_url(format: :json)
+    assert_equal 3, JSON.parse(response.body).count
+
+    sign_in user
+    get annotations_url(format: :json)
+    assert_equal 3, JSON.parse(response.body).count
+  end
+
+  test 'user who created submission should be able to see the annotation' do
+    annotation = create :annotation, submission: @submission, user: @zeus
+    sign_in @submission.user
+
+    get annotation_url(annotation, format: :json)
+    assert_response :success
+  end
+
+  test 'unrelated user should not be able to see the annotation' do
+    annotation = create :annotation, submission: @submission, user: @zeus
+    sign_in create(:user)
+
+    get annotation_url(annotation, format: :json)
+    assert_response :forbidden
+  end
+
+  test 'can update annotation, but only the content' do
+    annotation = create :annotation, submission: @submission, user: @zeus
+
+    put annotation_url(annotation), params: {
       annotation: {
         annotation_text: 'We changed this text'
       },
@@ -30,7 +71,7 @@ class AnnotationControllerTest < ActionDispatch::IntegrationTest
     }
     assert_response :success
 
-    patch annotation_url(@annotation), params: {
+    patch annotation_url(annotation), params: {
       annotation: {
         annotation_text: 'We changed this text again'
       },
@@ -40,8 +81,8 @@ class AnnotationControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'can remove annotation' do
-    @annotation = create :annotation, submission: @submission, user: @zeus
-    delete annotation_url(@annotation)
+    annotation = create :annotation, submission: @submission, user: @zeus
+    delete annotation_url(annotation)
     assert_response :no_content
   end
 
@@ -49,7 +90,7 @@ class AnnotationControllerTest < ActionDispatch::IntegrationTest
     post submission_annotations_url(@submission), params: {
       annotation: {
         line_nr: 1,
-        annotation_text: Faker::Lorem.sentences(number: 4_500).join(' ')
+        annotation_text: Faker::Lorem.sentences(number: 100).join(' ')
       },
       format: :json
     }
@@ -57,12 +98,11 @@ class AnnotationControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'can not update valid annotation with invalid annotation' do
-    @annotation = create :annotation, submission: @submission, user: @zeus
+    annotation = create :annotation, submission: @submission, user: @zeus
 
-    put annotation_url(@annotation), params: {
+    put annotation_url(annotation), params: {
       annotation: {
-        # Titanic script is around 4500 sentences worth of text, so why not test that users can not submit such long content
-        annotation_text: Faker::Lorem.sentences(number: 4_500).join(' ')
+        annotation_text: Faker::Lorem.sentences(number: 100).join(' ')
       },
       format: :json
     }

--- a/test/factories/annotations.rb
+++ b/test/factories/annotations.rb
@@ -2,5 +2,7 @@ FactoryBot.define do
   factory :annotation do
     line_nr { 1 }
     annotation_text { 'This code does not contain the right parameters' }
+    submission
+    user
   end
 end

--- a/test/models/annotation_test.rb
+++ b/test/models/annotation_test.rb
@@ -29,7 +29,7 @@ class AnnotationTest < ActiveSupport::TestCase
   test 'can not create annotation with an enormous message' do
     annotating_user = create :user
     annotation = create :annotation, submission: @submission, user: annotating_user
-    annotation.annotation_text = Faker::Lorem.paragraph sentence_count: 2048
+    annotation.annotation_text = Faker::Lorem.paragraph sentence_count: 100
     assert_not annotation.valid?
   end
 


### PR DESCRIPTION
Also allow filtering by user.

This pull request allows users to request all annotations they have access to (we got some requests for this). Also allows them to list all the annotations they (or someone else) made by adding a user filter. Note that this still doesn't include an HTML index view, but that seems less pressing.

Also fixes the second item of https://github.com/dodona-edu/dodona/issues/1767#issuecomment-602255087.