### PR TITLE
Add link to make series publicly visible. Fixes #1705.

### DIFF
--- a/app/views/series/_series.html.erb
+++ b/app/views/series/_series.html.erb
@@ -117,7 +117,10 @@
     </div>
   <% end %>
   <% if current_user&.course_admin?(series.course) && !series.exercises_visible %>
-    <div class="alert alert-info hidden-print"><%= t "series.show.exercises_not_visible" %></div>
+    <div class="alert alert-info hidden-print">
+      <%= t "series.show.exercises_not_visible" %>
+      <%= link_to(t('series.show.make_visible.link'), series_path(series, series: {exercises_visible: true}), method: :patch) + " " +  t('series.show.make_visible.for_students') %>
+    </div>
   <% end %>
   <div class="series-description">
     <%= markdown(series.description) %>

--- a/app/views/series/_series.html.erb
+++ b/app/views/series/_series.html.erb
@@ -105,10 +105,16 @@
     </div>
   </div>
   <% if current_user&.course_admin?(series.course) && series.hidden? %>
-    <div class="alert alert-info hidden-print"><%= t "series.show.series_not_visible" %></div>
+    <div class="alert alert-info hidden-print">
+      <%= t "series.show.series_not_visible" %>
+      <%= link_to(t('series.show.make_visible.link'), series_path(series, series: {visibility: :open}), method: :patch) + " " +  t('series.show.make_visible.for_students') %>
+    </div>
   <% end %>
   <% if current_user&.course_admin?(series.course) && series.closed? %>
-    <div class="alert alert-info hidden-print"><%= t "series.show.series_not_accessible" %></div>
+    <div class="alert alert-info hidden-print">
+      <%= t "series.show.series_not_accessible" %>
+      <%= link_to(t('series.show.make_visible.link'), series_path(series, series: {visibility: :open}), method: :patch) + " " +  t('series.show.make_visible.for_students') %>
+    </div>
   <% end %>
   <% if current_user&.course_admin?(series.course) && !series.exercises_visible %>
     <div class="alert alert-info hidden-print"><%= t "series.show.exercises_not_visible" %></div>

--- a/app/views/series/_series.html.erb
+++ b/app/views/series/_series.html.erb
@@ -107,19 +107,19 @@
   <% if current_user&.course_admin?(series.course) && series.hidden? %>
     <div class="alert alert-info hidden-print">
       <%= t "series.show.series_not_visible" %>
-      <%= link_to(t('series.show.make_visible.link'), series_path(series, series: {visibility: :open}), method: :patch) + " " +  t('series.show.make_visible.for_students') %>
+      <%= t('series.show.make_visible_html', series_url: series_path(series, series: {visibility: :open}), method: :patch) %>
     </div>
   <% end %>
   <% if current_user&.course_admin?(series.course) && series.closed? %>
     <div class="alert alert-info hidden-print">
       <%= t "series.show.series_not_accessible" %>
-      <%= link_to(t('series.show.make_visible.link'), series_path(series, series: {visibility: :open}), method: :patch) + " " +  t('series.show.make_visible.for_students') %>
+      <%= t('series.show.make_visible_html', series_url: series_path(series, series: {visibility: :open}), method: :patch) %>
     </div>
   <% end %>
   <% if current_user&.course_admin?(series.course) && !series.exercises_visible %>
     <div class="alert alert-info hidden-print">
       <%= t "series.show.exercises_not_visible" %>
-      <%= link_to(t('series.show.make_visible.link'), series_path(series, series: {exercises_visible: true}), method: :patch) + " " +  t('series.show.make_visible.for_students') %>
+      <%= t('series.show.make_visible_html', series_url: series_path(series, series: {visibility: :open}), method: :patch) %>
     </div>
   <% end %>
   <div class="series-description">

--- a/config/locales/views/series/en.yml
+++ b/config/locales/views/series/en.yml
@@ -24,6 +24,9 @@ en:
       exercises: Exercises
       download_submissions: Export my submissions
       download_all_solutions: Export student submissions
+      make_visible:
+        link: Make visible
+        for_students: for students.
       series_not_visible: This series is only visible for students using the secret link!
       series_not_accessible: This series is not accessible to students!
       exercises_not_visible: The exercises in this series are not visible to students!

--- a/config/locales/views/series/en.yml
+++ b/config/locales/views/series/en.yml
@@ -24,9 +24,7 @@ en:
       exercises: Exercises
       download_submissions: Export my submissions
       download_all_solutions: Export student submissions
-      make_visible:
-        link: Make visible
-        for_students: for students.
+      make_visible_html: "<a href=%{series_url} data-method=\"patch\">Make visible</a> for students."
       series_not_visible: This series is only visible for students using the secret link!
       series_not_accessible: This series is not accessible to students!
       exercises_not_visible: The exercises in this series are not visible to students!

--- a/config/locales/views/series/nl.yml
+++ b/config/locales/views/series/nl.yml
@@ -24,9 +24,7 @@ nl:
       exercises: Oefeningen
       download_submissions: Mijn oplossingen exporteren
       download_all_solutions: Oplossingen van studenten exporteren
-      make_visible:
-        link: Maak zichtbaar
-        for_students: voor studenten.
+      make_visible_html: "<a href=%{series_url} data-method=\"patch\">Maak zichtbaar</a> voor studenten."
       series_not_visible: Deze reeks is enkel zichtbaar voor studenten via de geheime link!
       series_not_accessible: Deze reeks is niet toegankelijk voor studenten!
       exercises_not_visible: De oefeningen in deze reeks zijn niet zichtbaar voor studenten!

--- a/config/locales/views/series/nl.yml
+++ b/config/locales/views/series/nl.yml
@@ -24,6 +24,9 @@ nl:
       exercises: Oefeningen
       download_submissions: Mijn oplossingen exporteren
       download_all_solutions: Oplossingen van studenten exporteren
+      make_visible:
+        link: Maak zichtbaar
+        for_students: voor studenten.
       series_not_visible: Deze reeks is enkel zichtbaar voor studenten via de geheime link!
       series_not_accessible: Deze reeks is niet toegankelijk voor studenten!
       exercises_not_visible: De oefeningen in deze reeks zijn niet zichtbaar voor studenten!
@@ -84,4 +87,3 @@ nl:
         other: "%{count} oefeningen"
       name: "Naam"
       deadline: "Deadline"
-  


### PR DESCRIPTION
This pull request adds a link to the information message that allows the user to make the series visible to students. Layout-wise this is identical to the impersonation-feature.

![Schermafdruk van 2020-04-06 10 58 52](https://user-images.githubusercontent.com/6131398/78541374-d146ea80-77f5-11ea-8de2-7d02d7f3e1b4.png)


Closes #1705.
