### PR TITLE
Fix code not being initialised in code listing sometimes

### DIFF
--- a/app/helpers/renderers/feedback_code_renderer.rb
+++ b/app/helpers/renderers/feedback_code_renderer.rb
@@ -27,8 +27,7 @@ class FeedbackCodeRenderer
       @builder.script(type: 'application/javascript') do
         @builder << <<~HEREDOC
           $(() => {
-            window.dodona.submissionCode#{@instance} = #{@code.to_json};
-            window.dodona.attachClipboard("#copy-to-clipboard-#{@instance}", window.dodona.submissionCode#{@instance});
+            window.dodona.attachClipboard("#copy-to-clipboard-#{@instance}", #{@code.to_json});
           });
         HEREDOC
       end
@@ -82,7 +81,7 @@ class FeedbackCodeRenderer
     @builder.script(type: 'application/javascript') do
       @builder << <<~HEREDOC
         $(() => {
-          window.dodona.codeListing = new window.dodona.codeListingClass(#{submission.id}, window.dodona.submissionCode#{@instance}, #{@code.lines.length});
+          window.dodona.codeListing = new window.dodona.codeListingClass(#{submission.id}, #{@code.to_json}, #{@code.lines.length});
           window.dodona.codeListing.addMachineAnnotations(#{messages.map { |o| Hash[o.each_pair.to_a] }.to_json});
           #{'window.dodona.codeListing.initAnnotateButtons();' if user_may_annotate}
           window.dodona.codeListing.loadUserAnnotations();


### PR DESCRIPTION
As far as I can tell, the order in which the functions in jquery `$()` calls are executed is not defined. This removes the dependency of the second script in the `feedback_code_renderer` on the first script by just including the code twice instead of storing it in a variable.

Closes #1879.
