### PR TITLE
Add submission status to series CSV export

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -175,12 +175,14 @@ class CoursesController < ApplicationController
         sheet = CSV.generate do |csv|
           csv << [I18n.t('courses.scoresheet.explanation')]
           columns = [User.human_attribute_name('first_name'), User.human_attribute_name('last_name'), User.human_attribute_name('username'), User.human_attribute_name('email')]
-          columns.concat(@series.flat_map { |s| [s.name, I18n.t('courses.scoresheet.started', series: s.name)] })
+          columns.concat(@series.map(&:name))
+          columns.concat(@series.map { |s| I18n.t('courses.scoresheet.started', series: s.name) })
           csv << columns
-          csv << ['Maximum', '', '', ''].concat(@series.flat_map { |s| [s.exercises.count] * 2 })
+          csv << ['Maximum', '', '', ''].concat(@series.map { |s| s.exercises.count }).concat(@series.map { |s| s.exercises.count })
           @users.each do |u|
             row = [u.first_name, u.last_name, u.username, u.email]
-            row.concat(@series.flat_map { |s| [@hash[[u.id, s.id]][:accepted], @hash[[u.id, s.id]][:started]] })
+            row.concat(@series.map { |s| @hash[[u.id, s.id]][:accepted] })
+            row.concat(@series.map { |s| @hash[[u.id, s.id]][:started] })
             csv << row
           end
         end

--- a/app/controllers/series_controller.rb
+++ b/app/controllers/series_controller.rb
@@ -192,13 +192,18 @@ class SeriesController < ApplicationController
       format.csv do
         sheet = CSV.generate do |csv|
           csv << [I18n.t('series.scoresheet.explanation')]
-          csv << [User.human_attribute_name('first_name'), User.human_attribute_name('last_name'), User.human_attribute_name('username'), User.human_attribute_name('email'), @series.name].concat(@exercises.map(&:name))
-          csv << ['Maximum', '', '', '', @exercises.count].concat(@exercises.map { 1 })
+          columns = [User.human_attribute_name('first_name'), User.human_attribute_name('last_name'), User.human_attribute_name('username'), User.human_attribute_name('email'), @series.name]
+          columns.concat(@exercises.map(&:name))
+          columns.concat(@exercises.map { |e| I18n.t('series.scoresheet.status', exercise: e.name) })
+          csv << columns
+          csv << ['Maximum', '', '', '', @exercises.count].concat(@exercises.map { 1 }).concat(@exercises.map { '' })
           @users.each do |u|
             row = [u.first_name, u.last_name, u.username, u.email]
             succeeded_exercises = @exercises.map { |e| @submissions[[u.id, e.id]]&.accepted ? 1 : 0 }
+            exercise_status = @exercises.map { |e| @submissions[[u.id, e.id]]&.status || 'unstarted' }
             row << succeeded_exercises.sum
             row.concat(succeeded_exercises)
+            row.concat(exercise_status)
             csv << row
           end
         end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -209,8 +209,8 @@ class Course < ApplicationRecord
     hash = sorted_series.map { |s| [s, s.scoresheet] }.product(sorted_users).map do |series_info, user|
       scores = series_info[1]
       data = {
-        :accepted => series_info[0].exercises.count { |e| scores[:submissions][[user.id, e.id]]&.accepted },
-        :started => series_info[0].exercises.count { |e| !scores[:submissions][[user.id, e.id]].nil? }
+        accepted: series_info[0].exercises.count { |e| scores[:submissions][[user.id, e.id]]&.accepted },
+        started: series_info[0].exercises.count { |e| !scores[:submissions][[user.id, e.id]].nil? }
       }
       [[user.id, series_info[0].id], data]
     end.to_h

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -208,7 +208,11 @@ class Course < ApplicationRecord
 
     hash = sorted_series.map { |s| [s, s.scoresheet] }.product(sorted_users).map do |series_info, user|
       scores = series_info[1]
