### PR TITLE
Fix iframe resizing

### DIFF
--- a/app/javascript/packs/exercise.js
+++ b/app/javascript/packs/exercise.js
@@ -7,4 +7,4 @@ window.dodona.onFrameMessage = onFrameMessage;
 window.dodona.onFrameScroll = onFrameScroll;
 
 // will automaticaly bind to window.iFrameResize()
-import { iframeResizer } from "iframe-resizer"; // eslint-disable-line no-unused-vars
+require("iframe-resizer");


### PR DESCRIPTION
#1927 broke resizing of iframes. My best guess is that a babel update probably changed how unused imports are handled. In any case, changing the `import` to a `require` fixed it for me. (Which also kinda makes sense to me, since we aren't actually importing anything, we just want the javascript to be bundled.)

Also deployed this on Naos, and it works there again as well.
