### PR TITLE
Performance optimizations of the course show page

### DIFF
--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -368,15 +368,20 @@ class Activity < ApplicationRecord
   private
 
   def activity_status_for(user, series = nil)
-    attempts = 0
     Current.status_store ||= {}
-    Current.status_store[[user.id, series.id, id]] ||= begin
-      ActivityStatus.find_or_create_by(activity: self, series: series, user: user)
-                                                       rescue StandardError
-                                                         # https://github.com/dodona-edu/dodona/issues/1877
-                                                         raise unless (attempts += 1) <= 1
+    Current.status_store[[user.id, series&.id, id]] ||= activity_status_for!(user, series)
+  end
 
-                                                         retry
+  def activity_status_for!(user, series = nil)
+    first_try = true
+    begin
+      ActivityStatus.find_or_create_by(activity: self, series: series, user: user)
+    rescue StandardError
+      # https://github.com/dodona-edu/dodona/issues/1877
+      raise unless first_try
+
+      first_try = false
+      retry
     end
   end
 

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -369,13 +369,14 @@ class Activity < ApplicationRecord
 
   def activity_status_for(user, series = nil)
     attempts = 0
-    begin
+    Current.status_store ||= {}
+    Current.status_store[[user.id, series.id, id]] ||= begin
       ActivityStatus.find_or_create_by(activity: self, series: series, user: user)
-    rescue StandardError
-      # https://github.com/dodona-edu/dodona/issues/1877
-      raise unless (attempts += 1) <= 1
+                                                       rescue StandardError
+                                                         # https://github.com/dodona-edu/dodona/issues/1877
+                                                         raise unless (attempts += 1) <= 1
 
-      retry
+                                                         retry
     end
   end
 

--- a/app/models/activity_status.rb
+++ b/app/models/activity_status.rb
@@ -15,6 +15,13 @@
 #  updated_at               :datetime         not null
 #
 class ActivityStatus < ApplicationRecord
+  # the reverse relations aren't defined because this doesn't make sense and there are no
+  # indexes defined to allow fast retrieval
+  belongs_to :last_submission, class_name: 'Submission', optional: true
+  belongs_to :last_submission_deadline, class_name: 'Submission', optional: true
+  belongs_to :best_submission, class_name: 'Submission', optional: true
+  belongs_to :best_submission_deadline, class_name: 'Submission', optional: true
+
   belongs_to :activity
   belongs_to :series, optional: true
   belongs_to :user
@@ -61,6 +68,11 @@ class ActivityStatus < ApplicationRecord
     best_before_deadline = activity.best_submission(user, series&.deadline, series&.course)
     last = activity.last_submission(user, nil, series&.course)
     last_before_deadline = activity.last_submission(user, series&.deadline, series&.course)
+
+    self.last_submission = last
+    self.last_submission_deadline = last_before_deadline
+    self.best_submission = best
+    self.best_submission_deadline = best_before_deadline
 
     self.accepted = last&.accepted? || false
     self.accepted_before_deadline = last_before_deadline&.accepted? || false

--- a/app/models/activity_status.rb
+++ b/app/models/activity_status.rb
@@ -64,10 +64,10 @@ class ActivityStatus < ApplicationRecord
   def initialise_values_for_exercise
     return unless activity.exercise?
 
-    best = activity.best_submission(user, nil, series&.course)
-    best_before_deadline = activity.best_submission(user, series&.deadline, series&.course)
-    last = activity.last_submission(user, nil, series&.course)
-    last_before_deadline = activity.last_submission(user, series&.deadline, series&.course)
+    best = activity.best_submission!(user, nil, series&.course)
+    best_before_deadline = activity.best_submission!(user, series&.deadline, series&.course)
+    last = activity.last_submission!(user, nil, series&.course)
+    last_before_deadline = activity.last_submission!(user, series&.deadline, series&.course)
 
     self.last_submission = last
     self.last_submission_deadline = last_before_deadline

--- a/app/models/activity_status.rb
+++ b/app/models/activity_status.rb
@@ -57,6 +57,10 @@ class ActivityStatus < ApplicationRecord
     end
   end
 
+  def self.clear_status_store
+    Current.status_store = {}
+  end
+
   private
 
   def initialise_values_for_content_page

--- a/app/models/activity_status.rb
+++ b/app/models/activity_status.rb
@@ -50,6 +50,13 @@ class ActivityStatus < ApplicationRecord
     save
   end
 
