### PR TITLE
Also cache repository and member status

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -243,10 +243,8 @@ class User < ApplicationRecord
   def admin_of?(course)
     return false if course.blank?
 
-    @admin_of ||= Hash.new do |h, course_id|
-      h[course_id] = administrating_courses.pluck(:id).include?(course_id)
-    end
-    @admin_of[course.id]
+    @admin_of ||= Set.new(administrating_courses.pluck(:id))
+    @admin_of.include?(course.id)
   end
 
   def membership_status_for(course)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -184,7 +184,10 @@ class User < ApplicationRecord
   end
 
   def repository_admin?(repository)
-    zeus? || repositories.pluck(:id).include?(repository.id)
+    return true if zeus?
+
+    @repository_admin ||= Set.new(repositories.pluck(:id))
+    @repository_admin.include?(repository.id)
   end
 
   def attempted_exercises(options)
@@ -237,7 +240,10 @@ class User < ApplicationRecord
   end
 
   def member_of?(course)
-    course.present? && subscribed_courses.pluck(:id).include?(course.id)
+    return false if course.blank?
+
+    @member_of ||= Set.new(subscribed_courses.pluck(:id))
+    @member_of.include?(course.id)
   end
 
   def admin_of?(course)

--- a/test/controllers/courses_controller_test.rb
+++ b/test/controllers/courses_controller_test.rb
@@ -104,7 +104,7 @@ class CoursesPermissionControllerTest < ActionDispatch::IntegrationTest
     with_users_signed_in @unsubscribed do |who, user|
       assert_not user.member_of?(@course), "#{who} was already a member"
       post subscribe_course_url(@course, format: :json)
-      assert user.member_of?(@course), "#{who} should be a member"
+      assert user.courses.include?(@course), "#{who} should be a member"
     end
   end
 

--- a/test/controllers/repositories_controller_test.rb
+++ b/test/controllers/repositories_controller_test.rb
@@ -49,21 +49,26 @@ class RepositoriesControllerTest < ActionDispatch::IntegrationTest
       post remove_admin_repository_url(@instance, user_id: @admin.id)
     end
 
-    user2 = create :user
-    @instance.admins << user2
+    @instance.admins << (create :user)
 
     sign_in @admin
 
     assert_difference('@instance.admins.count', -1, 'zeus should be able to remove a repository admin') do
       post remove_admin_repository_url(@instance, user_id: user.id)
     end
+  end
+
+  test 'normal user should not be able to edit repository admins' do
+    user = create :user
+    repo_admin = create :user
+    @instance.admins << repo_admin
 
     sign_in user
 
     @instance.admins << @admin
 
     assert_difference('@instance.admins.count', 0, 'user should not be able to remove a repository admin') do
-      post remove_admin_repository_url(@instance, user_id: user2.id)
+      post remove_admin_repository_url(@instance, user_id: repo_admin.id)
     end
 
     assert_difference('@instance.admins.count', 0, 'user should not be able to add a repository admin') do


### PR DESCRIPTION
This pull requests further improves the performance of the course load page. Similar to caching the values of the admin status (which is cleaned up in the PR), the repository and course member status are now similarly stored.