### PR TITLE
Allow 'readme.md' and 'about.md' as about file

### DIFF
--- a/app/models/exercise.rb
+++ b/app/models/exercise.rb
@@ -134,25 +134,26 @@ class Exercise < ApplicationRecord
     (description_localized || description_nl || description_en || '').force_encoding('UTF-8').scrub
   end
 
-  def about_file(lang)
-    full_path + "about.#{lang}.md"
-  end
+  def about_by_precedence(lang = I18n.locale.to_s)
+    files = full_path
+            .children
+            .filter { |path| path.file? && path.readable? }
+            .index_by { |path| [path.basename.to_s.downcase, path] }
 
-  def about_localized(lang = I18n.locale.to_s)
-    file = about_file(lang)
-    file.read if file.exist?
-  end
+    first_matching = [
+      "about.#{lang}.md",
+      'about.md',
+      'readme.md',
+      'readme',
+      'about.nl.md',
+      'about.en.md'
+    ].find { |fname| files.key?(fname) }
 
-  def about_nl
-    about_localized('nl')
-  end
-
-  def about_en
-    about_localized('en')
+    files[first_matching]&.read
   end
 
   def about
-    (about_localized || about_nl || about_en || '').force_encoding('UTF-8').scrub
+    (about_by_precedence || '').force_encoding('UTF-8').scrub
   end
 
   def boilerplate_localized(lang = I18n.locale.to_s)

--- a/app/models/exercise.rb
+++ b/app/models/exercise.rb
@@ -138,7 +138,7 @@ class Exercise < ApplicationRecord
     files = full_path
             .children
             .filter { |path| path.file? && path.readable? }
-            .index_by { |path| [path.basename.to_s.downcase, path] }
+            .index_by { |path| path.basename.to_s.downcase }
 
     first_matching = [
       "about.#{lang}.md",

--- a/app/models/exercise.rb
+++ b/app/models/exercise.rb
@@ -135,6 +135,8 @@ class Exercise < ApplicationRecord
   end
 
   def about_by_precedence(lang = I18n.locale.to_s)
+    return unless full_path.exist?
+
     files = full_path
             .children
             .filter { |path| path.file? && path.readable? }

--- a/test/models/exercise_test.rb
+++ b/test/models/exercise_test.rb
@@ -518,6 +518,8 @@ class ExerciseRemoteTest < ActiveSupport::TestCase
     @repository = create :repository, remote: @remote.path
     @repository.process_exercises
     @exercise = @repository.exercises.first
+    @about_nl_path = @exercise.full_path.join('about.nl.md')
+    @about_en_path = @exercise.full_path.join('README.md')
   end
 
   teardown do
@@ -621,6 +623,39 @@ class ExerciseRemoteTest < ActiveSupport::TestCase
   test 'config_file? should be false if exercise has no config file' do
     @exercise.path = '/wrong_path'
     assert_not @exercise.config_file?
+  end
+
+  test 'about should give a localized result for en' do
+    I18n.with_locale :en do
+      assert_equal File.read(@about_en_path), @exercise.about
+    end
+  end
+
+  test 'about should give a localized result for nl' do
+    I18n.with_locale :nl do
+      assert_equal File.read(@about_nl_path), @exercise.about
+    end
+  end
+
+  test 'about should fallback to other language if localized is unavailable' do
+    FileUtils.rm @about_en_path
+    I18n.with_locale :en do
+      assert_equal File.read(@about_nl_path), @exercise.about
+    end
+  end
+
+  test 'about can be in about.md' do
+    about = File.read @about_en_path
+    FileUtils.rm @about_nl_path
+    FileUtils.mv @about_en_path, @exercise.full_path.join('about.md')
+    assert_equal about, @exercise.about
+  end
+
+  test 'about can be in README' do
+    about = File.read @about_en_path
+    FileUtils.rm @about_nl_path
+    FileUtils.mv @about_en_path, @exercise.full_path.join('README')
+    assert_equal about, @exercise.about
   end
 end
 

--- a/test/remotes/exercises/echo/echo/README.md
+++ b/test/remotes/exercises/echo/echo/README.md
@@ -1,0 +1,3 @@
+# Echo exercise
+
+This is some information about the echo exercise.

--- a/test/remotes/exercises/echo/echo/about.nl.md
+++ b/test/remotes/exercises/echo/echo/about.nl.md
@@ -1,0 +1,3 @@
+# Echo oefening
+
+Dit is wat informatie over de oefening 'echo'.


### PR DESCRIPTION
This pull request adds `README.md`, and `about.md` to the possible locations of the about file. The localized files `about.nl.md` and `about.en.md` files still take precedence over these other possibilities.

- [X] Tests were added
- [X] Documentation update can be found at dodona-edu/dodona-edu.github.io#48

Closes #1894.
