### PR TITLE
optimize drawer partial

### DIFF
--- a/app/models/course_membership.rb
+++ b/app/models/course_membership.rb
@@ -38,6 +38,10 @@ class CourseMembership < ApplicationRecord
       .having('COUNT(DISTINCT(course_membership_labels.course_label_id)) = ?', course_labels.uniq.length)
   }
 
+  def subscribed?
+    student? || course_admin?
+  end
+
   def at_least_one_admin_per_course
     if status_was == 'course_admin' &&
        status != 'course_admin' &&

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -237,9 +237,9 @@ class User < ApplicationRecord
 
   def drawer_courses
     actual_memberships = course_memberships.includes(:course).to_a.select(&:subscribed?)
-    favorites = actual_memberships.select(&:favorite)
-
     return [] if actual_memberships.empty?
+
+    favorites = actual_memberships.select(&:favorite)
     return favorites.map(&:course) if favorites.any?
 
     sorted_courses = actual_memberships.map(&:course).sort_by(&:year).reverse

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -235,6 +235,17 @@ class User < ApplicationRecord
     subscribed_courses.group_by(&:year).first(number_of_years)
   end
 
+  def drawer_courses
+    actual_memberships = course_memberships.includes(:course).to_a.select(&:subscribed?)
+    favorites = actual_memberships.select(&:favorite)
+
+    return [] if actual_memberships.empty?
+    return favorites.map(&:course) if favorites.any?
+
+    sorted_courses = actual_memberships.map(&:course).sort_by(&:year).reverse
+    sorted_courses.select { |c| c.year == sorted_courses.first.year }
+  end
+
   def full_view?
     subscribed_courses.count > 4 || subscribed_courses.group_by(&:year).length > 1 || favorite_courses.count.positive?
   end

--- a/app/views/layouts/_drawer.html.erb
+++ b/app/views/layouts/_drawer.html.erb
@@ -3,11 +3,7 @@
     <div class="drawer-group">
       <h1 class="drawer-group-title"><%= t 'layout.menu.courses' %></h1>
       <ul class="drawer-list">
-        <% courses = if current_user.favorite_courses.any?
-                       current_user.favorite_courses
-                     else
-                       current_user.recent_courses(1)
-                     end %>
+        <% courses = current_user.drawer_courses %>
         <% courses.each do |course| %>
           <li>
             <%= activatable_link_to course_path(course),


### PR DESCRIPTION
This pull request hopefully improves the drawer partial performance. Right now on an exercise page on my account, it takes 12ms, 3 queries and 3ms in SQL to render the partial.

#1954 

In a later PR when cleaning up the home page, the grouped functions in the user model can be removed.