### PR TITLE
memoize the course admin check

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -241,7 +241,12 @@ class User < ApplicationRecord
   end
 
   def admin_of?(course)
-    course.present? && administrating_courses.pluck(:id).include?(course.id)
+    return false if course.blank?
+
+    @admin_of ||= Hash.new do |h, course_id|
+      h[course_id] = administrating_courses.pluck(:id).include?(course_id)
+    end
+    @admin_of[course.id]
   end
 
   def membership_status_for(course)

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -87,9 +87,9 @@ class UserTest < ActiveSupport::TestCase
     staff.course_memberships.first.update(status: 'course_admin')
     zeus.course_memberships.first.update(status: 'course_admin')
 
-    assert user.course_admin?(course)
-    assert staff.course_admin?(course)
-    assert zeus.course_admin?(course)
+    assert user.administrating_courses.include?(course)
+    assert staff.administrating_courses.include?(course)
+    assert zeus.administrating_courses.include?(course)
   end
 
   test 'full name should be n/a when blank' do


### PR DESCRIPTION
This pull request optimizes the course admin check, further improving the performance of the course load page.

According to the flamegraph, 30-40% of the time is spent in the admin check of a course. This method is called a lot due to the extensive policy checks, but apparently the combination of `pluck` with the complex association results is terrible performance.

This should bridge the gap in course load performance between course admins and Zeus-type users.

Thanks to @nudded and @dv