### PR TITLE
Add profiling to production

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -132,9 +132,9 @@ gem 'dalli', '~> 2.7.10'
 gem 'faker', '~> 2.11.0'
 
 # Profiling
-gem 'rack-mini-profiler', '~> 2.0.1'
-gem 'memory_profiler', '~> 0.9.14'
 gem 'flamegraph', '~> 0.9.5'
+gem 'memory_profiler', '~> 0.9.14'
+gem 'rack-mini-profiler', '~> 2.0.1'
 gem 'stackprof', '~> 0.2.15'
 
 group :development, :test do

--- a/Gemfile
+++ b/Gemfile
@@ -131,6 +131,9 @@ gem 'dalli', '~> 2.7.10'
 # Generate 'random' values like usernames, emails, ...
 gem 'faker', '~> 2.11.0'
 
+# Profiling
+gem 'rack-mini-profiler', '~> 2.0.1'
+
 group :development, :test do
   # Use mocha for stubbing and mocking
   gem 'mocha', '~> 1.11.2'

--- a/Gemfile
+++ b/Gemfile
@@ -133,6 +133,9 @@ gem 'faker', '~> 2.11.0'
 
 # Profiling
 gem 'rack-mini-profiler', '~> 2.0.1'
+gem 'memory_profiler', '~> 0.9.14'
+gem 'flamegraph', '~> 0.9.5'
+gem 'stackprof', '~> 0.2.15'
 
 group :development, :test do
   # Use mocha for stubbing and mocking

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -278,6 +278,8 @@ GEM
     pundit (2.1.0)
       activesupport (>= 3.0.0)
     rack (2.2.2)
+    rack-mini-profiler (2.0.1)
+      rack (>= 1.2.0)
     rack-protection (2.0.8.1)
       rack
     rack-proxy (0.6.5)
@@ -470,6 +472,7 @@ DEPENDENCIES
   pretender (~> 0.3.4)
   puma (~> 4.3.3)
   pundit (~> 2.1.0)
+  rack-mini-profiler (~> 2.0.1)
   rails (~> 6.0.2)
   rails-controller-testing (~> 1.0.4)
   rails-i18n (~> 6.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -163,6 +163,7 @@ GEM
     faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
     ffi (1.11.3)
+    flamegraph (0.9.5)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     has_scope (0.7.2)
@@ -215,6 +216,7 @@ GEM
       activemodel (>= 5.0)
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
+    memory_profiler (0.9.14)
     method_source (1.0.0)
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
@@ -383,6 +385,7 @@ GEM
     sshkit (1.20.0)
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
+    stackprof (0.2.15)
     therubyracer (0.12.3)
       libv8 (~> 3.16.14.15)
       ref
@@ -446,6 +449,7 @@ DEPENDENCIES
   exception_notification (~> 4.4.0)
   factory_bot_rails (~> 5.2.0)
   faker (~> 2.11.0)
+  flamegraph (~> 0.9.5)
   foreman!
   has_scope (~> 0.7.2)
   httparty (~> 0.18.0)
@@ -460,6 +464,7 @@ DEPENDENCIES
   letter_opener (~> 1.7.0)
   listen (~> 3.2.1)
   mail_form (~> 1.8.0)
+  memory_profiler (~> 0.9.14)
   minitest-ci (~> 3.4.0)
   minitest-utils (~> 0.4.6)
   mocha (~> 1.11.2)
@@ -488,6 +493,7 @@ DEPENDENCIES
   slack-notifier (~> 2.3.2)
   spring (~> 2.1.0)
   spring-watcher-listen (~> 2.0.1)
+  stackprof (~> 0.2.15)
   therubyracer
   tzinfo-data
   uglifier (>= 4.1.20)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -179,6 +179,8 @@ class ApplicationController < ActionController::Base
   end
 
   def enable_profiling
-    Rack::MiniProfiler.authorize_request if current_user && current_user.zeus?
+    if user_signed_in? && (current_user.zeus? || (true_user && true_user.zeus?))
+      Rack::MiniProfiler.authorize_request
+    end
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,6 +6,8 @@ class ApplicationController < ActionController::Base
 
   protect_from_forgery with: :null_session
 
+  before_action :enable_profiling
+
   before_action :store_current_location,
                 except: %i[media sign_in_page institution_not_supported],
                 unless: -> { devise_controller? || remote_request? }
@@ -174,5 +176,9 @@ class ApplicationController < ActionController::Base
     @notifications.where(read: false).each do |n|
       n.update(read: true) if helpers.current_page?(helpers.base_notifiable_url_params(n))
     end
+  end
+
+  def enable_profiling
+    Rack::MiniProfiler.authorize_request if current_user && current_user.zeus?
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -179,8 +179,6 @@ class ApplicationController < ActionController::Base
   end
 
   def enable_profiling
-    if user_signed_in? && (current_user.zeus? || (true_user && true_user.zeus?))
-      Rack::MiniProfiler.authorize_request
-    end
+    Rack::MiniProfiler.authorize_request if user_signed_in? && (current_user.zeus? || true_user&.zeus?)
   end
 end

--- a/config/initializers/mini_profiler.rb
+++ b/config/initializers/mini_profiler.rb
@@ -1,0 +1,2 @@
+Rack::MiniProfiler.config.position = 'bottom-right'
+Rack::MiniProfiler.config.show_total_sql_count = true


### PR DESCRIPTION
This pull request adds the rack-mini-profiler gem. This gem is enabled in production, but profiling is only started for users of class Zeus.

Clicking on the bottom right of the page should show more information:
![image](https://user-images.githubusercontent.com/481872/80457580-d5b37e80-892f-11ea-9797-11ff41f75b6d.png)

