### PR TITLE
Recalculate ExerciseStatus fully after submission update

### DIFF
--- a/app/models/exercise_status.rb
+++ b/app/models/exercise_status.rb
@@ -33,13 +33,9 @@ class ExerciseStatus < ApplicationRecord
     started && !accepted?
   end
 
-  def update_values(submission)
-    updates = { accepted: submission.accepted?, started: true }
-    updates[:accepted_before_deadline] = submission.accepted? if series.blank? || series&.deadline&.future?
-    updates[:solved] = solved || submission.accepted?
-    updates[:solved_at] = submission.created_at if submission.accepted? && !solved
-
-    update updates
+  def update_values
+    initialise_values
+    save
   end
 
   private

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -255,9 +255,9 @@ class Submission < ApplicationRecord
   end
 
   def update_exercise_status
-    exercise.exercise_statuses_for(user, course).each do |exercise_status|
-      exercise_status.update_values(self)
-    end
+    return if status.in?(%i[queued running])
+
+    exercise.exercise_statuses_for(user, course).each(&:update_values)
   end
 
   def invalidate_caches


### PR DESCRIPTION
This pull request changes the behaviour of the `update_values` method in `ExerciseStatus` to always recalculate the full model. Rejudges make trying to do granular update very hard to impossible.

It also only does this when the submission has finished judging, since this will then always be done in the background and this extra calculation cost will thus not be seen by users.

Closes #1887.