+  def self.add_status_for(user, series, eager = [])
+    Current.status_store ||= {}
+    ActivityStatus.where(series: series, user: user).includes(eager).find_each do |as|
+      Current.status_store[[as.user_id, as.series_id, as.activity_id]] = as
+    end
+  end
+
   private
 
   def initialise_values_for_content_page

--- a/app/models/activity_status.rb
+++ b/app/models/activity_status.rb
@@ -64,10 +64,10 @@ class ActivityStatus < ApplicationRecord
   def initialise_values_for_exercise
     return unless activity.exercise?
 
-    best = activity.best_submission!(user, nil, series&.course)
-    best_before_deadline = activity.best_submission!(user, series&.deadline, series&.course)
     last = activity.last_submission!(user, nil, series&.course)
-    last_before_deadline = activity.last_submission!(user, series&.deadline, series&.course)
+    last_before_deadline = activity.last_submission!(user, series&.deadline, series&.course) if last
+    best = activity.best_submission!(user, nil, series&.course) if last
+    best_before_deadline = activity.best_submission!(user, series&.deadline, series&.course) if best
 
     self.last_submission = last
     self.last_submission_deadline = last_before_deadline

--- a/app/models/activity_status.rb
+++ b/app/models/activity_status.rb
@@ -2,17 +2,21 @@
 #
 # Table name: activity_statuses
 #
-#  id                       :bigint           not null, primary key
-#  accepted                 :boolean          default(FALSE), not null
-#  accepted_before_deadline :boolean          default(FALSE), not null
-#  solved                   :boolean          default(FALSE), not null
-#  started                  :boolean          default(FALSE), not null
-#  solved_at                :datetime
-#  activity_id              :integer          not null
-#  series_id                :integer
-#  user_id                  :integer          not null
-#  created_at               :datetime         not null
-#  updated_at               :datetime         not null
+#  id                          :bigint           not null, primary key
+#  accepted                    :boolean          default(FALSE), not null
+#  accepted_before_deadline    :boolean          default(FALSE), not null
+#  solved                      :boolean          default(FALSE), not null
+#  started                     :boolean          default(FALSE), not null
+#  solved_at                   :datetime
+#  activity_id                 :integer          not null
+#  series_id                   :integer
+#  user_id                     :integer          not null
+#  created_at                  :datetime         not null
+#  updated_at                  :datetime         not null
+#  last_submission_id          :integer
+#  last_submission_deadline_id :integer
+#  best_submission_id          :integer
+#  best_submission_deadline_id :integer
 #
 class ActivityStatus < ApplicationRecord
   # the reverse relations aren't defined because this doesn't make sense and there are no

--- a/app/models/current.rb
+++ b/app/models/current.rb
@@ -1,4 +1,5 @@
 class Current < ActiveSupport::CurrentAttributes
   attribute :user
   attribute :demo_mode
+  attribute :status_store
 end

--- a/app/models/exercise.rb
+++ b/app/models/exercise.rb
@@ -97,6 +97,22 @@ class Exercise < Activity
   invalidateable_instance_cacheable(:users_tried,
                                     ->(this, options) { format(USERS_TRIED_CACHE_STRING, course_id: options[:course] ? options[:course].id.to_s : 'global', id: this.id.to_s) })
 
+  def last_submission(user, series = nil)
+    activity_status_for(user, series).last_submission
+  end
+
+  def last_submission_before_deadline(user, series = nil)
+    activity_status_for(user, series).last_submission_deadline
+  end
+
+  def best_submission(user, series = nil)
+    activity_status_for(user, series).best_submission
+  end
+
+  def best_submission_before_deadline(user, series = nil)
+    activity_status_for(user, series).best_submission_deadline
+  end
+
   def best_is_last_submission?(user, series = nil)
     activity_status_for(user, series).best_is_last?
   end

--- a/app/models/exercise.rb
+++ b/app/models/exercise.rb
@@ -101,18 +101,18 @@ class Exercise < Activity
     activity_status_for(user, series).best_is_last?
   end
 
-  def best_submission(user, deadline = nil, course = nil)
-    last_correct_submission(user, deadline, course) || last_submission(user, deadline, course)
+  def best_submission!(user, deadline = nil, course = nil)
+    last_correct_submission!(user, deadline, course) || last_submission!(user, deadline, course)
   end
 
