### PR TITLE
Fix slow test duration

### DIFF
--- a/test/controllers/courses_controller_test.rb
+++ b/test/controllers/courses_controller_test.rb
@@ -70,7 +70,7 @@ class CoursesPermissionControllerTest < ActionDispatch::IntegrationTest
 
   test 'should subscribe current_user to course' do
     with_users_signed_in @not_subscribed do |who, user|
-      post subscribe_course_url(@course)
+      post subscribe_course_url(@course, format: :json)
       assert @course.subscribed_members.include?(user), "#{who} should be able to subscribe"
     end
   end
@@ -86,7 +86,7 @@ class CoursesPermissionControllerTest < ActionDispatch::IntegrationTest
     with_users_signed_in @not_subscribed do |who, user|
       %w[visible_for_all visible_for_institution hidden].product(%w[open_for_all open_for_institution closed], [true, false]).each do |v, r, m|
         @course.update(visibility: v, registration: r, moderated: m)
-        get course_url(@course, secret: @course.secret)
+        get course_url(@course, secret: @course.secret, format: :json)
         assert_response :success, "#{who} should get registration page"
         # GET should not subscribe
         assert_not user.member_of?(@course), "#{who} should not be registered"
@@ -97,7 +97,7 @@ class CoursesPermissionControllerTest < ActionDispatch::IntegrationTest
   test 'should not subscribe when already subscribed' do
     with_users_signed_in @course.users do |who|
       assert_difference('CourseMembership.count', 0, "#{who} should not be able to create a second membership") do
-        post subscribe_course_url(@course)
+        post subscribe_course_url(@course, format: :json)
       end
     end
   end
@@ -105,12 +105,12 @@ class CoursesPermissionControllerTest < ActionDispatch::IntegrationTest
   test 'unsubscribed user should be able to resubscribe' do
     with_users_signed_in @unsubscribed do |who, user|
       assert_not user.member_of?(@course), "#{who} was already a member"
-      post subscribe_course_url(@course)
+      post subscribe_course_url(@course, format: :json)
       assert user.member_of?(@course), "#{who} should be a member"
     end
   end
 
-  test 'should get course scoresheet as course admin' do
+  test 'should get course scoresheet as course admin in html format' do
     sign_in @course_admins.first
     get scoresheet_course_url(@course)
     assert_response :success, 'course_admin should be able to get course scoresheet'
@@ -136,7 +136,7 @@ class CoursesPermissionControllerTest < ActionDispatch::IntegrationTest
 
   test 'visiting registration page when subscribed should redirect' do
     with_users_signed_in @subscribed do |who|
-      get registration_course_url(@course, @course.secret)
+      get registration_course_url(@course, @course.secret, format: :json)
       assert_redirected_to @course, "#{who} should be redirected"
     end
   end
@@ -193,7 +193,7 @@ class CoursesPermissionControllerTest < ActionDispatch::IntegrationTest
   test 'should be on pending list with moderated course' do
     @course.update(moderated: true)
     with_users_signed_in @not_subscribed do |who, user|
-      post subscribe_course_url(@course)
+      post subscribe_course_url(@course, format: :json)
       assert @course.pending_members.include?(user), "#{who} should be pending"
     end
   end
@@ -201,7 +201,7 @@ class CoursesPermissionControllerTest < ActionDispatch::IntegrationTest
   test 'should be able to withdraw registration request' do
     @course.update(moderated: true)
     with_users_signed_in @pending do |who, user|
-      post unsubscribe_course_url(@course)
+      post unsubscribe_course_url(@course, format: :json)
       assert_not @course.pending_members.include?(user), "#{who} should not be pending anymore"
     end
   end
@@ -209,7 +209,7 @@ class CoursesPermissionControllerTest < ActionDispatch::IntegrationTest
   test 'should be on pending list with moderated and hidden course' do
     @course.update(moderated: 'true', visibility: 'hidden')
     with_users_signed_in @not_subscribed do |who, user|
-      post subscribe_course_url(@course, secret: @course.secret)
+      post subscribe_course_url(@course, secret: @course.secret, format: :json)
       assert @course.pending_members.include?(user), "#{who} should be pending"
     end
   end

--- a/test/controllers/series_controller_test.rb
+++ b/test/controllers/series_controller_test.rb
@@ -189,7 +189,7 @@ end
 
 class SeriesVisibilityTest < ActionDispatch::IntegrationTest
   setup do
-    @series = create :series, exercise_count: 5, exercise_submission_count: 5
+    @series = create :series, exercise_count: 2, exercise_submission_count: 2
     @course = @series.course
     @student = create :student
     @zeus = create :zeus

--- a/test/factories/series.rb
+++ b/test/factories/series.rb
@@ -52,8 +52,8 @@ FactoryBot.define do
     end
 
     trait :with_submissions do
-      exercise_count { 10 }
-      exercise_submission_count { 3 }
+      exercise_count { 2 }
+      exercise_submission_count { 2 }
     end
   end
 end

--- a/test/models/course_test.rb
+++ b/test/models/course_test.rb
@@ -90,7 +90,7 @@ class CourseTest < ActiveSupport::TestCase
 
   test 'course scoresheet should be correct' do
     course = create :course
