### PR TITLE
Remove spurious top margin in exercise descriptions

### DIFF
--- a/app/assets/stylesheets/models/exercises.css.less
+++ b/app/assets/stylesheets/models/exercises.css.less
@@ -23,10 +23,6 @@
 }
 
 // exercise
-.exercise-description .card-supporting-text {
-  margin-top: 15px;
-}
-
 .exercise-description img {
   cursor: pointer;
 }


### PR DESCRIPTION
This pull request removes the extra top margin, as illustrated in the screenshots below:

**Old:**
![Schermafdruk van 2020-04-06 09 29 24](https://user-images.githubusercontent.com/6131398/78533359-1fa1bc80-77e9-11ea-94b0-239150b7d5ea.png)

**New:**
![Schermafdruk van 2020-04-06 09 28 34](https://user-images.githubusercontent.com/6131398/78533294-06990b80-77e9-11ea-8a99-be7e1e6e29a9.png)

- ~[ ] Tests were added~ (not applicable)

Closes #1811.
