### PR TITLE
Fix intra page links

### DIFF
--- a/app/assets/javascripts/exercise.js
+++ b/app/assets/javascripts/exercise.js
@@ -388,8 +388,18 @@ function afterResize(details) {
     }
 }
 
+function onFrameScroll(position) {
+    /**
+     * The scroll position does not account for the navigation bar, which is always
+     * visible. This will add the offset for the navigation bar.
+     */
+    const navHeight = document.querySelector("nav.dodona-navbar").offsetHeight;
+    window.scrollTo(position.x, position.y - navHeight);
+    return false;
+}
+
 export {
     initExerciseShow, initExerciseDescription, initLabelsEdit, afterResize,
-    onFrameMessage
+    onFrameMessage, onFrameScroll
 };
 

--- a/app/assets/stylesheets/models/exercises.css.less
+++ b/app/assets/stylesheets/models/exercises.css.less
@@ -76,6 +76,14 @@
   margin-left: 16px;
 }
 
+.exercise-description .footnotes {
+  border-top: 1px solid @divider-color;
+  padding-top: 16px;
+  font-size: 13px;
+  // The parent div has 16px of padding, which we don't want.
+  margin: 16px -16px 0;
+}
+
 center img {
   vertical-align: top;
   margin-left: 16px;

--- a/app/assets/stylesheets/models/exercises.css.less
+++ b/app/assets/stylesheets/models/exercises.css.less
@@ -76,12 +76,18 @@
   margin-left: 16px;
 }
 
-.exercise-description .footnotes {
-  border-top: 1px solid @divider-color;
-  padding-top: 16px;
-  font-size: 13px;
-  // The parent div has 16px of padding, which we don't want.
-  margin: 16px -16px 0;
+.footnotes::before {
+  content: "";
+  width: 150px;
+  height: 16px;
+  margin-left: 16px;
+  display: block;
+  border-top: 1px solid @text-secondary;
+}
+
+.footnotes {
+  font-size: 90%;
+  margin: 16px 0 0 -16px;
 }
 
 center img {

--- a/app/helpers/exercise_helper.rb
+++ b/app/helpers/exercise_helper.rb
@@ -73,7 +73,7 @@ module ExerciseHelper
           onResized: dodona.afterResize,
           onMessage: dodona.onFrameMessage,
           onScroll: dodona.onFrameScroll,
-          inPageLinks:true,
+          inPageLinks: true,
         },
         '##{id}')
     }

--- a/app/helpers/exercise_helper.rb
+++ b/app/helpers/exercise_helper.rb
@@ -72,6 +72,7 @@ module ExerciseHelper
           heightCalculationMethod: 'bodyScroll',
           onResized: dodona.afterResize,
           onMessage: dodona.onFrameMessage,
+          onScroll: dodona.onFrameScroll,
           inPageLinks:true,
         },
         '##{id}')

--- a/app/helpers/exercise_helper.rb
+++ b/app/helpers/exercise_helper.rb
@@ -54,7 +54,7 @@ module ExerciseHelper
     number_to_human bytes, units: BYTE_UNITS
   end
 
-  # returns a list with as the first item the description of an execise
+  # returns a list with as the first item the description of an exercise
   # and as second item a hash of footnote indexes mapped on their url
   def exercise_description_footnotes_and_first_image(exercise)
     renderer = DescriptionRenderer.new(exercise, request)

--- a/app/helpers/exercise_helper.rb
+++ b/app/helpers/exercise_helper.rb
@@ -72,6 +72,7 @@ module ExerciseHelper
           heightCalculationMethod: 'bodyScroll',
           onResized: dodona.afterResize,
           onMessage: dodona.onFrameMessage,
+          inPageLinks:true,
         },
         '##{id}')
     }
@@ -147,7 +148,7 @@ module ExerciseHelper
       end
     end
 
-    # Rewrite relative url's to absulute
+    # Rewrite relative url's to absolute
     # (i.e. if it is relative, rewrite it to be absolute)
     # Returns nil if the argument isn't an url
     def absolutize_url(url)

--- a/app/javascript/packs/exercise.js
+++ b/app/javascript/packs/exercise.js
@@ -1,9 +1,10 @@
-import { initExerciseShow, initLabelsEdit, afterResize, onFrameMessage } from "exercise.js";
+import { initExerciseShow, initLabelsEdit, afterResize, onFrameMessage, onFrameScroll } from "exercise.js";
 
 window.dodona.initExerciseShow = initExerciseShow;
 window.dodona.initLabelsEdit = initLabelsEdit;
 window.dodona.afterResize = afterResize;
 window.dodona.onFrameMessage = onFrameMessage;
+window.dodona.onFrameScroll = onFrameScroll;
 
 // will automaticaly bind to window.iFrameResize()
 import { iframeResizer } from "iframe-resizer"; // eslint-disable-line no-unused-vars


### PR DESCRIPTION
This pull request enables intra page links and applies some CSS to footnotes.

![image](https://user-images.githubusercontent.com/1756811/79342907-03f78e00-7f2e-11ea-8981-88699a480a7c.png)

Enabling the links to work was just an option in the iframe-resizer library, but I've also added some code to account for the permanent navbar: when going back from a footnote, it would cause the footnote mark to be under the navbar.

Closes #1810.