-  def last_correct_submission(user, deadline = nil, course = nil)
+  def last_correct_submission!(user, deadline = nil, course = nil)
     s = submissions.of_user(user).where(status: :correct)
     s = s.in_course(course) if course
     s = s.before_deadline(deadline) if deadline
     s.limit(1).first
   end
 
-  def last_submission(user, deadline = nil, course = nil)
+  def last_submission!(user, deadline = nil, course = nil)
     raise 'Second argument is a deadline, not a course' if deadline.is_a? Course
 
     s = submissions.of_user(user)

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -15,6 +15,7 @@
 #  indianio_token     :string(255)
 #  progress_enabled   :boolean          default(TRUE), not null
 #  activities_visible :boolean          default(TRUE), not null
+#  activities_count   :integer
 #
 
 require 'csv'
@@ -133,7 +134,7 @@ class Series < ApplicationRecord
   end
 
   def activity_count
-    @activity_count ||= activities.count
+    activities_count || series_memberships.size
   end
 
   def scoresheet

--- a/app/models/series_membership.rb
+++ b/app/models/series_membership.rb
@@ -11,7 +11,7 @@
 #
 
 class SeriesMembership < ApplicationRecord
-  belongs_to :series
+  belongs_to :series, counter_cache: :activities_count
   belongs_to :activity
 
   delegate :course, to: :series

--- a/app/views/activities/_activity.json.jbuilder
+++ b/app/views/activities/_activity.json.jbuilder
@@ -8,11 +8,11 @@ if activity.exercise?
   json.programming_language activity.programming_language
   if current_user
     json.last_solution_is_best activity.best_is_last_submission?(current_user, series)
-    json.has_solution activity.started(current_user)
-    json.has_correct_solution activity.solved(current_user)
+    json.has_solution activity.started_for?(current_user)
+    json.has_correct_solution activity.solved_for?(current_user)
   end
 elsif activity.content_page?
-  json.has_read activity.solved(current_user) if current_user
+  json.has_read activity.solved_for?(current_user) if current_user
 end
 json.description_url description_activity_url(activity, token: activity.access_token)
 json.url activity_scoped_url(activity: activity, series: series, course: course, options: { format: :json })

--- a/app/views/activities/_activity.json.jbuilder
+++ b/app/views/activities/_activity.json.jbuilder
@@ -8,8 +8,8 @@ if activity.exercise?
   json.programming_language activity.programming_language
   if current_user
     json.last_solution_is_best activity.best_is_last_submission?(current_user, series)
-    json.has_solution activity.last_submission(current_user).present?
-    json.has_correct_solution activity.last_correct_submission(current_user).present?
+    json.has_solution activity.last_submission!(current_user).present?
+    json.has_correct_solution activity.last_correct_submission!(current_user).present?
   end
 elsif activity.content_page?
   json.has_read activity.activity_read_states.find_by(user: current_user).present? if current_user

--- a/app/views/activities/_activity.json.jbuilder
+++ b/app/views/activities/_activity.json.jbuilder
@@ -8,11 +8,11 @@ if activity.exercise?
   json.programming_language activity.programming_language
   if current_user
     json.last_solution_is_best activity.best_is_last_submission?(current_user, series)
-    json.has_solution activity.last_submission!(current_user).present?
-    json.has_correct_solution activity.last_correct_submission!(current_user).present?
+    json.has_solution activity.started(current_user)
+    json.has_correct_solution activity.solved(current_user)
   end
 elsif activity.content_page?
-  json.has_read activity.activity_read_states.find_by(user: current_user).present? if current_user
+  json.has_read activity.solved(current_user) if current_user
 end
 json.description_url description_activity_url(activity, token: activity.access_token)
 json.url activity_scoped_url(activity: activity, series: series, course: course, options: { format: :json })

--- a/app/views/activities/_user_status.html.erb
+++ b/app/views/activities/_user_status.html.erb
@@ -1,7 +1,7 @@
 <% # arguments: activity (Activity), series (Series | nil), user (User) %>
 <% if activity.exercise? %>
-  <% submission = activity.last_submission!(user, nil, series&.course) %>
-  <% best_submission = activity.best_submission!(user, nil, series&.course) %>
+  <% submission = activity.last_submission(user, series) %>
+  <% best_submission = activity.best_submission(user, series) %>
   <% if submission.present? %>
     <% if submission.accepted? %>
       <%= link_to submission, class: 'deadline-ok' do %>

