### PR TITLE
Fix content_page read within and without course

### DIFF
--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -126,15 +126,13 @@ class ActivitiesController < ApplicationController
     read_state = ActivityReadState.new activity: @activity,
                                        course: @course,
                                        user: current_user
-    can_read = @activity.accessible?(current_user, @course)
-    if can_read && read_state.save
+    if read_state.save
       respond_to do |format|
         format.html { redirect_to helpers.activity_scoped_path(activity: @activity, course: @course, series: @series) }
         format.js { render 'activities/read', locals: { activity: @activity, course: @course, read_state: read_state, user: current_user } }
         format.json { head :ok }
       end
     else
-      read_state.errors.add(:activity, 'not permitted') unless can_read
       render json: { status: 'failed', errors: read_state.errors }, status: :unprocessable_entity
     end
   end

--- a/app/models/activity_read_state.rb
+++ b/app/models/activity_read_state.rb
@@ -15,7 +15,7 @@ class ActivityReadState < ApplicationRecord
   belongs_to :user
 
   validates :activity, uniqueness: { scope: %i[user course], message: 'already read' }
-  validate :activity_accessible_for_user?
+  validate :activity_accessible_for_user?, on: :create
 
   after_save :invalidate_caches
 

--- a/app/models/activity_read_state.rb
+++ b/app/models/activity_read_state.rb
@@ -14,7 +14,8 @@ class ActivityReadState < ApplicationRecord
   belongs_to :course, optional: true
   belongs_to :user
 
-  validates :activity, uniqueness: { scope: %i[user_id course_id] }
+  validates :activity, uniqueness: { scope: %i[user course], message: 'already read' }
+  validate :activity_accessible_for_user?
 
   after_save :invalidate_caches
 
@@ -46,5 +47,9 @@ class ActivityReadState < ApplicationRecord
     course.invalidate_delayed_correct_solutions
     user.invalidate_attempted_exercises(course: course)
     user.invalidate_correct_exercises(course: course)
+  end
+
+  def activity_accessible_for_user?
+    errors.add(:activity, 'not accessible') unless activity.accessible?(user, course)
   end
 end

--- a/test/controllers/activities_controller_test.rb
+++ b/test/controllers/activities_controller_test.rb
@@ -25,21 +25,44 @@ class ActivitiesControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
-  test 'should mark content_page as read outside course' do
+  test 'should not mark content_page as read twice' do
     cp = create :content_page
-    post read_activity_url(cp)
-    assert_response :success
-
-    assert ActivityReadState.where(user: @user, activity: cp, course: nil).exist?
+    create :activity_read_state, activity: cp, user: @user
+    post read_activity_url(cp, format: :js)
+    assert_response :unprocessable_entity
   end
 
-  test 'should mark content_page as within course' do
-    course = create :course, series_count: 1, content_pages_per_series: 1
-    cp = course.series.first.content_pages.first
-    post read_activity_url(cp)
+  test 'should mark content_page as read outside course' do
+    cp = create :content_page
+    post read_activity_url(cp, format: :js)
     assert_response :success
 
-    assert ActivityReadState.where(user: @user, activity: cp, course: course).exist?
+    assert ActivityReadState.where(user: @user, activity: cp, course: nil).any?
+  end
+
+  test 'should mark content_page as read within course' do
+    course = create :course, series_count: 1, content_pages_per_series: 1, subscribed_members: [@user]
+    cp = course.series.first.content_pages.first
+    post read_course_activity_url(course, cp, format: :js)
+    assert_response :success
+
+    assert ActivityReadState.where(user: @user, activity: cp, course: course).any?
+  end
+
+  test 'should mark content_page as read as html' do
+    cp = create :content_page
+    post read_activity_url(cp, format: :html)
+    assert_response :redirect
+
+    assert ActivityReadState.where(user: @user, activity: cp, course: nil).any?
+  end
+
+  test 'should mark content_page as read as json' do
+    cp = create :content_page
+    post read_activity_url(cp, format: :json)
+    assert_response :success
+
+    assert ActivityReadState.where(user: @user, activity: cp, course: nil).any?
   end
 
   test 'should not show activity description with incorrect token' do


### PR DESCRIPTION
- Adds controller tests for showing content pages and marking them as read
- Fix `activity#read` raising an error when course was `nil`
- Added redirect to activity path for format html
- Moved accessibility check to read state validation