### PR TITLE
Downgrade jQuery

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "first-input-delay": "^0.1.3",
     "iframe-resizer": "^4.2.10",
     "isomorphic-fetch": "^2.2.1",
-    "jquery": "^3.5.0",
+    "jquery": "~3.4.1",
     "moment": "^2.24.0",
     "ts-loader": "7.0.1",
     "typeahead.js": "^0.11.1",

--- a/vendor/assets/javascripts/bootstrap/collapse.js
+++ b/vendor/assets/javascripts/bootstrap/collapse.js
@@ -173,7 +173,7 @@
       var data    = $this.data('bs.collapse')
       var options = $.extend({}, Collapse.DEFAULTS, $this.data(), typeof option == 'object' && option)
 
-      if (!data && options.toggle  && typeof option === 'string' &&/show|hide/.test(option)) options.toggle = false
+      if (!data && options.toggle && /show|hide/.test(option)) options.toggle = false
       if (!data) $this.data('bs.collapse', (data = new Collapse(this, options)))
       if (typeof option == 'string') data[option]()
     })

--- a/vendor/assets/javascripts/vendor.js
+++ b/vendor/assets/javascripts/vendor.js
@@ -1,15 +1,15 @@
 // bootstrap
-//=require bootstrap/affix.js
+//=require bootstrap/transition.js
 //=require bootstrap/alert.js
 //=require bootstrap/button.js
 //=require bootstrap/collapse.js
 //=require bootstrap/dropdown.js
 //=require bootstrap/modal.js
+//=require bootstrap/tooltip.js
 //=require bootstrap/popover.js
 //=require bootstrap/scrollspy.js
 //=require bootstrap/tab.js
-//=require bootstrap/tooltip.js
-//=require bootstrap/transition.js
+//=require bootstrap/affix.js
 
 // flatpickr
 //=require flatpickr/flatpickr.min.js

--- a/yarn.lock
+++ b/yarn.lock
@@ -6312,10 +6312,15 @@ jest@^25.4.0:
     import-local "^3.0.2"
     jest-cli "^25.4.0"
 
-jquery@>=1.7, jquery@^3.5.0:
+jquery@>=1.7:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.5.0.tgz#9980b97d9e4194611c36530e7dc46a58d7340fc9"
   integrity sha512-Xb7SVYMvygPxbFMpTFQiHh1J7HClEaThguL15N/Gg37Lri/qKyhRGZYzHRyLH8Stq3Aow0LsHO2O2ci86fCrNQ==
+
+jquery@~3.4.1:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.4.1.tgz#714f1f8d9dde4bdfa55764ba37ef214630d80ef2"
+  integrity sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw==
 
 js-base64@^2.1.8:
   version "2.5.1"


### PR DESCRIPTION
The jQuery upgrade broke other things in bootstrap 3.4.1 as well. Proposal: downgrade jQuery (for now) and revert the bootstrap workaround (since it works with downgraded jQuery). This also fixes the order in which the bootstrap JavaScript files are loaded.