--- a/app/views/activities/_user_status.html.erb
+++ b/app/views/activities/_user_status.html.erb
@@ -1,7 +1,7 @@
 <% # arguments: activity (Activity), series (Series | nil), user (User) %>
 <% if activity.exercise? %>
-  <% submission = activity.last_submission(user, nil, series&.course) %>
-  <% best_submission = activity.best_submission(user, nil, series&.course) %>
+  <% submission = activity.last_submission!(user, nil, series&.course) %>
+  <% best_submission = activity.best_submission!(user, nil, series&.course) %>
   <% if submission.present? %>
     <% if submission.accepted? %>
       <%= link_to submission, class: 'deadline-ok' do %>

--- a/app/views/pages/_user_card.html.erb
+++ b/app/views/pages/_user_card.html.erb
@@ -40,7 +40,7 @@
     <div class="card-supporting-text card-border recents">
       <h5><%= t ".recent-exercises" %></h5>
       <% current_user.recent_exercises(5).each do |exercise| %>
-        <% submission = exercise.last_submission(current_user) %>
+        <% submission = exercise.last_submission!(current_user) %>
         <p>
           <% if submission.course.nil? %>
             <%= link_to activity_submissions_path(submission.exercise), class: 'btn-icon pull-right' do %>

--- a/app/views/pages/_user_card.html.erb
+++ b/app/views/pages/_user_card.html.erb
@@ -40,7 +40,7 @@
     <div class="card-supporting-text card-border recents">
       <h5><%= t ".recent-exercises" %></h5>
       <% current_user.recent_exercises(5).each do |exercise| %>
-        <% submission = exercise.last_submission!(current_user) %>
+        <% submission = exercise.last_submission(current_user) %>
         <p>
           <% if submission.course.nil? %>
             <%= link_to activity_submissions_path(submission.exercise), class: 'btn-icon pull-right' do %>

--- a/app/views/series/_series.html.erb
+++ b/app/views/series/_series.html.erb
@@ -7,6 +7,7 @@
    else
      user = current_user
    end %>
+<% ActivityStatus.add_status_for(user, series, [:last_submission, :best_submission]) if loaded %>
 
 <div class="card card-supporting-text series"
      id="series-card-<%= series.id %>"

--- a/db/migrate/20200428114649_add_submissions_to_activity_status.rb
+++ b/db/migrate/20200428114649_add_submissions_to_activity_status.rb
@@ -1,0 +1,9 @@
+class AddSubmissionsToActivityStatus < ActiveRecord::Migration[6.0]
+  def change
+    add_column :activity_statuses, :last_submission_id, :integer
+    add_column :activity_statuses, :last_submission_deadline_id, :integer
+    add_column :activity_statuses, :best_submission_id, :integer
+    add_column :activity_statuses, :best_submission_deadline_id, :integer
+    execute 'TRUNCATE TABLE activity_statuses'
+  end
+end

--- a/db/migrate/20200428114649_add_submissions_to_activity_status.rb
+++ b/db/migrate/20200428114649_add_submissions_to_activity_status.rb
@@ -1,5 +1,8 @@
 class AddSubmissionsToActivityStatus < ActiveRecord::Migration[6.0]
   def change
+    # since we need to nuke the table after this is done, we might as well start
+    # with it to make adding the columns faster
+    execute 'TRUNCATE TABLE activity_statuses'
     add_column :activity_statuses, :last_submission_id, :integer
     add_column :activity_statuses, :last_submission_deadline_id, :integer
     add_column :activity_statuses, :best_submission_id, :integer

--- a/db/migrate/20200428211530_add_activities_count_to_series.rb
+++ b/db/migrate/20200428211530_add_activities_count_to_series.rb
@@ -1,0 +1,8 @@
+class AddActivitiesCountToSeries < ActiveRecord::Migration[6.0]
+  def change
+    add_column :series, :activities_count, :integer
+    Series.find_each do |series|
+      Series.reset_counters(series.id, :series_memberships)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_24_161936) do
+ActiveRecord::Schema.define(version: 2020_04_28_114649) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -88,6 +88,10 @@ ActiveRecord::Schema.define(version: 2020_04_24_161936) do
     t.integer "user_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "last_submission_id"
