### PR TITLE
Allow multiple code listings on same page

### DIFF
--- a/app/assets/javascripts/code_listing/code_listing.ts
+++ b/app/assets/javascripts/code_listing/code_listing.ts
@@ -1,6 +1,4 @@
 import { Annotation } from "code_listing/annotation";
-import ClipboardJS from "clipboard";
-import { tooltip } from "util.js";
 import { MachineAnnotation, MachineAnnotationData } from "code_listing/machine_annotation";
 import { UserAnnotation, UserAnnotationData, UserAnnotationFormData } from "code_listing/user_annotation";
 
@@ -15,7 +13,6 @@ const annotationFormCancel = ".annotation-cancel-button";
 const annotationFormDelete = ".annotation-delete-button";
 const annotationFormSubmit = ".annotation-submission-button";
 const badge = "#badge_code";
-const clipboardBtn = "#copy-to-clipboard";
 
 const ANNOTATION_ORDER = ["error", "user", "warning", "info"];
 
@@ -25,9 +22,6 @@ export class CodeListing {
     public readonly code: string;
     public readonly codeLines: number;
     public readonly submissionId: number;
-
-    private clipboard: ClipboardJS;
-    private readonly clipboardBtn;
 
     private readonly markingClass: string = "marked";
 
@@ -50,8 +44,6 @@ export class CodeListing {
         this.badge = document.querySelector<HTMLSpanElement>(badge);
         this.table = document.querySelector<HTMLTableElement>("table.code-listing");
 
-        this.clipboardBtn = document.querySelector<HTMLButtonElement>(clipboardBtn);
-
         this.hideAllAnnotations = document.querySelector<HTMLButtonElement>(annotationHideAll);
         this.showAllAnnotations = document.querySelector<HTMLButtonElement>(annotationShowAll);
         this.showErrorAnnotations = document.querySelector<HTMLButtonElement>(annotationShowErrors);
@@ -61,7 +53,6 @@ export class CodeListing {
         this.globalAnnotationGroups = document.querySelector<HTMLDivElement>(annotationsGlobalGroups);
 
         this.initAnnotations();
-        this.initCopyToClipboard();
     }
 
     // /////////////////////////////////////////////////////////////////////////
@@ -268,16 +259,6 @@ export class CodeListing {
             annotationButton.appendChild(annotationButtonIcon);
 
             codeLine.querySelector(".rouge-gutter").prepend(annotationButton);
-        });
-    }
-
-    private initCopyToClipboard(): void {
-        this.clipboard = new ClipboardJS(clipboardBtn, { text: () => this.code });
-        this.clipboard.on("success", () => {
-            tooltip(this.clipboardBtn, I18n.t("js.copy-success"));
-        });
-        this.clipboard.on("error", () => {
-            tooltip(this.clipboardBtn, I18n.t("js.copy-fail"));
         });
     }
 

--- a/app/assets/javascripts/copy.ts
+++ b/app/assets/javascripts/copy.ts
@@ -1,6 +1,17 @@
 import ClipboardJS from "clipboard";
 import { tooltip } from "util.js";
 
+export function initClipboard(): void {
+    $(() => {
+        const selector = ".btn";
+        const delay = 1000;
+        const clip = new ClipboardJS(selector);
+        const targetOf = (e): any => $($(e.trigger).data("clipboard-target"));
+        clip.on("success", e => tooltip(targetOf(e), I18n.t("js.copy-success"), delay));
+        clip.on("error", e => tooltip(targetOf(e), I18n.t("js.copy-fail"), delay));
+    });
+}
+
 /**
  * Small wrapper around ClipboardJS to copy some content the clipboard when the
  * element with the given identifier is pressed. If the content you need to copy

--- a/app/assets/javascripts/copy.ts
+++ b/app/assets/javascripts/copy.ts
@@ -1,0 +1,22 @@
+import ClipboardJS from "clipboard";
+import { tooltip } from "util.js";
+
+/**
+ * Small wrapper around ClipboardJS to copy some content the clipboard when the
+ * element with the given identifier is pressed. If the content you need to copy
+ * is in some HTML element, you probably don't need this and can use ClipboardJS
+ * directly.
+ *
+ * @param {string} identifier The identifying query for the button to attach the listener to.
+ * @param {string} code The code to put on the clipboard.
+ */
+export function attachClipboard(identifier: string, code: string): void {
+    const clipboardBtn = document.querySelector<HTMLButtonElement>(identifier);
+    const clipboard = new ClipboardJS(clipboardBtn, { text: () => code });
+    clipboard.on("success", () => {
+        tooltip(clipboardBtn, I18n.t("js.copy-success"));
+    });
+    clipboard.on("error", () => {
+        tooltip(clipboardBtn, I18n.t("js.copy-fail"));
+    });
+}

--- a/app/assets/javascripts/util.js
+++ b/app/assets/javascripts/util.js
@@ -1,18 +1,5 @@
 /* globals ga */
 
