### PR TITLE
Fix submission not loading when judged

### DIFF
--- a/app/views/submissions/index.js.erb
+++ b/app/views/submissions/index.js.erb
@@ -1,8 +1,8 @@
-$("#submissions-table-wrapper").html("<%= escape_javascript(render partial: 'submissions_table', locals: {submissions: @submissions, exercise: @exercise, course: @course, user: @user }) %>");
+$("#submissions-table-wrapper").html("<%= escape_javascript(render partial: 'submissions_table', locals: {submissions: @submissions, exercise: @activity, course: @course, user: @user }) %>");
 if (dodona.feedbackTableLoaded) {
     dodona.feedbackTableLoaded(
         <%= raw "#{current_user&.id || 'undefined'}" %>,
-        <%= raw "#{@exercise&.id || 'undefined'}" %>,
+        <%= raw "#{@activity&.id || 'undefined'}" %>,
         <%= raw "#{@course&.id || 'undefined'}" %>
     );
 }


### PR DESCRIPTION
This pull request fixes a bug where the submissions table would not refresh when a submission is judged. This was caused by a reference to `@exercise` that was not renamed to `@activity`.

It would be nice if this could be hotfixed. Ther is an evaluation of DA1 tomorrow starting at 10, and this is a major UX issue.