+    t.integer "last_submission_deadline_id"
+    t.integer "best_submission_id"
+    t.integer "best_submission_deadline_id"
     t.index ["activity_id", "series_id", "user_id"], name: "index_activity_statuses_on_activity_id_and_series_id_and_user_id", unique: true
     t.index ["series_id"], name: "fk_rails_1bc42c2178"
     t.index ["user_id"], name: "fk_rails_8a05a160e8"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_28_114649) do
+ActiveRecord::Schema.define(version: 2020_04_28_211530) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -288,6 +288,7 @@ ActiveRecord::Schema.define(version: 2020_04_28_114649) do
     t.string "indianio_token"
     t.boolean "progress_enabled", default: true, null: false
     t.boolean "activities_visible", default: true, null: false
+    t.integer "activities_count"
     t.index ["access_token"], name: "index_series_on_access_token"
     t.index ["course_id"], name: "index_series_on_course_id"
     t.index ["deadline"], name: "index_series_on_deadline"

--- a/test/controllers/exports_controller_test.rb
+++ b/test/controllers/exports_controller_test.rb
@@ -24,7 +24,7 @@ class ExportsControllerTest < ActionDispatch::IntegrationTest
   test 'should download only last submissions' do
     post series_exports_path(@series), params: { all: true, only_last_submission: true, with_info: true }
     assert_redirected_to exports_path
-    count = @students.map { |u| @series.exercises.map { |e| e.last_submission!(u, nil, @series.course) } }.flatten.select(&:present?).count
+    count = @students.map { |u| @series.exercises.map { |e| e.last_submission(u, series) } }.flatten.select(&:present?).count
     assert_zip ActiveStorage::Blob.last.download, with_info: true, solution_count: count, data: @data
   end
 

--- a/test/controllers/exports_controller_test.rb
+++ b/test/controllers/exports_controller_test.rb
@@ -24,7 +24,7 @@ class ExportsControllerTest < ActionDispatch::IntegrationTest
   test 'should download only last submissions' do
     post series_exports_path(@series), params: { all: true, only_last_submission: true, with_info: true }
     assert_redirected_to exports_path
-    count = @students.map { |u| @series.exercises.map { |e| e.last_submission(u, nil, @series.course) } }.flatten.select(&:present?).count
+    count = @students.map { |u| @series.exercises.map { |e| e.last_submission!(u, nil, @series.course) } }.flatten.select(&:present?).count
     assert_zip ActiveStorage::Blob.last.download, with_info: true, solution_count: count, data: @data
   end
 

--- a/test/controllers/exports_controller_test.rb
+++ b/test/controllers/exports_controller_test.rb
@@ -24,7 +24,7 @@ class ExportsControllerTest < ActionDispatch::IntegrationTest
   test 'should download only last submissions' do
     post series_exports_path(@series), params: { all: true, only_last_submission: true, with_info: true }
     assert_redirected_to exports_path
-    count = @students.map { |u| @series.exercises.map { |e| e.last_submission(u, series) } }.flatten.select(&:present?).count
+    count = @students.map { |u| @series.exercises.map { |e| e.last_submission(u, @series) } }.flatten.select(&:present?).count
     assert_zip ActiveStorage::Blob.last.download, with_info: true, solution_count: count, data: @data
   end
 

--- a/test/factories/activity_statuses.rb
+++ b/test/factories/activity_statuses.rb
@@ -2,17 +2,21 @@
 #
 # Table name: activity_statuses
 #
-#  id                       :bigint           not null, primary key
-#  accepted                 :boolean          default(FALSE), not null
-#  accepted_before_deadline :boolean          default(FALSE), not null
-#  solved                   :boolean          default(FALSE), not null
-#  started                  :boolean          default(FALSE), not null
-#  solved_at                :datetime
-#  activity_id              :integer          not null
-#  series_id                :integer
-#  user_id                  :integer          not null
-#  created_at               :datetime         not null
-#  updated_at               :datetime         not null
+#  id                          :bigint           not null, primary key
+#  accepted                    :boolean          default(FALSE), not null
+#  accepted_before_deadline    :boolean          default(FALSE), not null
+#  solved                      :boolean          default(FALSE), not null
+#  started                     :boolean          default(FALSE), not null
+#  solved_at                   :datetime
+#  activity_id                 :integer          not null
+#  series_id                   :integer
+#  user_id                     :integer          not null
+#  created_at                  :datetime         not null
+#  updated_at                  :datetime         not null
+#  last_submission_id          :integer
+#  last_submission_deadline_id :integer
+#  best_submission_id          :integer
+#  best_submission_deadline_id :integer
 #
 FactoryBot.define do
   factory :activity_status do

