### PR TITLE
Only enable datadog in deployed environments

### DIFF
--- a/config/initializers/datadog-tracer.rb
+++ b/config/initializers/datadog-tracer.rb
@@ -2,6 +2,7 @@ if Rails.env.production? || Rails.env.staging?
   Datadog.configure do |c|
     c.use :rails, service_name: 'dodona'
     c.use :delayed_job
+    c.use :dalli
     c.analytics_enabled = true
     c.version = Dodona::Application::VERSION
   end

--- a/config/initializers/datadog-tracer.rb
+++ b/config/initializers/datadog-tracer.rb
@@ -1,6 +1,8 @@
-Datadog.configure do |c|
-  c.use :rails, service_name: 'dodona'
-  c.use :delayed_job
-  c.analytics_enabled = true
-  c.version = Dodona::Application::VERSION
+if Rails.env.production? || Rails.env.staging?
+  Datadog.configure do |c|
+    c.use :rails, service_name: 'dodona'
+    c.use :delayed_job
+    c.analytics_enabled = true
+    c.version = Dodona::Application::VERSION
+  end
 end


### PR DESCRIPTION
I was seeing error messages like this in server and test output, and it was annoying me:
```
E, [2020-05-16T11:35:57.282820 #5038] ERROR -- ddtrace: [ddtrace] (/home/charlotte/repos/dodona/dodona/vendor/bundle/2.6.6/gems/ddtrace-0.35.2/lib/ddtrace/transport/http/client.rb:35:in `rescue in send_request') Internal error during HTTP transport request. Cause: Failed to open TCP connection to 127.0.0.1:8126 (Connection refused - connect(2) for "127.0.0.1" port 8126) Location: /nix/store/8nlbhrrs2y2y3y7alqj8h40q8hh9miyf-ruby-2.6.6/lib/ruby/2.6.0/net/http.rb:949:in `rescue in block in connect'
```
