### PR TITLE
Enhance activity tests

### DIFF
--- a/app/models/activity_read_state.rb
+++ b/app/models/activity_read_state.rb
@@ -14,6 +14,8 @@ class ActivityReadState < ApplicationRecord
   belongs_to :course, optional: true
   belongs_to :user
 
+  validates :activity, uniqueness: { scope: %i[user_id course_id] }
+
   after_save :invalidate_caches
 
   scope :in_course, ->(course) { where course_id: course.id }

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -116,7 +116,7 @@ if Rails.env.development?
   contents_list = ContentPage.all.to_a
   exercises_list = Exercise.all.to_a
 
-  puts 'Add series, content pages, exercises and submissions to courses'
+  puts 'Add series, content pages, exercises, read states and submissions to courses'
 
   # Add contents and exercises to test course
   courses.each do |course|
@@ -147,6 +147,13 @@ if Rails.env.development?
     series.each do |s|
       series_contents = contents_list.sample(rand(3) + 2)
       s.content_pages << series_contents
+      series_contents.each do |content|
+        course.enrolled_members.sample(5).each do |student|
+          ActivityReadState.create user: student,
+                                   course: s.course,
+                                   activity: content
+        end
+      end
 
       series_exercises = exercises_list.sample(rand(3) + 2)
       s.exercises << series_exercises

--- a/test/controllers/series_controller_test.rb
+++ b/test/controllers/series_controller_test.rb
@@ -97,7 +97,7 @@ class SeriesControllerTest < ActionDispatch::IntegrationTest
 
   test 'should add activities to series' do
     stub_all_activities!