-import ClipboardJS from "clipboard";
-
-function initClipboard() {
-    $(() => {
-        const selector = ".btn";
-        const delay = 1000;
-        const clip = new ClipboardJS(selector);
-        const targetOf = e => $($(e.trigger).data("clipboard-target"));
-        clip.on("success", e => tooltip(targetOf(e), I18n.t("js.copy-success"), delay));
-        clip.on("error", e => tooltip(targetOf(e), I18n.t("js.copy-fail"), delay));
-    });
-}
-
 /*
  * Function to delay some other function until it isn't
  * called for "ms" ms
@@ -181,7 +168,6 @@ function fetch(url, options = {}) {
 }
 
 export {
-    initClipboard,
     delay,
     fetch,
     updateURLParameter,

--- a/app/assets/stylesheets/components/code_listing.css.less
+++ b/app/assets/stylesheets/components/code_listing.css.less
@@ -6,7 +6,7 @@
     left: 0;
     top: 0;
 
-    #copy-to-clipboard {
+    .copy-btn {
       margin-right: 5px;
       position: absolute;
       right: 1px;

--- a/app/helpers/renderers/feedback_table_renderer.rb
+++ b/app/helpers/renderers/feedback_table_renderer.rb
@@ -300,7 +300,7 @@ class FeedbackTableRenderer
     @builder.div(class: 'code-table', 'data-submission-id': @submission.id) do
       @builder << FeedbackCodeRenderer.new(@code, @submission.exercise.programming_language&.name)
                                       .add_messages(@submission, messages, @user)
-                                      .parse
+                                      .add_code
                                       .html
     end
   end

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -23,7 +23,8 @@ import "polyfills.js";
 import { Drawer } from "drawer";
 import { Toast } from "toast";
 import { Notification } from "notification";
-import { checkTimeZone, initClipboard, initCSRF, initTooltips } from "util.js";
+import { checkTimeZone, initCSRF, initTooltips } from "util.js";
+import { initClipboard } from "copy";
 
 
 import * as firebase from "firebase/app";

--- a/app/javascript/packs/frame.js
+++ b/app/javascript/packs/frame.js
@@ -6,7 +6,8 @@ window.jquery = jQuery;
 window.$ = jQuery;
 
 import "polyfills.js";
-import { initTooltips, initClipboard } from "util.js";
+import { initTooltips } from "util.js";
+import { initClipboard } from "copy";
 
 // Use a global dodona object to prevent polluting the global na
 const dodona = window.dodona || {};

--- a/app/javascript/packs/submission.js
+++ b/app/javascript/packs/submission.js
@@ -1,5 +1,7 @@
 import { initSubmissionShow } from "submission.js";
 import { CodeListing } from "code_listing/code_listing.ts";
+import { attachClipboard } from "copy";
 
 window.dodona.initSubmissionShow = initSubmissionShow;
 window.dodona.codeListingClass = CodeListing;
+window.dodona.attachClipboard = attachClipboard;

--- a/app/views/exercises/info.html.erb
+++ b/app/views/exercises/info.html.erb
@@ -1,3 +1,6 @@
+<% content_for :javascripts do %>
+  <%= javascript_pack_tag 'submission' %>
+<% end %>
 <%= render 'navbar_links' %>
 <%
   solutions = @exercise.solutions.sort(&method(:compare_solutions))
@@ -175,7 +178,7 @@
                     <%= link_to t('.sample_solution_submit'), exercise_url(@exercise, from_solution: fname), class: "btn-text" %>
                   </div>
                   <div class="code-table">
-                    <%= raw FeedbackCodeRenderer.new(code, @exercise.programming_language.name).parse.html %>
+                    <%= raw FeedbackCodeRenderer.new(code, @exercise.programming_language.name).add_code.html %>
                   </div>
                 </div>
               <% end %>

--- a/test/javascript/code_listing.test.ts
+++ b/test/javascript/code_listing.test.ts
@@ -1,19 +1,5 @@
 import { CodeListing } from "code_listing/code_listing";
 
-class ClipboardMock {
-    constructor() {
-    }
-
-    public on(ev: string, fn: CallableFunction): void {
-
-    }
-}
-
-// Mock the clipboard to make the tests pass.
-jest.mock("clipboard", () => {
-    return { default: () => new ClipboardMock() };
-});
-
 let codeListing;
 
 beforeEach(() => {
@@ -52,7 +38,6 @@ beforeEach(() => {
             </tr>
             </tbody>
         </table>
-        <button id="copy-to-clipboard"></button>
     </div>
 </div>`;
     codeListing = new CodeListing(54, "print(5 + 6)\nprint(6 + 3)\nprint(9 + 15)\n", 3);

--- a/test/renderers/feedback_code_renderer_test.rb
+++ b/test/renderers/feedback_code_renderer_test.rb
@@ -27,4 +27,10 @@ class FeedbackCodeRendererTest < ActiveSupport::TestCase
       assert_equal gen_html_orig, gen_html_cr
     end
   end
+
+  test 'Multiple instances result in unique html' do
+    programming_language = 'python'
+    tables = 5.times.collect { FeedbackCodeRenderer.new('print(5)', programming_language).add_code.html }
+    assert tables.uniq == tables
+  end
 end


### PR DESCRIPTION
The `FeedbackCodeRenderer` uses an id for the copy button; on the exercise information page there are multiple code listings in the same page, which breaks since there can't be multiple elements with the same id.
Additionally, `add_messages` is not called on the exercise information page, so the javascript is not initialised.

What I've done:
- The `FeedbackCodeRenderer` tracks an instance number to make unique ids. If there is a better solution, feel free to apply it.
- I've moved the copy functionality out of the code listing class. The `FeedbackCodeRenderer` will now always load it.
- I've renamed `parse` to `add_code` and added a new `parse` method, to better reflect their actual use (the old `parse` method did more than just parse the code).