### PR TITLE
Allow course admins to delete (almost) unused courses

### DIFF
--- a/app/assets/stylesheets/components/btn.css.less
+++ b/app/assets/stylesheets/components/btn.css.less
@@ -83,6 +83,18 @@
   transition: background-color 0.2s cubic-bezier(.4, 0, .2, 1);
 }
 
+.btn-danger.btn-text {
+  background-color: @btn-danger-bg;
+  color: @btn-danger-color;
+  .shadow-z1();
+}
+
+.btn-danger.btn-text:hover {
+  background-color: @btn-danger-bg;
+  color: @btn-danger-color;
+  .shadow-z3();
+}
+
 .btn-primary.btn-text {
   background-color: @btn-accent;
   color: white;

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -33,14 +33,14 @@ class Course < ApplicationRecord
 
   belongs_to :institution, optional: true
 
-  has_many :course_memberships, dependent: :restrict_with_error
-  has_many :series, dependent: :restrict_with_error
-  has_many :course_repositories, dependent: :restrict_with_error
+  has_many :course_memberships, dependent: :destroy
+  has_many :series, dependent: :destroy
+  has_many :course_repositories, dependent: :destroy
 
   has_many :exercises, -> { distinct }, through: :series
   has_many :series_memberships, through: :series
 
-  has_many :submissions, dependent: :restrict_with_error
+  has_many :submissions, dependent: :nullify
   has_many :users, through: :course_memberships
 
   has_many :usable_repositories, through: :course_repositories, source: :repository

--- a/app/models/course_membership.rb
+++ b/app/models/course_membership.rb
@@ -16,7 +16,7 @@ class CourseMembership < ApplicationRecord
 
   belongs_to :course
   belongs_to :user
-  has_many :course_membership_labels, dependent: :restrict_with_error
+  has_many :course_membership_labels, dependent: :destroy
   has_many :course_labels, through: :course_membership_labels
 
   validates :course_id, uniqueness: { scope: :user_id }

--- a/app/policies/course_policy.rb
+++ b/app/policies/course_policy.rb
@@ -50,7 +50,7 @@ class CoursePolicy < ApplicationPolicy
   end
 
   def destroy?
-    course_admin? && record.submissions.count <= MAX_SUBMISSIONS_FOR_DESTROY
+    user&.zeus? || (course_admin? && record.submissions.count <= MAX_SUBMISSIONS_FOR_DESTROY)
   end
 
   def members?

--- a/app/policies/course_policy.rb
+++ b/app/policies/course_policy.rb
@@ -1,4 +1,6 @@
 class CoursePolicy < ApplicationPolicy
+  MAX_SUBMISSIONS_FOR_DESTROY = 20
+
   class Scope < Scope
     def resolve
       if user&.zeus?
@@ -48,7 +50,7 @@ class CoursePolicy < ApplicationPolicy
   end
 
   def destroy?
-    user&.zeus?
+    course_admin? && record.submissions.count <= MAX_SUBMISSIONS_FOR_DESTROY
   end
 
   def members?

--- a/app/views/courses/edit.html.erb
+++ b/app/views/courses/edit.html.erb
@@ -20,3 +20,31 @@
     <% end %>
   </div>
 </div>
+
+<div class="row">
+  <div class="col-sm-10 col-sm-offset-1 col-xs-12">
+    <div class="card card-border">
+      <% if policy(@course).destroy? %>
+        <div class="card-supporting-text">
+          <h4><%= t ".delete.title" %></h4>
+          <p><%= t '.delete.sure' %></p>
+          <ul>
+            <li><%= t '.delete.submissions' %></li>
+            <li><%= t '.delete.lose' %></li>
+          </ul>
+        </div>
+        <div class="card-actions card-border">
+          <%= link_to @course, method: :delete, data: {confirm: t("general.are_you_sure")}, class: "btn btn-text btn-danger", title: t(".delete.button") do %>
+            <%= t('.delete.button') %>
+          <% end %>
+        </div>
+      <% else %>
+        <div class="card-supporting-text">
+          <h4><%= t ".delete.title" %></h4>
+          <p><%= t '.delete.impossible', count: CoursePolicy::MAX_SUBMISSIONS_FOR_DESTROY %></p>
+        </div>
+
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/courses/edit.html.erb
+++ b/app/views/courses/edit.html.erb
@@ -24,26 +24,25 @@
 <div class="row">
   <div class="col-sm-10 col-sm-offset-1 col-xs-12">
     <div class="card card-border">
+      <div class="card-supporting-text">
+        <h4><%= t ".delete.title" %></h4>
+        <p><%= t '.delete.consequences' %></p>
+        <ul>
+          <li><%= t '.delete.submissions' %></li>
+          <li><%= t '.delete.series' %></li>
+        </ul>
+      </div>
       <% if policy(@course).destroy? %>
-        <div class="card-supporting-text">
-          <h4><%= t ".delete.title" %></h4>
-          <p><%= t '.delete.sure' %></p>
-          <ul>
-            <li><%= t '.delete.submissions' %></li>
-            <li><%= t '.delete.lose' %></li>
-          </ul>
-        </div>
         <div class="card-actions card-border">
           <%= link_to @course, method: :delete, data: {confirm: t("general.are_you_sure")}, class: "btn btn-text btn-danger", title: t(".delete.button") do %>
             <%= t('.delete.button') %>
           <% end %>
         </div>
       <% else %>
-        <div class="card-supporting-text">
-          <h4><%= t ".delete.title" %></h4>
-          <p><%= t '.delete.impossible', count: CoursePolicy::MAX_SUBMISSIONS_FOR_DESTROY %></p>
+        <div class="card-supporting-text card-border">
+          <%= t '.delete.impossible', count: CoursePolicy::MAX_SUBMISSIONS_FOR_DESTROY %>
+          <%= t '.delete.contact_html', contact_url: contact_url %>
         </div>
-
       <% end %>
     </div>
   </div>

--- a/config/locales/views/courses/en.yml
+++ b/config/locales/views/courses/en.yml
@@ -72,8 +72,8 @@ en:
         series: "Series are irrevocably lost."
         button: "Delete"
         impossible:
-          one: "A course with more than %{count} submission cannot be removed."
-          other: "A course with more than %{count} submissions cannot be removed."
+          one: "You can't remove a course with more than %{count} submission yourself."
+          other: "You can't remove a course with more than %{count} submissions yourself."
         contact_html: "<a href=\"%{contact_url}\">Contact us</a> if you want to delete the course anyway."
     show:
       course: Course

--- a/config/locales/views/courses/en.yml
+++ b/config/locales/views/courses/en.yml
@@ -65,6 +65,15 @@ en:
       series_reordering_help_html: "You can reorder the series by dragging the icons at the left of the table. For students, a <b>reverse chronological</b> order is probably the easiest. This way, the most recent series is at the top, and the students don't have to scroll down each time."
       update: "Update"
       series_reordering_moved_help_html: 'Looking to reorder the series in this course? This functionality has moved to a <a href="%{course_url}">separate page</a>.'
+      delete:
+        title: "Delete course"
+        sure: "Deleting a course has following consequences."
+        submissions: "Submissions are kept, but are no longer linked to a course."
+        lose: "Series are irrevocably lost."
+        button: "Course"
+        impossible:
+          one: "A course with more than %{count} submission cannot be removed."
+          other: "A course with more than %{count} submissions cannot be removed."
     show:
       course: Course
       hidden_show_link: "Secret link"

--- a/config/locales/views/courses/en.yml
+++ b/config/locales/views/courses/en.yml
@@ -67,13 +67,14 @@ en:
       series_reordering_moved_help_html: 'Looking to reorder the series in this course? This functionality has moved to a <a href="%{course_url}">separate page</a>.'
       delete:
         title: "Delete course"
-        sure: "Deleting a course has the following consequences:"
+        consequences: "Deleting a course has the following consequences:"
         submissions: "Submissions are kept, but are no longer linked to a course."
-        lose: "Series are irrevocably lost."
-        button: "Course"
+        series: "Series are irrevocably lost."
+        button: "Delete"
         impossible:
           one: "A course with more than %{count} submission cannot be removed."
           other: "A course with more than %{count} submissions cannot be removed."
+        contact_html: "<a href=\"%{contact_url}\">Contact us</a> if you want to delete the course anyway."
     show:
       course: Course
       hidden_show_link: "Secret link"

--- a/config/locales/views/courses/en.yml
+++ b/config/locales/views/courses/en.yml
@@ -67,7 +67,7 @@ en:
       series_reordering_moved_help_html: 'Looking to reorder the series in this course? This functionality has moved to a <a href="%{course_url}">separate page</a>.'
       delete:
         title: "Delete course"
-        sure: "Deleting a course has following consequences."
+        sure: "Deleting a course has the following consequences:"
         submissions: "Submissions are kept, but are no longer linked to a course."
         lose: "Series are irrevocably lost."
         button: "Course"

--- a/config/locales/views/courses/nl.yml
+++ b/config/locales/views/courses/nl.yml
@@ -76,7 +76,7 @@ nl:
       series_reordering_moved_help_html: "Wou je de reeksen in dit vak herordenen? Deze functionaliteit is verplaatst naar een <a href=\"%{course_url}\">aparte pagina</a>."
       delete:
         title: "Cursus verwijderen"
-        sure: "Het verwijderen van een cursus heeft volgende gevolgen:"
+        sure: "Het verwijderen van een cursus heeft de volgende gevolgen:"
         submissions: "Oplossingen blijven bewaard, maar zijn niet meer gekoppeld aan een cursus."
         lose: "Reeksen gaan onherroepelijk verloren."
         button: "Verwijderen"

--- a/config/locales/views/courses/nl.yml
+++ b/config/locales/views/courses/nl.yml
@@ -81,8 +81,8 @@ nl:
         series: "Reeksen gaan onherroepelijk verloren."
         button: "Verwijderen"
         impossible:
-          one: "Een cursus met meer dan %{count} oplossing kan niet verwijderd worden."
-          other: "Een cursus met meer dan %{count} oplossingen kan niet verwijderd worden."
+          one: "Je kan een cursus met meer dan %{count} oplossing niet zelf verwijderen."
+          other: "Je kan een cursus met meer dan %{count} oplossingen niet zelf verwijderen."
         contact_html: "<a href=\"%{contact_url}\">Contacteer ons</a> als je de cursus toch wilt verwijderen."
     show:
       course: Cursus

--- a/config/locales/views/courses/nl.yml
+++ b/config/locales/views/courses/nl.yml
@@ -76,13 +76,14 @@ nl:
       series_reordering_moved_help_html: "Wou je de reeksen in dit vak herordenen? Deze functionaliteit is verplaatst naar een <a href=\"%{course_url}\">aparte pagina</a>."
       delete:
         title: "Cursus verwijderen"
-        sure: "Het verwijderen van een cursus heeft de volgende gevolgen:"
+        consequences: "Het verwijderen van een cursus heeft de volgende gevolgen:"
         submissions: "Oplossingen blijven bewaard, maar zijn niet meer gekoppeld aan een cursus."
-        lose: "Reeksen gaan onherroepelijk verloren."
+        series: "Reeksen gaan onherroepelijk verloren."
         button: "Verwijderen"
         impossible:
           one: "Een cursus met meer dan %{count} oplossing kan niet verwijderd worden."
           other: "Een cursus met meer dan %{count} oplossingen kan niet verwijderd worden."
+        contact_html: "<a href=\"%{contact_url}\">Contacteer ons</a> als je de cursus toch wilt verwijderen."
     show:
       course: Cursus
       hidden_show_link: 'Geheime link'

--- a/config/locales/views/courses/nl.yml
+++ b/config/locales/views/courses/nl.yml
@@ -74,6 +74,15 @@ nl:
       series_reordering_help_html: "Je kan de reeksen herordenen door ze te verslepen met de icoontjes aan de linkerkant van de tabel. Voor studenten is een <b>omgekeerd chronologische</b> volgorde waarschijnlijk het gemakkelijkste. Hierbij staan recente reeksen bovenaan de pagina en hoeven ze niet telkens naar onder te scrollen."
       update: "Aanpassen"
       series_reordering_moved_help_html: "Wou je de reeksen in dit vak herordenen? Deze functionaliteit is verplaatst naar een <a href=\"%{course_url}\">aparte pagina</a>."
+      delete:
+        title: "Cursus verwijderen"
+        sure: "Het verwijderen van een cursus heeft volgende gevolgen:"
+        submissions: "Oplossingen blijven bewaard, maar zijn niet meer gekoppeld aan een cursus."
+        lose: "Reeksen gaan onherroepelijk verloren."
+        button: "Verwijderen"
+        impossible:
+          one: "Een cursus met meer dan %{count} oplossing kan niet verwijderd worden."
+          other: "Een cursus met meer dan %{count} oplossingen kan niet verwijderd worden."
     show:
       course: Cursus
       hidden_show_link: 'Geheime link'

--- a/test/controllers/courses_controller_test.rb
+++ b/test/controllers/courses_controller_test.rb
@@ -519,4 +519,28 @@ class CoursesPermissionControllerTest < ActionDispatch::IntegrationTest
     get course_url(@course, secret: @course.secret)
     assert_not response.body.include?(subscribe_course_path(@course, secret: @course.secret))
   end
+
+  test 'should not destroy course as student' do
+    sign_in @students.first
+    delete course_url(@course)
+    assert_not response.successful?
+  end
+
+  test 'should destroy course as course admin' do
+    # Ensure there are not too many submissions.
+    @course.submissions.offset(CoursePolicy::MAX_SUBMISSIONS_FOR_DESTROY).each(&:destroy)
+    sign_in @course_admins.first
+    assert_difference 'Course.count', -1 do
+      delete course_url(@course)
+    end
+    assert response.body.include?(courses_url)
+  end
+
+  test 'should not destroy course as course admin if too many submissions' do
+    sign_in @course_admins.first
+    # Ensure we are testing something useful.
+    assert_operator @course.submissions.count, :>, CoursePolicy::MAX_SUBMISSIONS_FOR_DESTROY
+    delete course_url(@course)
+    assert_not response.successful?
+  end
 end

--- a/test/controllers/courses_controller_test.rb
+++ b/test/controllers/courses_controller_test.rb
@@ -543,4 +543,15 @@ class CoursesPermissionControllerTest < ActionDispatch::IntegrationTest
     delete course_url(@course)
     assert_not response.successful?
   end
+
+  test 'should destroy course as zeus even if too many submissions' do
+    admin = create :zeus
+    sign_in admin
+    # Ensure we are testing something useful.
+    assert_operator @course.submissions.count, :>, CoursePolicy::MAX_SUBMISSIONS_FOR_DESTROY
+    assert_difference 'Course.count', -1 do
+      delete course_url(@course)
+    end
+    assert response.body.include?(courses_url)
+  end
 end

--- a/test/models/course_test.rb
+++ b/test/models/course_test.rb
@@ -145,4 +145,11 @@ class CourseTest < ActiveSupport::TestCase
       assert_equal counts[:started], expected_started[key]
     end
   end
+
+  test 'destroying course does not destroy submissions' do
+    course = create :course, series_count: 10, exercises_per_series: 5, submissions_per_exercise: 5
+    assert_difference 'Submission.count', 0 do
+      course.destroy
+    end
+  end
 end


### PR DESCRIPTION
This pull request adds the possibility to delete courses:

- I've allowed course admins to delete their course. Is this what we want?
- Courses with more than 20 submissions cannot be deleted.
- A card with delete button is added to the course edit page.

Deletable course:
![image](https://user-images.githubusercontent.com/1756811/79005894-2ff2c800-7b58-11ea-8a0b-d6fc27b20da6.png)

Undeletable course:
![image](https://user-images.githubusercontent.com/1756811/79023288-35fc9f00-7b80-11ea-8815-f9a93c2b2a82.png)

Closes #1683.
