### PR TITLE
Allow marking content page as read

### DIFF
--- a/app/assets/stylesheets/components/btn.css.less
+++ b/app/assets/stylesheets/components/btn.css.less
@@ -175,6 +175,33 @@
   }
 }
 
+.btn-fab-extended-right {
+  display: flex;
+  height: 42px;
+  border-radius: 24px;
+  font-size: 14px;
+  line-height: 36px;
+  padding-left: 20px;
+  text-transform: uppercase;
+
+  .icon {
+    padding-left: 12px;
+    padding-top: 4px;
+  }
+
+  @media (max-width: 480px) {
+    padding-left: 8px;
+    padding-right: 8px;
+    .text {
+      display: none;
+    }
+
+    .icon {
+      padding-left: 0;
+    }
+  }
+}
+
 .btn-toggle {
   .btn {
     border: 1px solid @toggle-btn-border;

--- a/app/assets/stylesheets/components/btn.css.less
+++ b/app/assets/stylesheets/components/btn.css.less
@@ -156,6 +156,24 @@
   line-height: 36px;
   padding-right: 20px;
   text-transform: uppercase;
+  white-space: nowrap;
+
+  &.right{
+    padding-right: 0;
+    padding-left: 20px;
+    
+    .icon {
+      padding-left: 12px;
+      padding-right: 0;
+      padding-top: 4px;
+    }
+
+    @media (max-width: 480px) {
+      .icon {
+        padding-left: 0;
+      }
+    }
+  }
 
   .icon {
     padding-right: 12px;
@@ -171,33 +189,6 @@
 
     .icon {
       padding-right: 0;
-    }
-  }
-}
-
-.btn-fab-extended-right {
-  display: flex;
-  height: 42px;
-  border-radius: 24px;
-  font-size: 14px;
-  line-height: 36px;
-  padding-left: 20px;
-  text-transform: uppercase;
-
-  .icon {
-    padding-left: 12px;
-    padding-top: 4px;
-  }
-
-  @media (max-width: 480px) {
-    padding-left: 8px;
-    padding-right: 8px;
-    .text {
-      display: none;
-    }
-
-    .icon {
-      padding-left: 0;
     }
   }
 }

--- a/app/assets/stylesheets/components/btn.css.less
+++ b/app/assets/stylesheets/components/btn.css.less
@@ -168,7 +168,7 @@
       padding-top: 4px;
     }
 
