### PR TITLE
Disable forgery protection again on exercises#media

### DIFF
--- a/app/controllers/exercises_controller.rb
+++ b/app/controllers/exercises_controller.rb
@@ -6,6 +6,7 @@ class ExercisesController < ApplicationController
   before_action :set_series, only: %i[show edit update info]
   before_action :ensure_trailing_slash, only: :show
   before_action :allow_iframe, only: %i[description]
+  skip_before_action :verify_authenticity_token, only: [:media]
   skip_before_action :redirect_to_default_host, only: %i[description media]
 
   has_scope :by_filter, as: 'filter'

--- a/app/controllers/exercises_controller.rb
+++ b/app/controllers/exercises_controller.rb
@@ -6,6 +6,7 @@ class ExercisesController < ApplicationController
   before_action :set_series, only: %i[show edit update info]
   before_action :ensure_trailing_slash, only: :show
   before_action :allow_iframe, only: %i[description]
+  # Some exercise descriptions load JavaScript from their description. Rails has extra protections against loading unprivileged javascript.
   skip_before_action :verify_authenticity_token, only: [:media]
   skip_before_action :redirect_to_default_host, only: %i[description media]
 


### PR DESCRIPTION
Rails has extra protections against the unpriviliged loading of JavaScript. There are exercises that load javascript from their media directory.

Error message: `Security warning: an embedded <script> tag on another site requested protected JavaScript. If you know what you're doing, go ahead and disable forgery protection on this action to permit cross-origin JavaScript embedding.`