### PR TITLE
Fix empty actions menu at searchbar

### DIFF
--- a/app/views/layouts/_searchbar.html.erb
+++ b/app/views/layouts/_searchbar.html.erb
@@ -12,13 +12,15 @@
         <div class="auxbar bar bar3" style="width: 0%;"></div>
       </div>
     </form>
-    <div class="btn-group hidden actions" id="kebab-menu">
-      <a class="btn btn-icon dropdown-toggle" data-toggle="dropdown">
-        <i class="mdi mdi-dots-vertical"></i>
-      </a>
-      <ul class="dropdown-menu dropdown-menu-right">
-      </ul>
-    </div>
+    <% if local_assigns[:actions]&.any? %>
+      <div class="btn-group hidden actions" id="kebab-menu">
+        <a class="btn btn-icon dropdown-toggle" data-toggle="dropdown">
+          <i class="mdi mdi-dots-vertical"></i>
+        </a>
+        <ul class="dropdown-menu dropdown-menu-right">
+        </ul>
+      </div>
+    <% end %>
   </div>
 </div>
 


### PR DESCRIPTION
This PR fixes an odd visual bug, where the actions menu next to a sidebar shows up empty if there are no actions.

![image](https://user-images.githubusercontent.com/6131398/79594892-2cbe8580-80de-11ea-9b30-7ed8a65003df.png)
