### PR TITLE
Fix newlines being stripped from exercise boilerplate

### DIFF
--- a/app/models/exercise.rb
+++ b/app/models/exercise.rb
@@ -157,7 +157,7 @@ class Exercise < ApplicationRecord
   def boilerplate_localized(lang = I18n.locale.to_s)
     ext = lang ? ".#{lang}" : ''
     file = full_path + BOILERPLATE_DIR + "boilerplate#{ext}"
-    file.read.strip if file.exist?
+    file.read if file.exist?
   end
 
   def boilerplate_default

--- a/test/controllers/annotations_controller_test.rb
+++ b/test/controllers/annotations_controller_test.rb
@@ -119,7 +119,7 @@ class AnnotationControllerTest < ActionDispatch::IntegrationTest
 
     put annotation_url(annotation), params: {
       annotation: {
-        annotation_text: Faker::Lorem.sentences(number: 100).join(' ')
+        annotation_text: 'A' * 2049 # max length of annotation text is 2048 -> trigger failure
       },
       format: :json
     }

--- a/test/models/annotation_test.rb
+++ b/test/models/annotation_test.rb
@@ -41,7 +41,7 @@ class AnnotationTest < ActiveSupport::TestCase
   test 'can not create annotation with an enormous message' do
     annotating_user = create :user
     annotation = create :annotation, submission: @submission, user: annotating_user
-    annotation.annotation_text = Faker::Lorem.paragraph sentence_count: 100
+    annotation.annotation_text = 'A' * 2049 # max length of annotation text is 2048 -> trigger failure
     assert_not annotation.valid?
   end
 


### PR DESCRIPTION
This pull request removes the stripping of newlines at the end of exercise boilerplates.

**Before:**
![image](https://user-images.githubusercontent.com/6131398/78642888-b5a21980-78b3-11ea-8522-d9f6b283410c.png)

**After:**
![image](https://user-images.githubusercontent.com/6131398/78642904-bb97fa80-78b3-11ea-9569-9c24263cac30.png)


Closes #1829.