-    @media (max-width: 480px) {
+    @media (max-width: 768px) {
       .icon {
         padding-left: 0;
       }
@@ -180,7 +180,7 @@
     padding-top: 4px;
   }
 
-  @media (max-width: 480px) {
+  @media (max-width: 768px) {
     padding-left: 8px;
     padding-right: 8px;
     .text {

--- a/app/assets/stylesheets/models/activities.css.less
+++ b/app/assets/stylesheets/models/activities.css.less
@@ -83,6 +83,25 @@
   margin-left: 16px;
 }
 
+.content-page-actions {
+  display: flex;
+  padding-bottom: 16px;
+
+  .content-page-action {
+    display: flex;
+    flex: 1;
+    justify-content: center;
+
+    :first-child {
+      margin-right: auto;
+    }
+
+    :last-child {
+      margin-left: auto;
+    }
+  }
+}
+
 .footnotes::before {
   content: "";
   width: 150px;

--- a/app/assets/stylesheets/models/activities.css.less
+++ b/app/assets/stylesheets/models/activities.css.less
@@ -84,21 +84,21 @@
 }
 
 .content-page-actions {
-  display: flex;
   padding-bottom: 16px;
+  text-align: center;
 
-  .content-page-action {
-    display: flex;
-    flex: 1;
-    justify-content: center;
+  .btn-fab-extended {
+    display: inline-flex;
+  }
 
-    :first-child {
-      margin-right: auto;
-    }
+  .previous {
+    position: absolute;
+    left: 10px;
+  }
 
-    :last-child {
-      margin-left: auto;
-    }
+  .next {
+    position: absolute;
+    right: 10px;
   }
 }
 

--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -123,7 +123,10 @@ class ActivitiesController < ApplicationController
                                        user: current_user
     can_read = @activity.read_state_for(current_user, @course).blank?
     if can_read && read_state.save
-      render json: { status: 'ok', activity_id: read_state.activity_id, course_id: read_state.course_id }
+      respond_to do |format|
+        format.js { render 'activities/read', locals: { activity: @activity, course: @course, user: current_user } }
+        format.json { head :ok }
+      end
     else
       read_state.errors.add(:activity, 'already read') unless can_read
       render json: { status: 'failed', errors: read_state.errors }, status: :unprocessable_entity

--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -122,6 +122,7 @@ class ActivitiesController < ApplicationController
                                        course: @course,
                                        user: current_user
     can_read = @activity.read_state_for(current_user, @course).blank?
+    can_read &&= @activity.accessible?(current_user, course)
     if can_read && read_state.save
       respond_to do |format|
         format.js { render 'activities/read', locals: { activity: @activity, course: @course, user: current_user } }

--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -179,12 +179,6 @@ class ActivitiesController < ApplicationController
   def set_activity
     @activity = Activity.find(params[:id])
     authorize @activity
-    @activity = case @activity.type
-                when ContentPage.name
-                  @activity.becomes(ContentPage)
-                when Exercise.name
-                  @activity.becomes(Exercise)
-                end
   end
 
   def set_course

--- a/app/policies/activity_policy.rb
+++ b/app/policies/activity_policy.rb
@@ -64,6 +64,15 @@ class ActivityPolicy < ApplicationPolicy
     false
   end
 
+  def read?
+    return false if record.removed?
+    return false if user.blank?
+    return true if user.admin?
+    return true if record.ok?
+
+    false
+  end
+
   def permitted_attributes
     if update?
       %i[access name_nl name_en]

--- a/app/policies/course_policy.rb
+++ b/app/policies/course_policy.rb
@@ -45,6 +45,10 @@ class CoursePolicy < ApplicationPolicy
     user && show?
   end
 
+  def read?
+    user && user&.member_of?(record)
+  end
+
   def update?
     course_admin?
   end

--- a/app/views/activities/_content_page_read_button.erb
+++ b/app/views/activities/_content_page_read_button.erb
@@ -1,0 +1,15 @@
+<% # arguments: activity (Activity), course (Course) | nil), user (User) %>
+<% read_state = activity.read_state_for(user, course) %>
+<% if read_state.present? %>
+  <span>
+    <i class="mdi mdi-check icon"></i>
+    <%= t('activities.show.read_at', timestamp: l(read_state.created_at, format: :long)) %>
+  </span>
+<% else %>
+  <% read_url = read_activity_url(activity) %>
+  <% read_url = read_course_activity_url(course, activity) if course.present? %>
+  <%= link_to read_url, method: :post, remote: true, class: 'btn btn-primary with-text btn-fab-extended' do %>
+    <i class="mdi mdi-clipboard-check-outline icon"></i>
+    <span class="text"><%= t('activities.show.mark_as_read') %></span>
+  <% end %>
+<% end %>

--- a/app/views/activities/_content_page_read_button.erb
+++ b/app/views/activities/_content_page_read_button.erb
@@ -2,14 +2,16 @@
 <% read_state = activity.read_state_for(user, course) %>
 <% if read_state.present? %>
   <span>
-    <i class="mdi mdi-check icon"></i>
+    <i class="mdi mdi-check icon colored-correct"></i>
     <%= t('activities.show.read_at', timestamp: l(read_state.created_at, format: :long)) %>
   </span>
 <% else %>
-  <% read_url = read_activity_url(activity) %>
-  <% read_url = read_course_activity_url(course, activity) if course.present? %>
-  <%= link_to read_url, method: :post, remote: true, class: 'btn btn-primary with-text btn-fab-extended' do %>
-    <i class="mdi mdi-clipboard-check-outline icon"></i>
-    <span class="text"><%= t('activities.show.mark_as_read') %></span>
-  <% end %>
+  <span id='content_page_read_action'>
+    <% read_url = read_activity_url(activity) %>
+    <% read_url = read_course_activity_url(course, activity) if course.present? %>
+    <%= link_to read_url, method: :post, remote: true, class: 'btn btn-primary with-text btn-fab-extended' do %>
+      <i class="mdi mdi-clipboard-check-outline icon"></i>
+      <span class="text"><%= t('activities.show.mark_as_read') %></span>
+    <% end %>
+  </span>
 <% end %>

--- a/app/views/activities/read.js.erb
+++ b/app/views/activities/read.js.erb
@@ -1,0 +1,1 @@
+$("#content_page_read_action").html("<%= escape_javascript(render partial: 'activities/content_page_read_button', locals: {activity: activity, course: course, user: user}) %>");

--- a/app/views/activities/show.html.erb
+++ b/app/views/activities/show.html.erb
@@ -119,31 +119,30 @@ end %>
   </div>
 </div>
 <% elsif @activity.content_page? %>
-  <div class="row hidden-print">
-    <div class="col-sm-10 col-sm-offset-1 col-xs-12">
-      <div class="page-subtitle">
-        <% if @series.present? %>
-          <%= link_to previous_link, class: 'btn-fab-extended' do %>
-            <i class="mdi mdi-chevron-left icon"></i><span class="text"><%= previous_tooltip %></span>
-          <% end %>
-          <div class="flex-spacer"></div>
+<div class="row hidden-print">
+  <div class="col-sm-10 col-sm-offset-1 col-xs-12">
+    <div class="page-subtitle">
+      <% if @series.present? %>
+        <%= link_to previous_link, class: 'btn-fab-extended' do %>
+          <i class="mdi mdi-chevron-left icon"></i><span class="text"><%= previous_tooltip %></span>
         <% end %>
-        <a class="btn btn-primary with-text btn-fab-extended">
-          <i class="mdi mdi-clipboard-check-outline icon"></i>
-          <span class="text"><%= t('.mark_as_read') %></span>
-        </a>
-        <% if @series.present? %>
-          <div class="flex-spacer"></div>
-          <%= link_to next_link, class: 'btn-fab-extended' do %>
-            <i class="mdi mdi-chevron-right icon"></i><span class="text"><%= next_tooltip %></span>
-          <% end %>
+        <div class="flex-spacer"></div>
+      <% end %>
+      <% read_url = read_activity_url(@activity) %>
+      <% read_url = read_course_activity_url(@series&.course, @activity) if @series.present? %>
+      <%= link_to read_url, method: :post, remote: true, class: 'btn btn-primary with-text btn-fab-extended' do %>
+        <i class="mdi mdi-clipboard-check-outline icon"></i>
+        <span class="text"><%= t('.mark_as_read') %></span>
+      <% end %>
+      <% if @series.present? %>
+        <div class="flex-spacer"></div>
+        <%= link_to next_link, class: 'btn-fab-extended' do %>
+          <i class="mdi mdi-chevron-right icon"></i><span class="text"><%= next_tooltip %></span>
         <% end %>
-      </div>
-
-
-<!--      <span class="with-text btn-fab-extended" style="padding-right:20px;"><i class="mdi mdi-chevron-left icon"></i>vorige</span><div class="flex-spacer"></div><span class="btn with-text btn-primary btn-fab-extended" style="margin-left:auto;margin-right:auto"><i class="mdi mdi-playlist-edit icon"></i>markeren als gelezen</span><div class="flex-spacer"></div><span class="with-text btn-fab-extended" style="padding-left:20px;padding-right:0px;">volgende<i class="mdi mdi-chevron-right icon" style="padding-right:0px;"></i></span></div>-->
+      <% end %>
     </div>
   </div>
+</div>
 <% end %>
 <script type="text/javascript">
     $(function () {

--- a/app/views/activities/show.html.erb
+++ b/app/views/activities/show.html.erb
@@ -7,6 +7,14 @@
 <% end %>
 <%= render 'navbar_links' %>
 
+<% if @series.present?
+  previous_activity, next_activity = previous_next_activity_path(@series, @activity)
+  previous_link = previous_activity || breadcrumb_series_path(@series, current_user)
+  previous_tooltip = previous_activity ? t('.navigation.previous') : t('.navigation.back_to_course')
+  next_link = next_activity || breadcrumb_series_path(@series, current_user)
+  next_tooltip = next_activity ? t('.navigation.next') : t('.navigation.back_to_course')
+end %>
+
 <div class="row">
   <%= link_to '#submission-card', class: "btn btn-lg btn-down col-sm-1 hidden-xs hidden-print", title: t('.handin') do %>
     <span class='hidden-sm'><%= t('.handin') %></span><br>
@@ -19,13 +27,6 @@
           <%= @activity.name %>
         </h2>
         <% if @series.present? %>
-          <%
-            previous_activity, next_activity = previous_next_activity_path(@series, @activity)
-            previous_link = previous_activity || breadcrumb_series_path(@series, current_user)
-            previous_tooltip = previous_activity ? t('.navigation.previous') : t('.navigation.back_to_course')
-            next_link = next_activity || breadcrumb_series_path(@series, current_user)
-            next_tooltip = next_activity ? t('.navigation.next') : t('.navigation.back_to_course')
-          %>
           <div class="card-title-navigation hidden-print">
             <%= link_to previous_link, class: 'btn-icon-inverted', title: previous_tooltip, data: {toggle: 'tooltip', placement: 'top'} do %>
               <i class="mdi mdi-chevron-left"></i>
@@ -117,6 +118,32 @@
     </div>
   </div>
 </div>
+<% elsif @activity.content_page? %>
+  <div class="row hidden-print">
+    <div class="col-sm-10 col-sm-offset-1 col-xs-12">
+      <div class="page-subtitle">
+        <% if @series.present? %>
+          <%= link_to previous_link, class: 'btn-fab-extended' do %>
+            <i class="mdi mdi-chevron-left icon"></i><span class="text"><%= previous_tooltip %></span>
+          <% end %>
+          <div class="flex-spacer"></div>
+        <% end %>
+        <a class="btn btn-primary with-text btn-fab-extended">
+          <i class="mdi mdi-clipboard-check-outline icon"></i>
+          <span class="text"><%= t('.mark_as_read') %></span>
+        </a>
+        <% if @series.present? %>
+          <div class="flex-spacer"></div>
+          <%= link_to next_link, class: 'btn-fab-extended' do %>
+            <i class="mdi mdi-chevron-right icon"></i><span class="text"><%= next_tooltip %></span>
+          <% end %>
+        <% end %>
+      </div>
+
+
+<!--      <span class="with-text btn-fab-extended" style="padding-right:20px;"><i class="mdi mdi-chevron-left icon"></i>vorige</span><div class="flex-spacer"></div><span class="btn with-text btn-primary btn-fab-extended" style="margin-left:auto;margin-right:auto"><i class="mdi mdi-playlist-edit icon"></i>markeren als gelezen</span><div class="flex-spacer"></div><span class="with-text btn-fab-extended" style="padding-left:20px;padding-right:0px;">volgende<i class="mdi mdi-chevron-right icon" style="padding-right:0px;"></i></span></div>-->
+    </div>
+  </div>
 <% end %>
 <script type="text/javascript">
     $(function () {

--- a/app/views/activities/show.html.erb
+++ b/app/views/activities/show.html.erb
@@ -123,17 +123,13 @@ end %>
   <div class="col-sm-10 col-sm-offset-1 col-xs-12">
     <div class="content-page-actions">
       <% if @series.present? %>
-        <%= link_to previous_link, class: 'content-page-action btn-fab-extended' do %>
+        <%= link_to previous_link, class: 'content-page-action btn-fab-extended previous' do %>
           <i class="mdi mdi-chevron-left icon"></i><span class="text"><%= previous_tooltip %></span>
         <% end %>
-        <div class="flex-spacer"></div>
       <% end %>
-      <div class="content-page-action" id="content_page_read_action">
-        <%= render partial: 'content_page_read_button', locals: {activity: @activity, course: @series&.course, user: current_user} %>
-      </div>
+      <%= render partial: 'content_page_read_button', locals: {activity: @activity, course: @series&.course, user: current_user} %>
       <% if @series.present? %>
-        <div class="flex-spacer"></div>
-        <%= link_to next_link, class: 'content-page-action btn-fab-extended-right' do %>
+        <%= link_to next_link, class: 'content-page-action btn-fab-extended right next' do %>
           <span class="text"><%= next_tooltip %></span>
           <i class="mdi mdi-chevron-right icon"></i>
         <% end %>

--- a/app/views/activities/show.html.erb
+++ b/app/views/activities/show.html.erb
@@ -121,23 +121,21 @@ end %>
 <% elsif @activity.content_page? %>
 <div class="row hidden-print">
   <div class="col-sm-10 col-sm-offset-1 col-xs-12">
-    <div class="page-subtitle">
+    <div class="content-page-actions">
       <% if @series.present? %>
-        <%= link_to previous_link, class: 'btn-fab-extended' do %>
+        <%= link_to previous_link, class: 'content-page-action btn-fab-extended' do %>
           <i class="mdi mdi-chevron-left icon"></i><span class="text"><%= previous_tooltip %></span>
         <% end %>
         <div class="flex-spacer"></div>
       <% end %>
-      <% read_url = read_activity_url(@activity) %>
-      <% read_url = read_course_activity_url(@series&.course, @activity) if @series.present? %>
-      <%= link_to read_url, method: :post, remote: true, class: 'btn btn-primary with-text btn-fab-extended' do %>
-        <i class="mdi mdi-clipboard-check-outline icon"></i>
-        <span class="text"><%= t('.mark_as_read') %></span>
-      <% end %>
+      <div class="content-page-action" id="content_page_read_action">
+        <%= render partial: 'content_page_read_button', locals: {activity: @activity, course: @series&.course, user: current_user} %>
+      </div>
       <% if @series.present? %>
         <div class="flex-spacer"></div>
-        <%= link_to next_link, class: 'btn-fab-extended' do %>
-          <i class="mdi mdi-chevron-right icon"></i><span class="text"><%= next_tooltip %></span>
+        <%= link_to next_link, class: 'content-page-action btn-fab-extended-right' do %>
+          <span class="text"><%= next_tooltip %></span>
+          <i class="mdi mdi-chevron-right icon"></i>
         <% end %>
       <% end %>
     </div>

--- a/config/locales/views/activities/en.yml
+++ b/config/locales/views/activities/en.yml
@@ -72,6 +72,7 @@ en:
         back_to_course: Back to course overview
         previous: Previous exercise
         next: Next exercise
+      mark_as_read: Mark as read
     series_exercises_table:
       course_added_to_usable: "Adding this exercise will allow this course to use all private exercises in this exercise's repository. Are you sure?"
     edit:

--- a/config/locales/views/activities/en.yml
+++ b/config/locales/views/activities/en.yml
@@ -70,8 +70,8 @@ en:
       deadline_in_5_minutes: "The deadline for this exercise is at %{deadline}, which is less than 5 minutes away."
       navigation:
         back_to_course: Back to course
-        previous: Previous exercise
-        next: Next exercise
+        previous: Previous activity
+        next: Next activity
       mark_as_read: Mark as read
       read_at: "Marked as read at %{timestamp}"
     series_exercises_table:

--- a/config/locales/views/activities/en.yml
+++ b/config/locales/views/activities/en.yml
@@ -69,7 +69,7 @@ en:
       deadline_passed: "The deadline for this exercise was at %{deadline}. You can still submit, but your submissions may not be accounted for."
       deadline_in_5_minutes: "The deadline for this exercise is at %{deadline}, which is less than 5 minutes away."
       navigation:
-        back_to_course: Back to course overview
+        back_to_course: Back to course
         previous: Previous exercise
         next: Next exercise
       mark_as_read: Mark as read

--- a/config/locales/views/activities/en.yml
+++ b/config/locales/views/activities/en.yml
@@ -73,6 +73,7 @@ en:
         previous: Previous exercise
         next: Next exercise
       mark_as_read: Mark as read
+      read_at: "Marked as read at %{timestamp}"
     series_exercises_table:
       course_added_to_usable: "Adding this exercise will allow this course to use all private exercises in this exercise's repository. Are you sure?"
     edit:

--- a/config/locales/views/activities/nl.yml
+++ b/config/locales/views/activities/nl.yml
@@ -70,8 +70,8 @@ nl:
       deadline_in_5_minutes: "De deadline voor deze oefening is om %{deadline}, wat over minder dan 5 minuten is."
       navigation:
         back_to_course: Terug naar cursus
-        previous: Vorige oefening
-        next: Volgende oefening
+        previous: Vorige activiteit
+        next: Volgende activiteit
       mark_as_read: Markeren als gelezen
       read_at: "Gelezen op %{timestamp}"
     series_exercises_table:

--- a/config/locales/views/activities/nl.yml
+++ b/config/locales/views/activities/nl.yml
@@ -69,7 +69,7 @@ nl:
       deadline_passed: "De deadline voor deze oefening was om %{deadline}. Je kan nog steeds indienen, maar de lesgever houdt er mogelijk geen rekening meer mee."
       deadline_in_5_minutes: "De deadline voor deze oefening is om %{deadline}, wat over minder dan 5 minuten is."
       navigation:
-        back_to_course: Terug naar cursusoverzicht
+        back_to_course: Terug naar cursus
         previous: Vorige oefening
         next: Volgende oefening
       mark_as_read: Markeren als gelezen

--- a/config/locales/views/activities/nl.yml
+++ b/config/locales/views/activities/nl.yml
@@ -73,6 +73,7 @@ nl:
         previous: Vorige oefening
         next: Volgende oefening
       mark_as_read: Markeren als gelezen
+      read_at: "Gelezen op %{timestamp}"
     series_exercises_table:
       course_added_to_usable: "Deze oefening toevoegen zal deze cursus toegang geven tot alle privé oefeningen in de repository van deze oefening. Ben je zeker?"
     edit:

--- a/config/locales/views/activities/nl.yml
+++ b/config/locales/views/activities/nl.yml
@@ -72,6 +72,7 @@ nl:
         back_to_course: Terug naar cursusoverzicht
         previous: Vorige oefening
         next: Volgende oefening
+      mark_as_read: Markeren als gelezen
     series_exercises_table:
       course_added_to_usable: "Deze oefening toevoegen zal deze cursus toegang geven tot alle privé oefeningen in de repository van deze oefening. Ben je zeker?"
     edit:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,6 +35,12 @@ Rails.application.routes.draw do
       end
     end
 
+    concern :readable do
+      member do
+        post 'read'
+      end
+    end
+
     concern :submitable do
       resources :submissions, only: %i[index create]
     end
@@ -66,10 +72,10 @@ Rails.application.routes.draw do
 
     resources :courses do
       resources :series, only: %i[new index] do
-        resources :activities, only: %i[show edit update], concerns: %i[mediable submitable infoable]
+        resources :activities, only: %i[show edit update], concerns: %i[mediable readable submitable infoable]
         resources :activities, only: %i[show edit update], concerns: %i[submitable infoable], path: '/exercises'
       end
-      resources :activities, only: %i[show edit update], concerns: %i[mediable submitable infoable]
+      resources :activities, only: %i[show edit update], concerns: %i[mediable readable submitable infoable]
       resources :activities, only: %i[show edit update], concerns: %i[submitable infoable], path: '/exercises'
       resources :submissions, only: [:index]
       resources :members, only: %i[index show edit update], controller: :course_members do
@@ -93,7 +99,7 @@ Rails.application.routes.draw do
       end
     end
 
-    resources :activities, only: %i[index show edit update], concerns: %i[mediable submitable infoable] do
+    resources :activities, only: %i[index show edit update], concerns: %i[readable mediable submitable infoable] do
       member do
         scope 'description/:token/' do
           constraints host: Rails.configuration.sandbox_host do


### PR DESCRIPTION
This pull request adds a `Mark as read`-button to the bottom of a content page, as well as navigation buttons.

**Tasks:**
- [x] Implement mark-as-read controller action
- [x] Add button
- [x] Button is not centered
- [x] Chevron at "Next activity" is probably better off placed on the right
- [x] Add some visual feedback to indicate that the activity was successfully marked as read
- [x] Hide the button if the exercise was already read

**Consideration:**
If we were to implement "un-read", this would have to be implemented by destroying the ActivityReadState. However, this would imply that a user can miss a deadline after passing it first, or the other way around, since the ActivityStatus is just an ephemeral cache.