### PR TITLE
Fix performance regression on course page load

### DIFF
--- a/app/views/series/_series.html.erb
+++ b/app/views/series/_series.html.erb
@@ -17,7 +17,7 @@
       <%= render partial: 'series/series_status', locals: {loaded: loaded, series: series, user: user} %>
     </div>
     <h4 class="ellipsis-overflow" title="<%= series.name %>"><%= series.name %><br>
-      <%= render partial: 'deadlines/absolute', locals: {deadline: series.deadline, met: user ? series.completed_before_deadline?(user) : false} %>
+      <%= render partial: 'deadlines/absolute', locals: {deadline: series.deadline, met: user && loaded ? series.completed_before_deadline?(user) : false} %>
     </h4>
     <div class="flex-spacer"></div>
     <div class="card-subtitle-actions">


### PR DESCRIPTION
This pull request fixes a performance regression when loading a course page.
The deadline was formatted for every series, even if the series itself was not loaded.

Formatting of the deadline needs the series status, which can be cached. If it is not cached, the status for all exercises must be retrieved. If the activity status is not in the database, this causes a lot of submission loads.