### PR TITLE
Make delayed cache invalidation a special case

### DIFF
--- a/app/models/concerns/cacheable.rb
+++ b/app/models/concerns/cacheable.rb
@@ -20,6 +20,11 @@ module Cacheable
 
       define_method("invalidate_#{name}".to_sym) do |options = {}|
         lookup_string = cache_string.call(self, options)
+        Rails.cache.delete(lookup_string)
+      end
+
+      define_method("invalidate_delayed_#{name}".to_sym) do |options = {}|
+        lookup_string = cache_string.call(self, options)
         value = Rails.cache.read(lookup_string)
         Rails.cache.write(lookup_string, [true, value[1]], expires_in: CACHE_EXPIRY_TIME) if value.present? && !value[0]
       end

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -261,8 +261,8 @@ class Submission < ApplicationRecord
   end
 
   def invalidate_caches
-    exercise.invalidate_users_correct
-    exercise.invalidate_users_tried
+    exercise.invalidate_delayed_users_correct
+    exercise.invalidate_delayed_users_tried
     user.invalidate_attempted_exercises
     user.invalidate_correct_exercises
 
@@ -279,9 +279,9 @@ class Submission < ApplicationRecord
     end
 
     # Invalidate other statistics.
-    course.invalidate_correct_solutions
-    exercise.invalidate_users_correct(course: course)
-    exercise.invalidate_users_tried(course: course)
+    course.invalidate_delayed_correct_solutions
+    exercise.invalidate_delayed_users_correct(course: course)
+    exercise.invalidate_delayed_users_tried(course: course)
     user.invalidate_attempted_exercises(course: course)
     user.invalidate_correct_exercises(course: course)
   end


### PR DESCRIPTION
This pull request renames the `invalidate_` method in the `cacheable` concern to `invalidate_delayed_` and adds an `invalidate_` method that does immediate invalidation. For the course-level statistics that change often, the `invalidate_delayed_` method is used.
