### PR TITLE
Nullify user email

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -112,6 +112,7 @@ class User < ApplicationRecord
   before_save :split_last_name, unless: :first_name?, if: :last_name?
   before_update :check_permission_change
   before_save :nullify_empty_username
+  before_save :nullify_empty_email
 
   scope :by_permission, ->(permission) { where(permission: permission) }
   scope :by_institution, ->(institution) { where(institution: institution) }
@@ -297,6 +298,10 @@ class User < ApplicationRecord
 
   def check_permission_change
     Event.create(event_type: :permission_change, user: self, message: "Granted #{permission}#{Current.user ? " by #{Current.user.full_name} (id: #{Current.user.id})" : ''}") if permission_changed?
+  end
+
+  def nullify_empty_email
+    self.email = nil if email.blank?
   end
 
   def nullify_empty_username


### PR DESCRIPTION
This pull request fixes a bug where a user's `update_from_oauth` would set their email to the empty string (instead of `nil`).   PR #1793 made a `index_users_on_email` which required uniqueness, throwing an error when a smartschool user without email would log in. A test was added to reproduce this behavior.

This bug is fixed by adding a `nullify_empty_email` callback before a record is saved.

When this is merged, I suggest clearing users with an empty string email by running `User.where(email: '').update(email: nil)`.


