### PR TITLE
Also see SIGABRT as a judge error that shouldn't result in an internal error

### DIFF
--- a/app/runners/submission_runner.rb
+++ b/app/runners/submission_runner.rb
@@ -179,7 +179,7 @@ class SubmissionRunner
       ]
     end
 
-    if [0, 137, 143].exclude? exit_status
+    if [0, 134, 137, 143].exclude? exit_status
       return build_error 'internal error', 'internal error', [
         build_message("Judge exited with status code #{exit_status}.", 'staff', 'plain'),
         build_message('Standard Error:', 'staff', 'plain'),
@@ -194,7 +194,7 @@ class SubmissionRunner
       rc.feed(stdout.force_encoding('utf-8'))
       rc.result(timeout)
              rescue ResultConstructorError => e
-               if [137, 143].include? exit_status
+               if [134, 137, 143].include? exit_status
                  description = timeout ? 'time limit exceeded' : 'memory limit exceeded'
                  build_error description, description, [
                    build_message("Judge exited with <strong>status code #{exit_status}.</strong>", 'staff', 'html'),


### PR DESCRIPTION
The JS judge exits with SIGABRT in the case of an out of memory error. This should thus fix the recent internal errors due to out of memory errors in the JavaScript judge (the internal errors we get since https://github.com/dodona-edu/judge-javascript/pull/56 are due to high memory usage in the student code). The current signals we whitelist are SIGKILL and SIGTERM, so SIGABRT seems reasonable to me as well.

I also propose that we hotfix this, due to this happening quite often recently.
