### PR TITLE
Fix focus issue with lightbox in exercise descriptions

### DIFF
--- a/app/assets/javascripts/exercise.js
+++ b/app/assets/javascripts/exercise.js
@@ -57,6 +57,9 @@ function initLabelsEdit(labels, undeletableLabels) {
 
 function showLightbox(content) {
     Strip.show(content.images, { side: "top" }, content.index);
+    // Transfer focus back to the document body to allow the lightbox to be closed.
+    // https://github.com/dodona-edu/dodona/issues/1759.
+    document.body.focus();
 }
 
 function onFrameMessage(event) {

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -89,7 +89,7 @@
   <%= csrf_meta_tags %>
   <%= csp_meta_tag %>
 </head>
-<body>
+<body tabindex="-1">
 <div id="page-wrapper">
   <%= yield :modal %>
   <%= render 'layouts/navbar' %>


### PR DESCRIPTION
This pull request fix an issue with focus after a lightbox is opened in an exercise description. I have added a `tabindex` attribute to the document body, to allow the parent document to be focused. This could be transferred to another attribute specific to the exercise-show page as well, but having a focusable body might prevent future headaches.

**Consequences:**
- Lightboxes can now be closed with the `ESC` key without explicitly having to click them.
- Users can use arrow keys to cycle between images in the lightbox.

Closes #1759  .
