### PR TITLE
Fix hiding of correct tests on exercise page

### DIFF
--- a/app/assets/javascripts/submission.js
+++ b/app/assets/javascripts/submission.js
@@ -28,7 +28,7 @@ function initSubmissionShow(parentClass, mediaPath, token) {
         const buttons = $(".correct-switch-buttons .btn");
         buttons.click(e => {
             const button = $(e.currentTarget);
-            const tab = button.parents(".tab-pane");
+            const tab = button.parents(".feedback-tab-pane");
             const tabButtons = tab.find(".correct-switch-buttons .btn");
             tabButtons.removeClass("active");
             button.addClass("active");

--- a/app/helpers/renderers/feedback_table_renderer.rb
+++ b/app/helpers/renderers/feedback_table_renderer.rb
@@ -113,7 +113,7 @@ class FeedbackTableRenderer
   end
 
   def tab(t, i)
-    @builder.div(class: "tab-pane #{'active' if i.zero?}", id: "#{(t[:description] || 'test').parameterize}-#{i}") do
+    @builder.div(class: "tab-pane feedback-tab-pane #{'active' if i.zero?}", id: "#{(t[:description] || 'test').parameterize}-#{i}") do
       tab_content(t)
     end
   end


### PR DESCRIPTION
This pull request fixes the behaviour of hiding correct tests on the exercise page. The code looked for parents with the class `tab-pane`, but on the exercise page this found too much elements (because we have nested tabs there). The intended behaviour was that the only the correct tests of the current tab are hidden, which is now restored.

Closes #1789.
