### PR TITLE
Stricter asserts for system tests

### DIFF
--- a/test/system/annotations_test.rb
+++ b/test/system/annotations_test.rb
@@ -100,7 +100,6 @@ class AnnotationsTest < ApplicationSystemTestCase
     end
 
     assert_no_css '.annotation'
-    # assert all('.annotation').empty?
     assert_no_css 'form.annotation-submission'
   end
 


### PR DESCRIPTION
This pull request modifies the previously made code to include stricter asserts. Mostly scoping the assert_text to an `.annotation` block. Also added some page reloads to check if operations fail properly

- [x] Tests were modified

Closes #1854 .
