### PR TITLE
Add time and memory limit status to partial format

### DIFF
--- a/public/schemas/partial_output.json
+++ b/public/schemas/partial_output.json
@@ -197,6 +197,8 @@
       "enum": [
         "internal error",
         "compilation error",
+        "memory limit exceeded",
+        "time limit exceeded",
         "runtime error",
         "wrong", "wrong answer",
         "correct", "correct answer"

--- a/test/runners/result_constructor_test.rb
+++ b/test/runners/result_constructor_test.rb
@@ -269,6 +269,18 @@ class ResultConstructorTest < ActiveSupport::TestCase
       '{ "command": "close-judgement", "status": { "enum": "runtime error", "human": "Runtime" } }'
     ])
     assert_equal('runtime error', result[:status])
+    result = construct_result([
+      '{ "command": "start-judgement" }',
+      '{ "command": "escalate-status", "status": { "enum": "wrong", "human": "Wrong" } }',
+      '{ "command": "close-judgement", "status": { "enum": "memory limit exceeded", "human": "Runtime" } }'
+    ])
+    assert_equal('memory limit exceeded', result[:status])
+    result = construct_result([
+      '{ "command": "start-judgement" }',
+      '{ "command": "escalate-status", "status": { "enum": "wrong", "human": "Wrong" } }',
+      '{ "command": "close-judgement", "status": { "enum": "time limit exceeded", "human": "Runtime" } }'
+    ])
+    assert_equal('time limit exceeded', result[:status])
   end
 
   test 'correct permissions should be present in result' do


### PR DESCRIPTION
This pull request adds the status `memory limit exceeded` and `time limit exceeded` to the partial output format.

- [x] Tests were added
- [x] Documentation updates: not needed, documentation already says this is possible (see https://dodona-edu.github.io/en/guides/creating-a-judge/)