### PR TITLE
Use fragment cache for markdown descriptions

### DIFF
--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -32,7 +32,9 @@
       <% if @course.description.present? or current_user&.member_of?(@course).! %>
         <div class="card-supporting-text card-border row course-description">
           <div class="col-sm-<%= current_user&.member_of?(@course).! ? '6' : '12' %> col-xs-12">
-            <%= markdown(@course.description) %>
+            <%= cache @course do %>
+              <%= markdown(@course.description) %>
+            <% end %>
           </div>
           <% if current_user&.member_of?(@course).! %>
             <%= render partial: 'not_a_member_card' %>

--- a/app/views/series/_series.html.erb
+++ b/app/views/series/_series.html.erb
@@ -110,7 +110,9 @@
     </div>
   <% end %>
   <div class="series-description">
-    <%= markdown(series.description) %>
+    <%= cache series do %>
+      <%= markdown(series.description) %>
+    <% end %>
   </div>
 
   <% if policy(series).overview? && series.activity_count > 0 %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -38,7 +38,7 @@ Rails.application.configure do
 
     config.action_mailer.perform_caching = false
 
-    # config.cache_store = :mem_cache_store, { namespace: :"2" }
+    config.cache_store = :mem_cache_store, { namespace: :"2" }
     config.public_file_server.headers = {
       'Cache-Control' => "public, max-age=#{2.days.to_i}"
     }

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -38,7 +38,7 @@ Rails.application.configure do
 
     config.action_mailer.perform_caching = false
 
-    config.cache_store = :mem_cache_store, { namespace: :"2" }
+    # config.cache_store = :mem_cache_store, { namespace: :"2" }
     config.public_file_server.headers = {
       'Cache-Control' => "public, max-age=#{2.days.to_i}"
     }


### PR DESCRIPTION
This pull request enables the rails fragment cache for series and course descriptions. On the course page, 30% of the time is spent on markdown rendering and sanitization. The fragment cache auto-generates a cache key which changes if the object itself (`updated_at` value) or the code within the cache block changes so we don't have to worry about invalidation.

The skeleton series could also be cached as a whole in a future pull request since they don't contain any dynamic content.