### PR TITLE
Fix submission export

### DIFF
--- a/app/views/exports/_selection_table.html.erb
+++ b/app/views/exports/_selection_table.html.erb
@@ -34,8 +34,8 @@
                       total: data[:course].subscribed_members_count,
                       tried: el.users_tried(course: data[:course]),
                       correct: el.users_correct(course: data[:course]),
-                      info_tried: 'exercises.index.progress_chart_info_tried',
-                      info_correct: 'exercises.index.progress_chart_info_correct'
+                      info_tried: 'activities.index.progress_chart_info_tried',
+                      info_correct: 'activities.index.progress_chart_info_correct'
                   }
               %>
             </td>


### PR DESCRIPTION
Not much to fix here, IMO. Only some translation keys that weren't updated.

Export selection of a series that looks like this:
![image](https://user-images.githubusercontent.com/42220376/80289110-d7692080-873c-11ea-8439-62342db64a95.png)
Looks like this:
![image](https://user-images.githubusercontent.com/42220376/80289116-e059f200-873c-11ea-9fa2-886987bdafd7.png)

Which I would think is the correct behaviour. Export itself uses exercises as well, and only uses submissions.
