### PR TITLE
Remove submit link on content pages

### DIFF
--- a/app/views/activities/show.html.erb
+++ b/app/views/activities/show.html.erb
@@ -16,9 +16,13 @@
 end %>
 
 <div class="row">
-  <%= link_to '#submission-card', class: "btn btn-lg btn-down col-sm-1 hidden-xs hidden-print", title: t('.handin') do %>
-    <span class='hidden-sm'><%= t('.handin') %></span><br>
-    <i class="mdi mdi-chevron-down"></i>
+  <% if @activity.exercise? %>
+    <%= link_to '#submission-card', class: "btn btn-lg btn-down col-sm-1 hidden-xs hidden-print", title: t('.handin') do %>
+      <span class='hidden-sm'><%= t('.handin') %></span><br>
+      <i class="mdi mdi-chevron-down"></i>
+    <% end %>
+  <% else %>
+    <div class="col-sm-1 hidden-xs hidden-print">&nbsp;</div>
   <% end %>
   <div class="col-sm-10 col-xs-12">
     <div class="card activity-description">


### PR DESCRIPTION
This pull request hides the submit text on the left side of a content page.

![image](https://user-images.githubusercontent.com/6131398/80318658-e66ad400-880b-11ea-947a-b6515be0212a.png)
