### PR TITLE
Fix broken staff/zeus icon on inline submissions

### DIFF
--- a/app/assets/stylesheets/bootstrap_overrides.css.less
+++ b/app/assets/stylesheets/bootstrap_overrides.css.less
@@ -141,11 +141,6 @@ mark,
   background-color: @mark-bg;
 }
 
-// fix position errors
-.tab-content {
-  position: relative;
-}
-
 .lead {
   font-size: 18px;
   margin-top: 5px;


### PR DESCRIPTION
This pull request resolves an issue regarding the broken staff and zeus icons. Ironically the fix was to remove a "fix of position errors". Fix was found by @niknetniko 

The original css lines turn out to be remnants from unipept.

**Before:**
![Schermafdruk van 2020-04-06 09 46 58](https://user-images.githubusercontent.com/6131398/78536616-71007a80-77ee-11ea-9294-b935273e3967.png)

**After:**
![Schermafdruk van 2020-04-06 10 06 45](https://user-images.githubusercontent.com/6131398/78536630-75c52e80-77ee-11ea-8b0a-766808f26eb2.png)

Closes #1756.