--- a/test/factories/series.rb
+++ b/test/factories/series.rb
@@ -15,6 +15,7 @@
 #  indianio_token     :string(255)
 #  progress_enabled   :boolean          default(TRUE), not null
 #  activities_visible :boolean          default(TRUE), not null
+#  activities_count   :integer
 #
 
 FactoryBot.define do

--- a/test/models/activity_status_test.rb
+++ b/test/models/activity_status_test.rb
@@ -2,17 +2,21 @@
 #
 # Table name: activity_statuses
 #
-#  id                       :bigint           not null, primary key
-#  accepted                 :boolean          default(FALSE), not null
-#  accepted_before_deadline :boolean          default(FALSE), not null
-#  solved                   :boolean          default(FALSE), not null
-#  started                  :boolean          default(FALSE), not null
-#  solved_at                :datetime
-#  activity_id              :integer          not null
-#  series_id                :integer
-#  user_id                  :integer          not null
-#  created_at               :datetime         not null
-#  updated_at               :datetime         not null
+#  id                          :bigint           not null, primary key
+#  accepted                    :boolean          default(FALSE), not null
+#  accepted_before_deadline    :boolean          default(FALSE), not null
+#  solved                      :boolean          default(FALSE), not null
+#  started                     :boolean          default(FALSE), not null
+#  solved_at                   :datetime
+#  activity_id                 :integer          not null
+#  series_id                   :integer
+#  user_id                     :integer          not null
+#  created_at                  :datetime         not null
+#  updated_at                  :datetime         not null
+#  last_submission_id          :integer
+#  last_submission_deadline_id :integer
+#  best_submission_id          :integer
+#  best_submission_deadline_id :integer
 #
 require 'test_helper'
 

--- a/test/models/exercise_test.rb
+++ b/test/models/exercise_test.rb
@@ -327,76 +327,76 @@ class ExerciseTest < ActiveSupport::TestCase
   end
 
   test 'last submission' do
-    assert_nil @exercise.last_submission(@user)
+    assert_nil @exercise.last_submission!(@user)
 
     first = create :wrong_submission,
                    user: @user,
                    exercise: @exercise,
                    created_at: @date
 
-    assert_equal first, @exercise.last_submission(@user)
+    assert_equal first, @exercise.last_submission!(@user)
 
-    assert_nil @exercise.last_submission(@user, @date - 1.second)
+    assert_nil @exercise.last_submission!(@user, @date - 1.second)
 
     second = create :correct_submission,
                     user: @user,
                     exercise: @exercise,
                     created_at: @date + 1.minute
 
-    assert_equal second, @exercise.last_submission(@user)
-    assert_equal first, @exercise.last_submission(@user, @date + 10.seconds)
+    assert_equal second, @exercise.last_submission!(@user)
+    assert_equal first, @exercise.last_submission!(@user, @date + 10.seconds)
   end
 
   test 'last correct submission' do
-    assert_nil @exercise.last_correct_submission(@user)
+    assert_nil @exercise.last_correct_submission!(@user)
 
     create :wrong_submission,
            user: @user,
            exercise: @exercise,
            created_at: @date
 
-    assert_nil @exercise.last_correct_submission(@user)
+    assert_nil @exercise.last_correct_submission!(@user)
 
     correct = create :correct_submission,
                      user: @user,
                      exercise: @exercise,
                      created_at: @date + 1.second
 
-    assert_equal correct, @exercise.last_correct_submission(@user)
-    assert_nil @exercise.last_correct_submission(@user, @date - 1.second)
+    assert_equal correct, @exercise.last_correct_submission!(@user)
+    assert_nil @exercise.last_correct_submission!(@user, @date - 1.second)
 
     create :wrong_submission,
            user: @user,
            exercise: @exercise,
            created_at: @date + 2.seconds
 
-    assert_equal correct, @exercise.last_correct_submission(@user)
+    assert_equal correct, @exercise.last_correct_submission!(@user)
   end
 
   test 'best submission' do
