### PR TITLE
Fix unread notification favicon always being shown

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,8 +17,8 @@
   <meta name="msapplication-TileColor" content="#2196F3"/>
   <meta name="msapplication-TileImage" content="/icon.png"/>
   <link rel="apple-touch-icon-precomposed" href="/icon.png"/>
-  <link rel="shortcut icon" sizes="192x192" href="<%= @unread_notifications ? "/icon-not.png" : "/icon.png" %>">
-  <link rel="shortcut icon" href="<%= @unread_notifications ? "/favicon-not.ico" : "/favicon.ico" %>">
+  <link rel="shortcut icon" sizes="192x192" href="<%= @unread_notifications&.any? ? "/icon-not.png" : "/icon.png" %>">
+  <link rel="shortcut icon" href="<%= @unread_notifications&.any? ? "/favicon-not.ico" : "/favicon.ico" %>">
   <link rel="manifest" href="/manifest.json">
   <title>Dodona<%= " - #{@title}" if @title %></title>
   <link href='https://fonts.googleapis.com/css?family=Roboto:400,400italic,300,500,700' rel='stylesheet' type='text/css'>


### PR DESCRIPTION
`[]` is thruthy in ruby, apparently.
