### PR TITLE
Only generate JS translations in development mode

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -40,8 +40,6 @@ module Dodona
     config.autoload_paths += Dir[Rails.root.join('app', 'helpers', 'renderers')]
     config.autoload_paths += Dir[Rails.root.join('app', 'models', 'transient')]
 
-    config.middleware.use I18n::JS::Middleware
-
     config.active_job.queue_adapter = :delayed_job
 
     config.active_storage.queues.analysis = :default

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -84,6 +84,10 @@ Rails.application.configure do
   # Raises error for missing translations
   config.action_view.raise_on_missing_translations = true
 
+
+  # Regenerate js translation files
+  config.middleware.use I18n::JS::Middleware
+
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   # config.file_watcher = ActiveSupport::EventedFileUpdateChecker


### PR DESCRIPTION
This pull request removes the I18n js middleware from production and only loads it in development.

Our JS translation files are "compiled" into a js file for use by our i18n library. Every time there are changes to the source files, the result is regenerated. This was done through some rails middleware.

Upon profiling our pages, I noticed that the check to see if the JS translations were up to date took 5-10ms on every request. Since these do not change after deployment, this is of course unnecessary. I therefore disabled the middleware in the production environment and only enable it in development mode.

Risk: changing a JS translation without loading at least one page in development mode will not propagate that change into production.