### PR TITLE
Add annotation status to submission json

### DIFF
--- a/app/views/submissions/_submission_basic.json.jbuilder
+++ b/app/views/submissions/_submission_basic.json.jbuilder
@@ -1,5 +1,6 @@
 json.extract! submission, :created_at, :status, :summary, :accepted, :id
 json.url submission_url(submission, format: :json)
 json.user user_url(submission.user, format: :json)
+json.has_annotations submission.annotated?
 json.exercise activity_url(submission.exercise, format: :json)
 json.course course_url(submission.course, format: :json) if submission.course


### PR DESCRIPTION
This pull requests adds a `has_annotations` field to the submission json, as requested by @beardhatcode .

![image](https://user-images.githubusercontent.com/6131398/80701751-2bc72400-8ae0-11ea-9017-16826876cca6.png)


Fixes #1951.