### PR TITLE
Fix copy button location

### DIFF
--- a/app/assets/stylesheets/components/code_listing.css.less
+++ b/app/assets/stylesheets/components/code_listing.css.less
@@ -8,6 +8,7 @@
 
     .copy-btn {
       margin-right: 5px;
+      margin-top: 5px;
       position: absolute;
       right: 1px;
       top: 0;


### PR DESCRIPTION
It sticks to the top of the listing now.

Before:
![before](https://user-images.githubusercontent.com/994166/79847231-b660a280-83bf-11ea-9046-93a7b931947a.png)


After:
![after](https://user-images.githubusercontent.com/994166/79847239-b95b9300-83bf-11ea-8b40-cb0ba9a7f00d.png)