-    create_list :series, 4, course: course, exercise_count: 5, deadline: Time.current
+    create_list :series, 2, course: course, exercise_count: 2, deadline: Time.current
     users = create_list(:user, 6, courses: [course])
 
     expected_started = Hash.new 0
@@ -167,7 +167,7 @@ class CourseTest < ActiveSupport::TestCase
   end
 
   test 'destroying course does not destroy submissions' do
-    course = create :course, series_count: 10, exercises_per_series: 5, submissions_per_exercise: 5
+    course = create :course, series_count: 2, exercises_per_series: 1, submissions_per_exercise: 2
     assert_difference 'Submission.count', 0 do
       course.destroy
     end

--- a/test/models/series_test.rb
+++ b/test/models/series_test.rb
@@ -114,7 +114,7 @@ class SeriesTest < ActiveSupport::TestCase
 
   test 'series scoresheet should be correct' do
     course = create :course
-    create_list :series, 4, course: course, exercise_count: 5, deadline: Time.current
+    create_list :series, 2, course: course, exercise_count: 2, deadline: Time.current
     users = create_list(:user, 6, courses: [course])
 
     expected_submissions = {}

--- a/test/models/submission_test.rb
+++ b/test/models/submission_test.rb
@@ -240,26 +240,26 @@ class SubmissionTest < ActiveSupport::TestCase
 
   test 'user option should work for heatmap' do
     temp = create :user
-    49.times { create :submission, created_at: Faker::Time.between(from: Time.current - 5.years, to: Time.current), user: temp }
+    2.times { create :submission, created_at: Faker::Time.between(from: Time.current - 5.years, to: Time.current), user: temp }
     user = create :user
-    50.times { create :submission, created_at: Faker::Time.between(from: Time.current - 5.years, to: Time.current), user: user }
-    assert_equal 50, Submission.old_heatmap_matrix(user: user)[:value].values.sum
+    3.times { create :submission, created_at: Faker::Time.between(from: Time.current - 5.years, to: Time.current), user: user }
+    assert_equal 3, Submission.old_heatmap_matrix(user: user)[:value].values.sum
   end
 
   test 'course option should work for punchcard' do
     temp = create :course
-    49.times { create :submission, created_at: Faker::Time.between(from: Time.current - 5.years, to: Time.current), course: temp }
+    2.times { create :submission, created_at: Faker::Time.between(from: Time.current - 5.years, to: Time.current), course: temp }
     course = create :course
-    50.times { create :submission, created_at: Faker::Time.between(from: Time.current - 5.years, to: Time.current), course: course }
-    assert_equal 50, Submission.old_punchcard_matrix(timezone: Time.zone, course: course)[:value].values.sum
+    3.times { create :submission, created_at: Faker::Time.between(from: Time.current - 5.years, to: Time.current), course: course }
+    assert_equal 3, Submission.old_punchcard_matrix(timezone: Time.zone, course: course)[:value].values.sum
   end
 
   test 'course option should work for heatmap' do
     temp = create :course
-    49.times { create :submission, created_at: Faker::Time.between(from: Time.current - 5.years, to: Time.current), course: temp }
+    2.times { create :submission, created_at: Faker::Time.between(from: Time.current - 5.years, to: Time.current), course: temp }
     course = create :course
-    50.times { create :submission, created_at: Faker::Time.between(from: Time.current - 5.years, to: Time.current), course: course }
-    assert_equal 50, Submission.old_heatmap_matrix(course: course)[:value].values.sum
+    3.times { create :submission, created_at: Faker::Time.between(from: Time.current - 5.years, to: Time.current), course: course }
+    assert_equal 3, Submission.old_heatmap_matrix(course: course)[:value].values.sum
   end
 
   test 'update to internal error should send exception notification' do

--- a/test/models/submission_test.rb
+++ b/test/models/submission_test.rb
@@ -267,4 +267,11 @@ class SubmissionTest < ActiveSupport::TestCase
     ExceptionNotifier.expects(:notify_exception).with { |_e, data| data[:data][:url].present? }
     submission.update(status: :"internal error")
   end
+
+  test 'file is removed when submission is destroyed' do
+    submission = create :submission
+    assert File.exist?(submission.fs_path)
+    submission.destroy
+    assert_not File.exist?(submission.fs_path)
+  end
 end


### PR DESCRIPTION
This pull request reduces the duration of executing the test suite:

- The slowest test was the `CoursesPermissionControllerTest`, where one test case took 72s to execute. Since this is a permission test, I have modified the test to send requests over the API instead of rendering HTML.

- The setup phase of the `CoursesPermissionControllerTest` executes 2732 queries, every time, maybe this can be reduced since not every test case requires so much data. Unless necessary, we now don't create as much series, exercises & series

- [x] Heatmap & punchard tests use 50 or 100 submissions. Could this be reduced to 5 or 10 for example, or is this needed for batch tests?

### Current results (measured on Github Actions)
- Time needed on `develop`: 3m50
- Time needed here: 2m35