### PR TITLE
Add users read to activity

### DIFF
--- a/app/models/activity_read_state.rb
+++ b/app/models/activity_read_state.rb
@@ -20,6 +20,7 @@ class ActivityReadState < ApplicationRecord
   scope :of_user, ->(user) { where user_id: user.id }
 
   def invalidate_caches
+    activity.invalidate_delayed_users_read
     activity.activity_statuses_for(user, course).each(&:update_values)
     user.invalidate_attempted_exercises
     user.invalidate_correct_exercises
@@ -37,6 +38,7 @@ class ActivityReadState < ApplicationRecord
     end
 
     # Invalidate other statistics.
+    activity.invalidate_delayed_users_read(course: course)
     course.invalidate_delayed_correct_solutions
     user.invalidate_attempted_exercises(course: course)
     user.invalidate_correct_exercises(course: course)

--- a/test/factories/activity_read_state.rb
+++ b/test/factories/activity_read_state.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :activity_read_state do
+    activity
+    user
+  end
+end

--- a/test/factories/activity_statuses.rb
+++ b/test/factories/activity_statuses.rb
@@ -15,6 +15,6 @@
 #  updated_at               :datetime         not null
 #
 FactoryBot.define do
-  factory :exercise_status do
+  factory :activity_status do
   end
 end

--- a/test/models/activity_test.rb
+++ b/test/models/activity_test.rb
@@ -34,6 +34,32 @@ class ActivityTest < ActiveSupport::TestCase
     assert_not_nil @exercise
   end
 
+  test 'users_read' do
+    e = create :exercise
+    course1 = create :course
+    create :series, course: course1, exercises: [e]
+    course2 = create :course
+    create :series, course: course2, exercises: [e]
+
+    user_c1 = create :user, courses: [course1]
+
+    assert_equal 0, e.users_read
+    assert_equal 0, e.users_read(course: course1)
+    assert_equal 0, e.users_read(course: course2)
+
+    # Create activity read state for unscoped exercise.
+    create :activity_read_state, user: user_c1, activity: e
+    assert_equal 1, e.users_read
+    assert_equal 0, e.users_read(course: course1)
+    assert_equal 0, e.users_read(course: course2)
+
+    # Create activity read state for course 1.
+    create :activity_read_state, user: user_c1, course: course1, activity: e
+    assert_equal 1, e.users_read
+    assert_equal 1, e.users_read(course: course1)
+    assert_equal 0, e.users_read(course: course2)
+  end
+
   test 'converting an exercise to a content page and back should retain submissions' do
     exercise = create :exercise, submission_count: 10
     exercise_id = exercise.id


### PR DESCRIPTION
This pull request adds a cached `users_read` method to an activity. This can be used to fix the progress bars for content pages later on.

- [x] Tests were added.