-    assert_nil @exercise.best_submission(@user)
+    assert_nil @exercise.best_submission!(@user)
 
     wrong = create :wrong_submission,
                    user: @user,
                    exercise: @exercise,
                    created_at: @date
 
-    assert_equal wrong, @exercise.best_submission(@user)
+    assert_equal wrong, @exercise.best_submission!(@user)
 
     correct = create :correct_submission,
                      user: @user,
                      exercise: @exercise,
                      created_at: @date + 10.seconds
 
-    assert_equal correct, @exercise.best_submission(@user)
-    assert_equal wrong, @exercise.best_submission(@user, @date + 1.second)
+    assert_equal correct, @exercise.best_submission!(@user)
+    assert_equal wrong, @exercise.best_submission!(@user, @date + 1.second)
 
     create :wrong_submission,
            user: @user,
            exercise: @exercise,
            created_at: @date + 1.minute
 
-    assert_equal correct, @exercise.best_submission(@user)
+    assert_equal correct, @exercise.best_submission!(@user)
   end
 
   test 'best is last submission' do

--- a/test/models/exercise_test.rb
+++ b/test/models/exercise_test.rb
@@ -322,7 +322,7 @@ class ExerciseTest < ActiveSupport::TestCase
                   .raises(StandardError.new('This is an error')).then
                   .raises(StandardError.new('This is an error'))
     assert_raises StandardError do
-      @exercise.solved_for?(@user)
+      @exercise.activity_status_for!(@user)
     end
   end
 

--- a/test/models/series_test.rb
+++ b/test/models/series_test.rb
@@ -15,6 +15,7 @@
 #  indianio_token     :string(255)
 #  progress_enabled   :boolean          default(TRUE), not null
 #  activities_visible :boolean          default(TRUE), not null
+#  activities_count   :integer
 #
 
 require 'test_helper'

--- a/test/models/series_test.rb
+++ b/test/models/series_test.rb
@@ -72,7 +72,7 @@ class SeriesTest < ActiveSupport::TestCase
 
     series.update(deadline: Time.zone.now - 1.day)
 
-    Current.status_store = {}
+    ActivityStatus.clear_status_store
 
     assert_equal false, series.completed_before_deadline?(user)
   end
@@ -97,14 +97,14 @@ class SeriesTest < ActiveSupport::TestCase
 
     series.update(deadline: now - 1.day)
 
-    Current.status_store = {}
+    ActivityStatus.clear_status_store
 
     assert_equal false, series.completed_before_deadline?(user)
 
     # Reset the deadline to the original one to ensure the status was not removed.
     series.update(deadline: original_deadline)
 
-    Current.status_store = {}
+    ActivityStatus.clear_status_store
 
     assert_equal true, series.completed_before_deadline?(user)
   end

--- a/test/models/series_test.rb
+++ b/test/models/series_test.rb
@@ -71,6 +71,8 @@ class SeriesTest < ActiveSupport::TestCase
 
     series.update(deadline: Time.zone.now - 1.day)
 
+    Current.status_store = {}
+
     assert_equal false, series.completed_before_deadline?(user)
   end
 
@@ -94,10 +96,14 @@ class SeriesTest < ActiveSupport::TestCase
 
     series.update(deadline: now - 1.day)
 
+    Current.status_store = {}
+
     assert_equal false, series.completed_before_deadline?(user)
 
     # Reset the deadline to the original one to ensure the status was not removed.
     series.update(deadline: original_deadline)
+
+    Current.status_store = {}
 
     assert_equal true, series.completed_before_deadline?(user)
   end


### PR DESCRIPTION
This pull request should  significantly improve the performance of the course show page. This is done in multiple ways:

* The submission id's of relevant submissions are now also stored in the ActivityStatus model. They were calculated anyway when initializing the ActivityStatus, so there is no overhead there. This prevents several expensive queries when rendering a series card where we link to the last submission.
* The ActivityStatus objects that are used on the course page were loaded one by one. The code was modified to first hit a local store to check if we already retrieved the status before hitting the database. In addition, a method was added to preload activity statuses in batch (for all activities in a series) which reduces the number of queries.
* The batch loading described above was expanded with optional eager loading for submissions which further reduces the number of queries.
* The number of activities in a series is now stored in the database. We use a built-in rails mechanism for this so rails handles all the invalidation. This eliminates a query for each of the skeleton series loaded.

Closes #1892 