-      [[user.id, series_info[0].id], series_info[0].exercises.count { |e| scores[:submissions][[user.id, e.id]]&.accepted }]
+      data = {
+        :accepted => series_info[0].exercises.count { |e| scores[:submissions][[user.id, e.id]]&.accepted },
+        :started => series_info[0].exercises.count { |e| !scores[:submissions][[user.id, e.id]].nil? }
+      }
+      [[user.id, series_info[0].id], data]
     end.to_h
 
     {

--- a/app/views/courses/_scoresheet_table.html.erb
+++ b/app/views/courses/_scoresheet_table.html.erb
@@ -13,7 +13,7 @@
       <tr>
         <td class="user-name ellipsis-overflow"><%= link_to student.full_name, course_member_path(course, student), title: student.full_name, class: "ellipsis-overflow" %></td>
         <% series.each do |s| %>
-          <td class="status" title="<%= "#{s.name} - #{student.full_name} - #{hash[[student.id, s.id]]}/#{s.exercises.count}" %>"><%= hash[[student.id, s.id]] %></td>
+          <td class="status" title="<%= "#{s.name} - #{student.full_name} - #{hash[[student.id, s.id]][:accepted]}/#{s.exercises.count}" %>"><%= hash[[student.id, s.id]][:accepted] %></td>
         <% end %>
       </tr>
     <% end %>

--- a/app/views/courses/scoresheet.json.jbuilder
+++ b/app/views/courses/scoresheet.json.jbuilder
@@ -4,7 +4,8 @@ json.array! @users do |user|
     json.array! @series do |series|
       json.extract! series, :id, :name
       json.total_exercises series.exercises.count
-      json.correct_exercises @hash[[user.id, series.id]]
+      json.correct_exercises @hash[[user.id, series.id]][:accepted]
+      json.started_exercises @hash[[user.id, series.id]][:started]
     end
   end
 end

--- a/config/locales/views/courses/en.yml
+++ b/config/locales/views/courses/en.yml
@@ -110,6 +110,7 @@ en:
       scoresheet: Scoresheet
       course_view: Course scoresheet
       select_view: Select view
+      started: "Started in %{series}"
     not_a_member_card:
       not_a_member: You are not a member of this course. Do you wish to register?
       not_a_member_moderated: Your registration needs to be approved by a course administrator before you gain access to this course.

--- a/config/locales/views/courses/nl.yml
+++ b/config/locales/views/courses/nl.yml
@@ -67,6 +67,7 @@ nl:
       download: Statusoverzicht downloaden
       course_view: Statusoverzicht van cursus
       select_view: Weergave selecteren
+      started: "Begonnen in %{series}"
     edit:
       confidential: Geheime link
       series_in_course: "Reeksen in deze cursus"

--- a/config/locales/views/series/en.yml
+++ b/config/locales/views/series/en.yml
@@ -61,6 +61,7 @@ en:
       download: Download scoresheet
       course_view: Course scoresheet
       select_view: Select view
+      status: "Status %{exercise}"
     series_status:
       completed_after_deadline_missed: You solved all exercises, but unfortunately not before the deadline.
       wrong_after_deadline_missed: You missed the deadline, and there are still some incorrect exercises.

--- a/config/locales/views/series/nl.yml
+++ b/config/locales/views/series/nl.yml
@@ -61,6 +61,7 @@ nl:
       download: Statusoverzicht downloaden
       course_view: Statusoverzicht van cursus
       select_view: Weergave selecteren
+      status: "Status %{exercise}"
     overview:
       progress: '%{solved} van de %{count} opgelost'
     series_status:

--- a/test/models/course_test.rb
+++ b/test/models/course_test.rb
@@ -83,46 +83,46 @@ class CourseTest < ActiveSupport::TestCase
           case i
           when 0 # Wrong submission before deadline
             create :wrong_submission,
-              exercise: exercise,
-              user: u,
-              created_at: (deadline - 2.minutes),
-              course: course
+                   exercise: exercise,
+                   user: u,
+                   created_at: (deadline - 2.minutes),
+                   course: course
             expected_started[[u.id, series.id]] += 1
           when 1 # Wrong, then correct submission before deadline
             create :correct_submission,
-              exercise: exercise,
-              user: u,
-              created_at: (deadline - 2.minutes),
-              course: course
+                   exercise: exercise,
+                   user: u,
+                   created_at: (deadline - 2.minutes),
+                   course: course
             create :correct_submission,
-              exercise: exercise,
-              user: u,
-              created_at: (deadline - 1.minutes),
-              course: course
+                   exercise: exercise,
+                   user: u,
+                   created_at: (deadline - 1.minute),
+                   course: course
             expected_started[[u.id, series.id]] += 1
             expected_accepted[[u.id, series.id]] += 1
           when 2 # Wrong submission after deadline
             create :wrong_submission,
-              exercise: exercise,
-              user: u,
-              created_at: (deadline + 2.minutes),
-              course: course
+                   exercise: exercise,
+                   user: u,
+                   created_at: (deadline + 2.minutes),
+                   course: course
           when 3 # Correct submission after deadline
             create :correct_submission,
-              exercise: exercise,
-              user: u,
-              created_at: (deadline + 2.minutes),
-              course: course
+                   exercise: exercise,
+                   user: u,
+                   created_at: (deadline + 2.minutes),
+                   course: course
           when 4 # Correct submission before deadline not in course
             create :correct_submission,
-              exercise: exercise,
-              user: u,
-              created_at: (deadline - 2.minutes)
+                   exercise: exercise,
+                   user: u,
+                   created_at: (deadline - 2.minutes)
           when 5 # Correct submission after deadline not in course
             create :correct_submission,
-              exercise: exercise,
-              user: u,
-              created_at: (deadline + 2.minutes)
+                   exercise: exercise,
+                   user: u,
+                   created_at: (deadline + 2.minutes)
           end
         end
       end

--- a/test/models/series_test.rb
+++ b/test/models/series_test.rb
@@ -117,7 +117,7 @@ class SeriesTest < ActiveSupport::TestCase
     create_list :series, 4, course: course, exercise_count: 5, deadline: Time.current
     users = create_list(:user, 6, courses: [course])
 
-    expected_submissions = Hash.new
+    expected_submissions = {}
 
     course.series.each do |series|
       deadline = series.deadline
@@ -128,10 +128,10 @@ class SeriesTest < ActiveSupport::TestCase
           case i
           when 0 # Wrong submission before deadline
             s = create :wrong_submission,
-                   exercise: exercise,
-                   user: u,
-                   created_at: (deadline - 2.minutes),
-                   course: course
+                       exercise: exercise,
+                       user: u,
+                       created_at: (deadline - 2.minutes),
+                       course: course
             expected_submissions[series.id] << s.id
           when 1 # Wrong, then correct submission before deadline
             create :correct_submission,
@@ -140,10 +140,10 @@ class SeriesTest < ActiveSupport::TestCase
                    created_at: (deadline - 2.minutes),
                    course: course
             s = create :correct_submission,
-                   exercise: exercise,
-                   user: u,
-                   created_at: (deadline - 1.minutes),
-                   course: course
+                       exercise: exercise,
+                       user: u,
+                       created_at: (deadline - 1.minute),
+                       course: course
             expected_submissions[series.id] << s.id
           when 2 # Wrong submission after deadline
             create :wrong_submission,
@@ -179,7 +179,7 @@ class SeriesTest < ActiveSupport::TestCase
       # Only latest submissions in the course and after the deadline are counted.
       assert_equal 2 * series.exercises.count, scoresheet[:submissions].count
       # Submissions are for the correct user.
-      assert_equal users[0,2].map(&:id).to_set, scoresheet[:submissions].keys.map(&:first).to_set
+      assert_equal users[0, 2].map(&:id).to_set, scoresheet[:submissions].keys.map(&:first).to_set
       # Expected submissions are returned.
       assert_equal expected_submissions[series.id].to_set, scoresheet[:submissions].values.map(&:id).to_set
       # Hash mapping is correct.

--- a/test/models/series_test.rb
+++ b/test/models/series_test.rb
@@ -115,36 +115,76 @@ class SeriesTest < ActiveSupport::TestCase
   test 'series scoresheet should be correct' do
     course = create :course
     create_list :series, 4, course: course, exercise_count: 5, deadline: Time.current
-    users = create_list(:user, 4, courses: [course])
+    users = create_list(:user, 6, courses: [course])
+
+    expected_submissions = Hash.new
 
     course.series.each do |series|
       deadline = series.deadline
+      expected_submissions[series.id] = []
       series.exercises.map do |exercise|
-        4.times do |i|
+        6.times do |i|
           u = users[i]
           case i
           when 0 # Wrong submission before deadline
-            create :wrong_submission,
+            s = create :wrong_submission,
                    exercise: exercise,
                    user: u,
-                   created_at: (deadline - 2.minutes)
-          when 1 # Correct submission before deadline
+                   created_at: (deadline - 2.minutes),
+                   course: course
+            expected_submissions[series.id] << s.id
+          when 1 # Wrong, then correct submission before deadline
             create :correct_submission,
                    exercise: exercise,
                    user: u,
-                   created_at: (deadline - 2.minutes)
+                   created_at: (deadline - 2.minutes),
+                   course: course
+            s = create :correct_submission,
+                   exercise: exercise,
+                   user: u,
+                   created_at: (deadline - 1.minutes),
+                   course: course
+            expected_submissions[series.id] << s.id
           when 2 # Wrong submission after deadline
             create :wrong_submission,
                    exercise: exercise,
                    user: u,
-                   created_at: (deadline + 2.minutes)
+                   created_at: (deadline + 2.minutes),
+                   course: course
           when 3 # Correct submission after deadline
+            create :correct_submission,
+                   exercise: exercise,
+                   user: u,
+                   created_at: (deadline + 2.minutes),
+                   course: course
+          when 4 # Correct submission before deadline not in course
+            create :correct_submission,
+                   exercise: exercise,
+                   user: u,
+                   created_at: (deadline - 2.minutes)
+          when 5 # Correct submission after deadline not in course
             create :correct_submission,
                    exercise: exercise,
                    user: u,
                    created_at: (deadline + 2.minutes)
           end
         end
+      end
+
+      scoresheet = series.scoresheet
+      # All users are included in the scoresheet.
+      assert_equal users.to_set, scoresheet[:users].to_set
+      # All exercises are included in the scoresheet.
+      assert_equal series.exercises.to_set, scoresheet[:exercises].to_set
+      # Only latest submissions in the course and after the deadline are counted.
+      assert_equal 2 * series.exercises.count, scoresheet[:submissions].count
+      # Submissions are for the correct user.
+      assert_equal users[0,2].map(&:id).to_set, scoresheet[:submissions].keys.map(&:first).to_set
+      # Expected submissions are returned.
+      assert_equal expected_submissions[series.id].to_set, scoresheet[:submissions].values.map(&:id).to_set
+      # Hash mapping is correct.
+      scoresheet[:submissions].each do |key, submission|
+        assert_equal [submission.user_id, submission.exercise.id], key
       end
     end
   end


### PR DESCRIPTION
This pull request:
- Adds the status to the CSV export for series. I've named the columns `Status ${exercise_name}`.
- Adds the started count to CSV export for courses. I've named the columns `Started in ${series_name}` or `Begonnen in ${series_name}`. I'm not terribly happy with the names, so suggestions welcome.
  - I've also added this to the json output, seems useful to have.
- Adds tests for the scoresheet function in series and courses.

Fixes #1712.
