### PR TITLE
Add type field to activity json

### DIFF
--- a/app/views/activities/_activity.json.jbuilder
+++ b/app/views/activities/_activity.json.jbuilder
@@ -1,6 +1,7 @@
 json.extract! activity,
               :id,
               :name,
+              :type,
               :description_format
 if activity.exercise?
   json.boilerplate activity.boilerplate


### PR DESCRIPTION
This pull request adds a `type` field to the json view of an activity.
![image](https://user-images.githubusercontent.com/6131398/80356740-2f597180-887a-11ea-99dd-f784b6c3b4a8.png)
