### PR TITLE
Disable CSRF protection for API requests

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,8 @@ class ApplicationController < ActionController::Base
 
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
 
+  protect_from_forgery with: :null_session
+
   before_action :store_current_location,
                 except: %i[media sign_in_page institution_not_supported],
                 unless: -> { devise_controller? || remote_request? }

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -1,8 +1,6 @@
 class CoursesController < ApplicationController
   before_action :set_course_and_current_membership, except: %i[index new create]
 
-  skip_forgery_protection only: [:subscribe]
-
   has_scope :by_filter, as: 'filter'
   has_scope :by_institution, as: 'institution_id'
   has_scope :at_least_one_started, type: :boolean, only: :scoresheet do |controller, scope|

--- a/app/controllers/exercises_controller.rb
+++ b/app/controllers/exercises_controller.rb
@@ -4,7 +4,6 @@ class ExercisesController < ApplicationController
   before_action :set_series, only: %i[show edit update info]
   before_action :ensure_trailing_slash, only: :show
   before_action :allow_iframe, only: %i[description]
-  skip_before_action :verify_authenticity_token, only: [:media]
   skip_before_action :redirect_to_default_host, only: %i[description media]
 
   has_scope :by_filter, as: 'filter'

--- a/app/controllers/judges_controller.rb
+++ b/app/controllers/judges_controller.rb
@@ -1,6 +1,5 @@
 class JudgesController < ApplicationController
   before_action :set_judge, only: %i[show edit update destroy hook]
-  skip_before_action :verify_authenticity_token, only: [:hook]
 
   # GET /judges
   # GET /judges.json

--- a/app/controllers/repositories_controller.rb
+++ b/app/controllers/repositories_controller.rb
@@ -2,7 +2,6 @@ require 'set'
 
 class RepositoriesController < ApplicationController
   before_action :set_repository, only: %i[show edit update destroy hook reprocess admins add_admin remove_admin courses add_course remove_course]
-  skip_before_action :verify_authenticity_token, only: [:hook]
 
   # GET /repositories
   # GET /repositories.json

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -3,8 +3,6 @@ class SubmissionsController < ApplicationController
   before_action :set_submissions, only: %i[index mass_rejudge]
   before_action :ensure_trailing_slash, only: :show
 
-  skip_before_action :verify_authenticity_token, only: [:create]
-
   has_scope :by_filter, as: 'filter' do |controller, scope, value|
     scope.by_filter(value, controller.params[:user_id].present?, controller.params[:exercise_id].present?)
   end

--- a/test/controllers/annotations_controller_test.rb
+++ b/test/controllers/annotations_controller_test.rb
@@ -107,7 +107,7 @@ class AnnotationControllerTest < ActionDispatch::IntegrationTest
     post submission_annotations_url(@submission), params: {
       annotation: {
         line_nr: 1,
-        annotation_text: Faker::Lorem.sentences(number: 100).join(' ')
+        annotation_text: 'A' * 2049 # max length of annotation text is 2048 -> trigger failure
       },
       format: :json
     }

--- a/test/controllers/series_controller_test.rb
+++ b/test/controllers/series_controller_test.rb
@@ -141,6 +141,50 @@ class SeriesControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_equal ids, @instance.series_memberships.map(&:exercise_id)
   end
+
+  test 'update should work using api' do
+    # https://github.com/dodona-edu/dodona/issues/1765
+    sign_out :user
+
+    user = create :staff
+    token = create :api_token, user: user
+    @instance.course.administrating_members << user
+
+    updated_description = 'The new description value.'
+
+    original_csrf_protection = ActionController::Base.allow_forgery_protection
+    begin
+      ActionController::Base.allow_forgery_protection = true
+      patch series_url(@instance, format: :json, series: { description: updated_description }),
+            params: { format: :json },
+            headers: { 'Authorization' => token.token }
+      assert_response :success
+      assert_equal updated_description, @instance.reload.description
+    ensure
+      ActionController::Base.allow_forgery_protection = original_csrf_protection
+    end
+  end
+
+  test 'update should not work over api without token' do
+    # https://github.com/dodona-edu/dodona/issues/1765
+    sign_out :user
+
+    user = create :staff
+    @instance.course.administrating_members << user
+
+    updated_description = 'The new description value.'
+
+    original_csrf_protection = ActionController::Base.allow_forgery_protection
+    begin
+      ActionController::Base.allow_forgery_protection = true
+      patch series_url(@instance, format: :json, series: { description: updated_description }),
+            params: { format: :json }
+      assert_response :unauthorized
+      assert_not_equal updated_description, @instance.reload.description
+    ensure
+      ActionController::Base.allow_forgery_protection = original_csrf_protection
+    end
+  end
 end
 
 class SeriesVisibilityTest < ActionDispatch::IntegrationTest


### PR DESCRIPTION
This pull request disables CSRF protection for API requests, as discussed in #1765. My latest reply in that issue contains the reason as to why the current implementation is used.

- [x] Tests were added.

Closes #1765.
