### PR TITLE
Fix viewing activity removed from repository

### DIFF
--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -85,9 +85,7 @@ class Activity < ApplicationRecord
   end
 
   def full_path
-    return '' unless path
-
-    Pathname.new File.join(repository.full_path, path)
+    Pathname.new(path ? File.join(repository.full_path, path) : '')
   end
 
   def media_path

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -85,7 +85,9 @@ class Activity < ApplicationRecord
   end
 
   def full_path
-    Pathname.new(path ? File.join(repository.full_path, path) : '')
+    return Pathname.new '' unless path
+
+    Pathname.new File.join(repository.full_path, path)
   end
 
   def media_path

--- a/test/controllers/activities_controller_test.rb
+++ b/test/controllers/activities_controller_test.rb
@@ -14,6 +14,12 @@ class ActivitiesControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test 'should show activity if removed' do
+    @instance.update(status: :removed, path: nil)
+    get activity_url(@instance)
+    assert_response :success
+  end
+
   test 'should show activity description' do
     get description_activity_url(@instance, token: @instance.access_token)
     assert_response :success


### PR DESCRIPTION
It is assumed that full_path will always return a Pathname, but it returned a string when there is no path.

- [x] Tests were added