### PR TITLE
Improve course load performance

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -33,7 +33,7 @@ class CoursesController < ApplicationController
     end
     @title = @course.name
     @series = policy_scope(@course.series)
-    @series_loaded = params[:secret].present? ? @course.series.count : 3
+    @series_loaded = params[:secret].present? ? @course.series.count : 2
   end
 
   # GET /courses/new

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -176,7 +176,7 @@ class CoursesController < ApplicationController
           columns.concat(@series.map(&:name))
           columns.concat(@series.map { |s| I18n.t('courses.scoresheet.started', series: s.name) })
           csv << columns
-          csv << ['Maximum', '', '', ''].concat(@series.map { |s| s.activity_count }).concat(@series.map { |s| s.activity_count })
+          csv << ['Maximum', '', '', ''].concat(@series.map(&:activity_count)).concat(@series.map(&:activity_count))
           @users.each do |u|
             row = [u.first_name, u.last_name, u.username, u.email]
             row.concat(@series.map { |s| @hash[[u.id, s.id]][:accepted] })

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -176,7 +176,7 @@ class CoursesController < ApplicationController
           columns.concat(@series.map(&:name))
           columns.concat(@series.map { |s| I18n.t('courses.scoresheet.started', series: s.name) })
           csv << columns
-          csv << ['Maximum', '', '', ''].concat(@series.map { |s| s.activities.count }).concat(@series.map { |s| s.activities.count })
+          csv << ['Maximum', '', '', ''].concat(@series.map { |s| s.activity_count }).concat(@series.map { |s| s.activity_count })
           @users.each do |u|
             row = [u.first_name, u.last_name, u.username, u.email]
             row.concat(@series.map { |s| @hash[[u.id, s.id]][:accepted] })

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -132,6 +132,10 @@ class Series < ApplicationRecord
     end
   end
 
+  def activity_count
+    @activity_c ||= activities.count
+  end
+
   def scoresheet
     users = course.subscribed_members
                   .order('course_memberships.status ASC')

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -133,7 +133,7 @@ class Series < ApplicationRecord
   end
 
   def activity_count
-    @activity_c ||= activities.count
+    @activity_count ||= activities.count
   end
 
   def scoresheet

--- a/app/views/courses/_scoresheet_table.html.erb
+++ b/app/views/courses/_scoresheet_table.html.erb
@@ -13,7 +13,7 @@
       <tr>
         <td class="user-name ellipsis-overflow"><%= link_to student.full_name, course_member_path(course, student), title: student.full_name, class: "ellipsis-overflow" %></td>
         <% series.each do |s| %>
-          <td class="status" title="<%= "#{s.name} - #{student.full_name} - #{hash[[student.id, s.id]][:accepted]}/#{s.activities.count}" %>"><%= hash[[student.id, s.id]][:accepted] %></td>
+          <td class="status" title="<%= "#{s.name} - #{student.full_name} - #{hash[[student.id, s.id]][:accepted]}/#{s.activity_count}" %>"><%= hash[[student.id, s.id]][:accepted] %></td>
         <% end %>
       </tr>
     <% end %>

--- a/app/views/courses/scoresheet.json.jbuilder
+++ b/app/views/courses/scoresheet.json.jbuilder
@@ -3,7 +3,7 @@ json.array! @users do |user|
   json.series do
     json.array! @series do |series|
       json.extract! series, :id, :name
-      json.total_activities series.activities.count
+      json.total_activities series.activity_count
       json.completed_activities @hash[[user.id, series.id]][:accepted]
       json.started_activities @hash[[user.id, series.id]][:started]
     end

--- a/app/views/series/_course_series_table.html.erb
+++ b/app/views/series/_course_series_table.html.erb
@@ -46,7 +46,7 @@
         <% end %>
       </td>
       <td>
-        <%= t ".num_activities", {count: s.activities.count} %>
+        <%= t ".num_activities", {count: s.activity_count} %>
       </td>
       <td class="actions">
         <% if policy(s).edit? %>

--- a/app/views/series/_series.html.erb
+++ b/app/views/series/_series.html.erb
@@ -112,7 +112,7 @@
     <%= markdown(series.description) %>
   </div>
 
-  <% if policy(series).overview? && series.activities.length > 0 %>
+  <% if policy(series).overview? && series.activity_count > 0 %>
     <div class="series-activities-table-wrapper">
       <% if loaded %>
         <%= render partial: 'activities/activities_table', locals: {
@@ -124,7 +124,7 @@
       <% else %>
         <div class="activity-table-skeleton">
           <div class="skeleton-head"></div>
-          <% series.activities.count.times do %>
+          <% series.activity_count.times do %>
             <div class="skeleton-row"></div>
           <% end %>
         </div>


### PR DESCRIPTION
This pull request should slightly improve course load performance by:
- loading only 2 series by default for a course instead of 3 (can later be reduced if needed)
- don't do 2 queries per series and avoid hitting the queries cache by memoization

#1892 
