### PR TITLE
streamline course attribution

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -145,6 +145,12 @@ class Course < ApplicationRecord
     Course.format_year year
   end
 
+  def formatted_attribution
+    result = teacher || ''
+    result += ' · ' if teacher.present? && institution&.name.present?
+    result + (institution&.name || '')
+  end
+
   def secret_required?(user = nil)
     return false if visible_for_all?
     return false if visible_for_institution? && user&.institution == institution

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -22,15 +22,9 @@
         <h2 class="card-title-text">
           <%= @course.name %> (<%= @course.formatted_year %>)
         </h2>
-        <% if @course.institution&.name.present? || @course.teacher.present? %>
+        <% if @course.formatted_attribution.present? %>
           <h3 class="card-subtitle-text">
-            <% if @course.institution&.name.present? && @course.teacher.present? %>
-              <%= t(".taught_by_at", {teacher: @course.teacher, institution: @course.institution.name}) %>
-            <% elsif @course.institution&.name.present? %>
-              <%= t(".taught_at", {institution: @course.institution.name}) %>
-            <% elsif @course.teacher.present? %>
-              <%= t(".taught_by", {teacher: @course.teacher}) %>
-            <% end %>
+            <%= @course.formatted_attribution %>
           </h3>
         <% end %>
       </div>

--- a/app/views/pages/_course_card.html.erb
+++ b/app/views/pages/_course_card.html.erb
@@ -25,13 +25,10 @@
       <% end %>
       <h2 class="card-title-text course-name" title="<%= course.name %>"><%= course.name %></h2>
       <h3 class="card-subtitle-text"><%= course.formatted_year %>&nbsp;</h3>
-      <% if course.institution&.name.present? && course.teacher.present? %>
-        <h3 class="card-subtitle-text ellipsis-overflow" title="<%= course.teacher %> (<%= course.institution.name %>)"><%= course.teacher %>
-          (<%= course.institution.name %>)&nbsp;</h3>
-      <% elsif course.teacher.present? %>
-        <h3 class="card-subtitle-text ellipsis-overflow" title="<%= course.teacher %>"><%= course.teacher %>&nbsp;</h3>
-      <% elsif course.institution&.name.present? %>
-        <h3 class="card-subtitle-text ellipsis-overflow" title="<%= course.institution.name %>"><%= course.institution.name %></h3>
+      <% if course.formatted_attribution.present? %>
+        <h3 class="card-subtitle-text ellipsis-overflow" title="<%= course.formatted_attribution %>">
+          <%= course.formatted_attribution %>
+        </h3>
       <% end %>
     </div>
   <% end %>

--- a/config/locales/views/courses/en.yml
+++ b/config/locales/views/courses/en.yml
@@ -97,9 +97,6 @@ en:
       mass_decline_toast:
         one: 1 pending user is declined.
         other: "%{count} pending users are declined."
-      taught_by: "Taught by %{teacher}."
-      taught_by_at: "Taught by %{teacher} at %{institution}."
-      taught_at: "Taught at %{institution}."
       copy: "Copy this course"
       manage_series: "Manage series"
     scoresheet:

--- a/config/locales/views/courses/nl.yml
+++ b/config/locales/views/courses/nl.yml
@@ -106,9 +106,6 @@ nl:
       mass_decline_toast:
         one: 1 gebruiker op de wachtlijst is afgewezen.
         other: "%{count} gebruikers op de wachtlijst zijn afgewezen."
-      taught_by: "Gegeven door %{teacher}."
-      taught_by_at: "Gegeven door %{teacher} aan %{institution}."
-      taught_at: "Gegeven aan %{institution}."
       copy: "Deze cursus kopiëren"
       manage_series: "Reeksen beheren"
     registration:

--- a/test/models/course_test.rb
+++ b/test/models/course_test.rb
@@ -32,6 +32,26 @@ class CourseTest < ActiveSupport::TestCase
     assert_equal '2017–2018', course.formatted_year
   end
 
+  test 'course formatted attribution should only have a dot with teacher and institution' do
+    course = create :course, teacher: ''
+    assert_equal '', course.formatted_attribution
+
+    course = create :course, teacher: 'teach'
+    assert_equal 'teach', course.formatted_attribution
+
+    course = create :course, teacher: '', institution: (create :institution, short_name: 'sn', name: '')
+    assert_equal '', course.formatted_attribution
+
+    course = create :course, teacher: 'teach', institution: (create :institution, short_name: 'sn', name: '')
+    assert_equal 'teach', course.formatted_attribution
+
+    course = create :course, teacher: '', institution: (create :institution, short_name: 'sn', name: 'inst')
+    assert_equal 'inst', course.formatted_attribution
+
+    course = create :course, teacher: 'teach', institution: (create :institution, short_name: 'sn', name: 'inst')
+    assert_equal 'teach · inst', course.formatted_attribution
+  end
+
   test 'hidden course should always require secret' do
     course = create :course, institution: (create :institution), visibility: :hidden
     user1 = create :user, institution: nil


### PR DESCRIPTION
This pull request streamlines course attribution. The mini card and course show page now also use the same format.

![image](https://user-images.githubusercontent.com/481872/79112210-57c37500-7d7e-11ea-9bee-fdf22091c63c.png)

- [x] Tests were added

Closes #1841 
