### PR TITLE
Fix activity status invalidation

### DIFF
--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -269,9 +269,10 @@ class Activity < ApplicationRecord
   end
 
   def activity_statuses_for(user, course)
-    return [activity_status_for(user, nil)] if course.nil?
+    nil_status = [activity_status_for(user, nil)]
+    return nil_status if course.nil?
 
-    series_memberships.joins(:series).where('course_id = ?', course.id).map do |series_membership|
+    nil_status + series_memberships.joins(:series).where('course_id = ?', course.id).map do |series_membership|
       activity_status_for(user, series_membership.series)
     end
   end

--- a/test/models/activity_status_test.rb
+++ b/test/models/activity_status_test.rb
@@ -21,7 +21,21 @@
 require 'test_helper'
 
 class ActivityStatusTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test 'submitting to an exercise should update all activity statuses' do
+    course = create :course
+    series = create :series, course: course, exercise_count: 1
+    activity = series.activities.first
+    user = create :user
+    as1 = create :activity_status, user: user, activity: activity, series: nil
+    as2 = create :activity_status, user: user, activity: activity, series: series
+    assert_not as1.started
+    assert_not as2.started
+
+    create :submission, exercise: activity, course: course, status: :correct, user: user
+
+    as1.reload
+    as2.reload
+    assert as1.started
+    assert as2.started
+  end
 end


### PR DESCRIPTION
This pull request fixes an activity status invalidation for series = nil when submission from within a course. This caused errors on the home page.