-    activity = create(:activity)
+    activity = create :exercise
     post add_activity_series_path(@instance),
          params: {
            format: 'application/javascript',
@@ -108,7 +108,7 @@ class SeriesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should remove activity from series' do
-    activity = create(:activity, series: [@instance])
+    activity = create(:exercise, series: [@instance])
     post remove_activity_series_path(@instance),
          params: {
            format: 'application/javascript',
@@ -119,13 +119,13 @@ class SeriesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'repository admin adding private activity to series should add course to repository\'s allowed courses' do
-    activity = create :activity, access: :private
+    activity = create :exercise, access: :private
     post add_activity_series_path @instance, params: { format: 'application/javascript', activity_id: activity.id }
     assert activity.repository.allowed_courses.include? @instance.course
   end
 
   test 'course admin should not be able to add private activity to series' do
-    activity = create :activity, access: :private
+    activity = create :exercise, access: :private
     user = create :user
     sign_in user
     @instance.course.administrating_members << user
@@ -134,7 +134,7 @@ class SeriesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should reorder activities' do
-    activities = create_list(:activity, 10, series: [@instance])
+    activities = create_list(:exercise, 10, series: [@instance])
     activities.shuffle!
     ids = activities.map(&:id)
     post reorder_activities_series_path @instance, params: { format: 'application/javascript', order: ids.to_json }
@@ -144,7 +144,7 @@ class SeriesControllerTest < ActionDispatch::IntegrationTest
 
   test 'missed deadlines should have correct class' do
     series = create :series, deadline: Time.zone.now - 1.day
-    create :activity, series: [series]
+    create :exercise, series: [series]
 
     get series_url(series)
 
@@ -154,7 +154,7 @@ class SeriesControllerTest < ActionDispatch::IntegrationTest
 
   test 'upcoming deadlines should have correct class' do
     series = create :series, deadline: Time.zone.now + 1.day
-    create :activity, series: [series]
+    create :exercise, series: [series]
 
     get series_url(series)
     assert_response :success

--- a/test/controllers/series_controller_test.rb
+++ b/test/controllers/series_controller_test.rb
@@ -352,7 +352,7 @@ class SeriesIndianioDownloadControllerTest < ActionDispatch::IntegrationTest
     @series.reload
     assert_zip response.body,
                with_info: true,
-               solution_count: @series.activities.count,
+               solution_count: @series.exercises.count,
                group_by: 'exercise',
                data: { exercises: @series.exercises }
   end

--- a/test/controllers/submissions_controller_test.rb
+++ b/test/controllers/submissions_controller_test.rb
@@ -115,11 +115,18 @@ class SubmissionsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test 'should not create submission for content page' do
+    attrs = generate_attr_hash
+    attrs[:exercise_id] = create(:content_page).id
+    create_request(attr_hash: attrs)
+    assert_response :unprocessable_entity
+  end
+
   test 'create submission should respond bad_request without an exercise' do
     attrs = generate_attr_hash
     attrs.delete(:exercise_id)
     create_request(attr_hash: attrs)
-    assert_response 422
+    assert_response :unprocessable_entity
   end
 
   test 'create submission within course' do

--- a/test/factories/activities.rb
+++ b/test/factories/activities.rb
@@ -1,5 +1,0 @@
-FactoryBot.define do
-  factory :activity do
-    initialize_with { create :exercise }
-  end
-end

--- a/test/factories/activity_read_state.rb
+++ b/test/factories/activity_read_state.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :activity_read_state do
-    activity
+    activity { content_page }
     user
   end
 end

--- a/test/factories/courses.rb
+++ b/test/factories/courses.rb
@@ -30,6 +30,8 @@ FactoryBot.define do
     transient do
       series_count { 0 }
       activities_per_series { 0 }
+      exercises_per_series { nil }
+      content_pages_per_series { nil }
       submissions_per_exercise { 0 }
       start_year { Time.zone.today.year }
     end
@@ -38,7 +40,12 @@ FactoryBot.define do
 
     after :create do |course, e|
       e.series_count.times do
-        create :series, course: course, activity_count: e.activities_per_series, exercise_submission_count: e.submissions_per_exercise
+        create :series,
+               course: course,
+               activity_count: e.activities_per_series,
+               exercise_count: e.exercises_per_series,
+               content_page_count: e.content_pages_per_series,
+               exercise_submission_count: e.submissions_per_exercise
       end
     end
   end

--- a/test/factories/series.rb
+++ b/test/factories/series.rb
@@ -30,8 +30,11 @@ FactoryBot.define do
 
     transient do
       activity_count { 0 }
+      exercise_count { nil }
+      content_page_count { nil }
       exercise_repositories do
-        create_list(:repository, 2, :git_stubbed) if activity_count.positive?
+        create_list(:repository, 2, :git_stubbed) if \
+          exercise_count.present? || content_page_count.present? || activity_count.positive?
       end
 
       exercise_submission_count { 0 }
@@ -41,12 +44,19 @@ FactoryBot.define do
     end
 
     after :create do |series, e|
-      e.activity_count.times do
+      content_page_count = e.content_page_count || e.activity_count / 2
+      exercise_count = e.exercise_count || (e.activity_count - content_page_count)
+      exercise_count.times do
         create :exercise,
                repository: e.exercise_repositories.sample,
                series: [series],
                submission_count: e.exercise_submission_count,
                submission_users: e.exercise_submission_users
+      end
+      content_page_count.times do
+        create :content_page,
+               repository: e.exercise_repositories.sample,
+               series: [series]
       end
       series.reload
     end

--- a/test/helpers/activity_helper_test.rb
+++ b/test/helpers/activity_helper_test.rb
@@ -6,7 +6,7 @@ class ActivityHelperTest < ActiveSupport::TestCase
 
   setup do
     course = create :course
-    @series = create :series, course: course, activity_count: 3
+    @series = create :series, course: course, exercise_count: 3
   end
 
   test 'previous activity at beginning of series should be nil' do

--- a/test/models/activity_read_state_test.rb
+++ b/test/models/activity_read_state_test.rb
@@ -1,0 +1,39 @@
+# == Schema Information
+#
+# Table name: activity_read_states
+#
+#  id          :bigint           not null, primary key
+#  activity_id :integer          not null
+#  course_id   :integer
+#  user_id     :integer          not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
+
+require 'test_helper'
+
+class ActivityReadStateTest < ActiveSupport::TestCase
+  test 'only one read state allowed for a combination of course - user - activity' do
+    series = create :series, content_page_count: 1
+    user = create :user, enrolled_courses: [series.course]
+
+    read_state = create :activity_read_state,
+                        user: user,
+                        course: series.course,
+                        activity: series.content_pages.first
+
+    assert_not_nil read_state
+    assert read_state.valid?
+
+    second_read_state = build :activity_read_state,
+                              user: user,
+                              course: series.course,
+                              activity: series.content_pages.first
+
+    assert_not second_read_state.valid?
+
+    # but we can make a new read state outside the course
+    second_read_state.course = nil
+    assert second_read_state.valid?
+  end
+end

--- a/test/models/course_test.rb
+++ b/test/models/course_test.rb
@@ -90,7 +90,7 @@ class CourseTest < ActiveSupport::TestCase
 
   test 'correct solutions should be updated for submission in course' do
     course = create :course
-    series = create :series, course: course, activity_count: 1
+    series = create :series, course: course, activity_count: 2
     user = create :user
 
     assert_equal 0, course.correct_solutions
@@ -112,7 +112,7 @@ class CourseTest < ActiveSupport::TestCase
 
   test 'correct solutions should not be updated for submission outside course' do
     course = create :course
-    series = create :series, course: course, activity_count: 1
+    series = create :series, course: course, activity_count: 2
     user = create :user
 
     assert_equal 0, course.correct_solutions
@@ -132,7 +132,10 @@ class CourseTest < ActiveSupport::TestCase
 
   test 'course scoresheet should be correct' do
     course = create :course
-    create_list :series, 2, course: course, activity_count: 2, deadline: Time.current
+    create_list :series, 2,
+                course: course,
+                exercise_count: 2,
+                deadline: Time.current
     content_pages = create_list :content_page, 2
     SeriesMembership.create(series: course.series.first, activity: content_pages.first)
     SeriesMembership.create(series: course.series.second, activity: content_pages.second)
@@ -224,7 +227,7 @@ class CourseTest < ActiveSupport::TestCase
   end
 
   test 'destroying course does not destroy submissions' do
-    course = create :course, series_count: 2, activities_per_series: 1, submissions_per_exercise: 2
+    course = create :course, series_count: 2, exercises_per_series: 1, submissions_per_exercise: 2
     assert_difference 'Submission.count', 0 do
       course.destroy
     end

--- a/test/models/series_test.rb
+++ b/test/models/series_test.rb
@@ -330,4 +330,53 @@ class SeriesTest < ActiveSupport::TestCase
            created_at: (deadline + 2.minutes)
     assert_equal false, series.completed?(user: user)
   end
+
+  test 'completed? with correct submission and unread content_page' do
+    series = create :series, exercise_count: 1, content_page_count: 1, deadline: Time.current
+    user = create :user
+
+    deadline = series.deadline
+    # Correct submission before deadline
+    create :correct_submission,
+           exercise: series.exercises.first,
+           user: user,
+           created_at: (deadline - 2.minutes)
+    assert_equal false, series.completed?(user: user)
+  end
+
+  test 'completed? with wrong submission and read content_page' do
+    series = create :series, exercise_count: 1, content_page_count: 1, deadline: Time.current
+    user = create :user
+
+    deadline = series.deadline
+    # Wrong submission before deadline
+    create :wrong_submission,
+           exercise: series.exercises.first,
+           user: user,
+           created_at: (deadline - 2.minutes)
+    # Read before deadline
+    create :activity_read_state,
+           activity: series.content_pages.first,
+           user: user,
+           created_at: (deadline - 2.minutes)
+    assert_equal false, series.completed?(user: user)
+  end
+
+  test 'completed? with correct submission and read content_page' do
+    series = create :series, exercise_count: 1, content_page_count: 1, deadline: Time.current
+    user = create :user
+
+    deadline = series.deadline
+    # Correct submission before deadline
+    create :correct_submission,
+           exercise: series.exercises.first,
+           user: user,
+           created_at: (deadline - 2.minutes)
+    # Read before deadline
+    create :activity_read_state,
+           activity: series.content_pages.first,
+           user: user,
+           created_at: (deadline - 2.minutes)
+    assert_equal true, series.completed?(user: user)
+  end
 end

--- a/test/models/series_test.rb
+++ b/test/models/series_test.rb
@@ -261,6 +261,7 @@ class SeriesTest < ActiveSupport::TestCase
            exercise: series.exercises.first,
            user: user,
            created_at: (deadline - 2.minutes)
+
     assert_equal false, series.completed?(user: user)
   end
 
@@ -275,6 +276,7 @@ class SeriesTest < ActiveSupport::TestCase
            exercise: series.exercises.first,
            user: user,
            created_at: (deadline - 2.minutes)
+
     assert_equal true, series.completed?(user: user)
   end
 
@@ -382,6 +384,33 @@ class SeriesTest < ActiveSupport::TestCase
            user: user,
            course: series.course,
            created_at: (deadline - 2.minutes)
+    assert_equal true, series.completed?(user: user)
+  end
+
+  test 'completed? with content_page' do
+    series = create :series, content_page_count: 1, deadline: Time.current
+    user = create :user
+    deadline = series.deadline
+
+    # unread
+    assert_equal false, series.completed?(user: user)
+
+    # read after deadline
+    read_state = create :activity_read_state,
+                        activity: series.content_pages.first,
+                        user: user,
+                        course: series.course,
+                        created_at: (deadline + 2.minutes)
+
+    assert_equal false, series.completed?(user: user)
+
+    read_state.delete
+    create :activity_read_state,
+           activity: series.content_pages.first,
+           user: user,
+           course: series.course,
+           created_at: (deadline - 2.minutes)
+
     assert_equal true, series.completed?(user: user)
   end
 end

--- a/test/models/series_test.rb
+++ b/test/models/series_test.rb
@@ -58,7 +58,7 @@ class SeriesTest < ActiveSupport::TestCase
 
   test 'changing deadline should invalidate exercise statuses' do
     course = create :course
-    series = create :series, course: course, deadline: Time.zone.now + 1.day, activity_count: 2
+    series = create :series, course: course, deadline: Time.zone.now + 1.day, exercise_count: 1
     user = create :user
 
     create :correct_submission,
@@ -252,7 +252,7 @@ class SeriesTest < ActiveSupport::TestCase
   end
 
   test 'completed? with wrong submission before deadline' do
-    series = create :series, activity_count: 2, deadline: Time.current
+    series = create :series, exercise_count: 1, deadline: Time.current
     user = create :user
 
     deadline = series.deadline
@@ -265,7 +265,7 @@ class SeriesTest < ActiveSupport::TestCase
   end
 
   test 'completed? with correct submission before deadline within a course' do
-    series = create :series, activity_count: 2, deadline: Time.current
+    series = create :series, exercise_count: 1, deadline: Time.current
     user = create :user
 
     deadline = series.deadline
@@ -279,7 +279,7 @@ class SeriesTest < ActiveSupport::TestCase
   end
 
   test 'completed? with correct submission before deadline without course' do
-    series = create :series, activity_count: 2, deadline: Time.current
+    series = create :series, exercise_count: 1, deadline: Time.current
     user = create :user
 
     deadline = series.deadline
@@ -292,7 +292,7 @@ class SeriesTest < ActiveSupport::TestCase
   end
 
   test 'completed? with wrong submission after deadline' do
-    series = create :series, activity_count: 2, deadline: Time.current
+    series = create :series, exercise_count: 1, deadline: Time.current
     user = create :user
 
     deadline = series.deadline
@@ -305,7 +305,7 @@ class SeriesTest < ActiveSupport::TestCase
   end
 
   test 'completed? with correct submission after deadline within course' do
-    series = create :series, activity_count: 2, deadline: Time.current
+    series = create :series, exercise_count: 1, deadline: Time.current
     user = create :user
 
     deadline = series.deadline
@@ -319,7 +319,7 @@ class SeriesTest < ActiveSupport::TestCase
   end
 
   test 'completed? with correct submission after deadline without course' do
-    series = create :series, activity_count: 2, deadline: Time.current
+    series = create :series, exercise_count: 1, deadline: Time.current
     user = create :user
 
     deadline = series.deadline

--- a/test/models/series_test.rb
+++ b/test/models/series_test.rb
@@ -58,7 +58,7 @@ class SeriesTest < ActiveSupport::TestCase
 
   test 'changing deadline should invalidate exercise statuses' do
     course = create :course
-    series = create :series, course: course, deadline: Time.zone.now + 1.day, activity_count: 1
+    series = create :series, course: course, deadline: Time.zone.now + 1.day, activity_count: 2
     user = create :user
 
     create :correct_submission,
@@ -252,7 +252,7 @@ class SeriesTest < ActiveSupport::TestCase
   end
 
   test 'completed? with wrong submission before deadline' do
-    series = create :series, activity_count: 1, deadline: Time.current
+    series = create :series, activity_count: 2, deadline: Time.current
     user = create :user
 
     deadline = series.deadline
@@ -265,7 +265,7 @@ class SeriesTest < ActiveSupport::TestCase
   end
 
   test 'completed? with correct submission before deadline within a course' do
-    series = create :series, activity_count: 1, deadline: Time.current
+    series = create :series, activity_count: 2, deadline: Time.current
     user = create :user
 
     deadline = series.deadline
@@ -279,7 +279,7 @@ class SeriesTest < ActiveSupport::TestCase
   end
 
   test 'completed? with correct submission before deadline without course' do
-    series = create :series, activity_count: 1, deadline: Time.current
+    series = create :series, activity_count: 2, deadline: Time.current
     user = create :user
 
     deadline = series.deadline
@@ -292,7 +292,7 @@ class SeriesTest < ActiveSupport::TestCase
   end
 
   test 'completed? with wrong submission after deadline' do
-    series = create :series, activity_count: 1, deadline: Time.current
+    series = create :series, activity_count: 2, deadline: Time.current
     user = create :user
 
     deadline = series.deadline
@@ -305,7 +305,7 @@ class SeriesTest < ActiveSupport::TestCase
   end
 
   test 'completed? with correct submission after deadline within course' do
-    series = create :series, activity_count: 1, deadline: Time.current
+    series = create :series, activity_count: 2, deadline: Time.current
     user = create :user
 
     deadline = series.deadline
@@ -319,7 +319,7 @@ class SeriesTest < ActiveSupport::TestCase
   end
 
   test 'completed? with correct submission after deadline without course' do
-    series = create :series, activity_count: 1, deadline: Time.current
+    series = create :series, activity_count: 2, deadline: Time.current
     user = create :user
 
     deadline = series.deadline

--- a/test/models/series_test.rb
+++ b/test/models/series_test.rb
@@ -340,6 +340,7 @@ class SeriesTest < ActiveSupport::TestCase
     create :correct_submission,
            exercise: series.exercises.first,
            user: user,
+           course: series.course,
            created_at: (deadline - 2.minutes)
     assert_equal false, series.completed?(user: user)
   end
@@ -353,11 +354,13 @@ class SeriesTest < ActiveSupport::TestCase
     create :wrong_submission,
            exercise: series.exercises.first,
            user: user,
+           course: series.course,
            created_at: (deadline - 2.minutes)
     # Read before deadline
     create :activity_read_state,
            activity: series.content_pages.first,
            user: user,
+           course: series.course,
            created_at: (deadline - 2.minutes)
     assert_equal false, series.completed?(user: user)
   end
@@ -371,11 +374,13 @@ class SeriesTest < ActiveSupport::TestCase
     create :correct_submission,
            exercise: series.exercises.first,
            user: user,
+           course: series.course,
            created_at: (deadline - 2.minutes)
     # Read before deadline
     create :activity_read_state,
            activity: series.content_pages.first,
            user: user,
+           course: series.course,
            created_at: (deadline - 2.minutes)
     assert_equal true, series.completed?(user: user)
   end

--- a/test/models/series_test.rb
+++ b/test/models/series_test.rb
@@ -394,6 +394,7 @@ class SeriesTest < ActiveSupport::TestCase
 
     # unread
     assert_equal false, series.completed?(user: user)
+    assert_equal false, series.completed_before_deadline?(user)
 
     # read after deadline
     read_state = create :activity_read_state,
@@ -402,7 +403,8 @@ class SeriesTest < ActiveSupport::TestCase
                         course: series.course,
                         created_at: (deadline + 2.minutes)
 
-    assert_equal false, series.completed?(user: user)
+    assert_equal true, series.completed?(user: user)
+    assert_equal false, series.completed_before_deadline?(user)
 
     read_state.delete
     create :activity_read_state,
@@ -412,5 +414,6 @@ class SeriesTest < ActiveSupport::TestCase
            created_at: (deadline - 2.minutes)
 
     assert_equal true, series.completed?(user: user)
+    assert_equal true, series.completed_before_deadline?(user)
   end
 end

--- a/test/models/submission_test.rb
+++ b/test/models/submission_test.rb
@@ -23,6 +23,17 @@ class SubmissionTest < ActiveSupport::TestCase
     assert_not_nil create(:submission)
   end
 
+  test 'submission with content_page as exercise is not valid' do
+    submission = create :submission
+    content_page = create :content_page
+
+    assert_raises ActiveRecord::AssociationTypeMismatch do
+      submission.exercise = content_page
+    end
+
+    assert_not submission.update(exercise_id: content_page.id)
+  end
+
   test 'submissions should be rate limited for a user' do
     user = create :user
     create :submission, user: user


### PR DESCRIPTION
This pull request:
- got rid of the activity factory, it should always be explicit which activity is tested,
- adds tests for `series.completed?`  and `series.completed_before_deadline?` for series with content pages,
- adds more asserts for `series.completed_before_deadline?` for already existing tests ,
- adds a uniqueness validation for the activity read state (previously it would raise a mysql error because the index uniqueness was invalidated),
- generates read states for content pages in the seeds.