### PR TITLE
Clamp line number of annotation to line count of code

### DIFF
--- a/app/assets/javascripts/code_listing/code_listing.ts
+++ b/app/assets/javascripts/code_listing/code_listing.ts
@@ -187,7 +187,7 @@ export class CodeListing {
     }
 
     private appendAnnotationToTable(annotation: Annotation): void {
-        const line = annotation.line;
+        const line = Math.min(annotation.line, this.codeLines);
         const row = this.table.querySelector<HTMLTableRowElement>(`#line-${line}`);
 
         const cell = row.querySelector<HTMLDivElement>(`#annotation-cell-${line}`);
@@ -267,11 +267,12 @@ export class CodeListing {
     // /////////////////////////////////////////////////////////////////////////
 
     public hideAnnotations(keepImportant = false): void {
-        this.annotations.forEach((annotations, line) => {
+        this.annotations.forEach((annotations, _line) => {
             // Do not hide global annotations.
-            if (line === 0) {
+            if (_line === 0) {
                 return;
             }
+            const line = Math.min(_line, this.codeLines);
 
             // Find the dot for this line.
             const dot = this.table.querySelector<HTMLSpanElement>(`#dot-${line}`);


### PR DESCRIPTION
This pull request makes sure that annotations with a line number higher than the line count of the code are still shown. Problematic submissions now look like this:

![screenshot_2020-04-21-101554](https://user-images.githubusercontent.com/42220376/79842545-43ecc400-83b9-11ea-9b39-617a6ddaa31c.png)

Hiding/unhiding works as expected.

I also tested that user annotations with a line number that is too high are shown correctly as well and can be edited/deleted/etc.
