### PR TITLE
Remove datadog RUM

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -25,14 +25,6 @@ import { Toast } from "toast";
 import { Notification } from "notification";
 import { checkTimeZone, initCSRF, initTooltips } from "util.js";
 import { initClipboard } from "copy";
-import { datadogRum } from "@datadog/browser-rum";
-
-datadogRum.init({
-    applicationId: "477d9a7b-e9be-42eb-9caa-f4e92286eb32",
-    clientToken: "pub9b24c5cc957941661162cd98406925ad",
-    datacenter: "us",
-    sampleRate: 100,
-});
 
 // Initialize clipboard.js
 initClipboard();

--- a/app/javascript/packs/frame.js
+++ b/app/javascript/packs/frame.js
@@ -1,5 +1,4 @@
 import jQuery from "jquery";
-import { datadogRum } from "@datadog/browser-rum";
 
 // jQuery aliases
 window.jQuery = jQuery;
@@ -19,10 +18,3 @@ window.dodona = dodona;
 initClipboard();
 
 $(initTooltips);
-
-datadogRum.init({
-    applicationId: "477d9a7b-e9be-42eb-9caa-f4e92286eb32",
-    clientToken: "pub9b24c5cc957941661162cd98406925ad",
-    datacenter: "us",
-    sampleRate: 100,
-});

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -11,7 +11,6 @@ Rails.application.config.content_security_policy do |policy|
 
   if Rails.env.development?
     # Allow webpack-dev-server
-    # Don't allow datadog
     policy.connect_src :self, 'https://pandora.ugent.be',
                        'https://www.google-analytics.com',
                        'https://*.googleapis.com',
@@ -19,7 +18,6 @@ Rails.application.config.content_security_policy do |policy|
   else
     policy.connect_src :self, 'https://pandora.ugent.be',
                        'https://www.google-analytics.com',
-                       'https://rum-http-intake.logs.datadoghq.com',
                        'https://*.googleapis.com'
   end
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
   },
   "dependencies": {
     "@babel/preset-typescript": "^7.9.0",
-    "@datadog/browser-rum": "^1.11.4",
     "@rails/activestorage": "^6.0.3",
     "@rails/ujs": "^6.0.3",
     "@rails/webpacker": "5.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -845,25 +845,6 @@
   resolved "https://registry.yarnpkg.com/@csstools/convert-colors/-/convert-colors-1.4.0.tgz#ad495dc41b12e75d588c6db8b9834f08fa131eb7"
   integrity sha512-5a6wqoJV/xEdbRNKVo6I4hO3VjyDq//8q2f9I6PBAvMesJHFauXDorcNCsr9RzvsZnaWi5NYCcfyqP1QeFHFbw==
 
-"@datadog/browser-core@1.11.4":
-  version "1.11.4"
-  resolved "https://registry.yarnpkg.com/@datadog/browser-core/-/browser-core-1.11.4.tgz#3a304498b2019aecfd262040f30db5127dd24ed4"
-  integrity sha512-yHrEhMzwWsHxgAodSlB3Rjnlxk4yrlJnKbpwUU/40SGHPtehmHw0N2fsIpRKIuCZYSshL3IjW0ZLO+odGzt0Cg==
-  dependencies:
-    lodash.assign "4.2.0"
-    lodash.merge "4.6.2"
-    tslib "1.10.0"
-
-"@datadog/browser-rum@^1.11.4":
-  version "1.11.4"
-  resolved "https://registry.yarnpkg.com/@datadog/browser-rum/-/browser-rum-1.11.4.tgz#cb7200f7a56cda8411cfef3985a59406f8613689"
-  integrity sha512-HyN8wutk/pFexEiKtGW2GCn0psPXy8Rqu5HKv7gj0GsE0idHgxVwC5IX9H8MnXd9DOq4+e2rsEE3miWxS75vXQ==
-  dependencies:
-    "@datadog/browser-core" "1.11.4"
-    lodash.assign "4.2.0"
-    lodash.merge "4.6.2"
-    tslib "1.10.0"
-
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@istanbuljs/load-nyc-config/-/load-nyc-config-1.0.0.tgz#10602de5570baea82f8afbfa2630b24e7a8cfe5b"
@@ -6253,11 +6234,6 @@ lodash._reinterpolate@^3.0.0:
   resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
   integrity sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=
 
-lodash.assign@4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/lodash.assign/-/lodash.assign-4.2.0.tgz#0d99f3ccd7a6d261d19bdaeb9245005d285808e7"
-  integrity sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=
-
 lodash.get@^4.0:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
@@ -6272,11 +6248,6 @@ lodash.memoize@4.x, lodash.memoize@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
   integrity sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=
-
-lodash.merge@4.6.2:
-  version "4.6.2"
-  resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
-  integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
 lodash.sortby@^4.7.0:
   version "4.7.0"
@@ -9006,7 +8977,7 @@ simple-swizzle@^0.2.2:
   dependencies:
     is-arrayish "^0.3.1"
 
-sisteransi@^1.0.3:
+sisteransi@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/sisteransi/-/sisteransi-1.0.5.tgz#134d681297756437cc05ca01370d3a7a571075ed"
   integrity sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==
@@ -9775,11 +9746,6 @@ ts-pnp@^1.1.6:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.2.0.tgz#a500ad084b0798f1c3071af391e65912c86bca92"
   integrity sha512-csd+vJOb/gkzvcCHgTGSChYpy5f1/XKNsmvBGO4JXS+z1v2HobugDz4s1IeFXM3wZB44uczs+eazB5Q/ccdhQw==
-
-tslib@1.10.0:
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
-  integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==
 
 tslib@^1.8.1, tslib@^1.9.0:
   version "1.11.1"


### PR DESCRIPTION
This pull request removes the Datadog RUM. The results from this data are limited and don't outweigh the additional data gathering.

After this gets deployed, we will gather less data than before since firebase was removed as well. Performance monitoring now only happens using anonymous server-side metrics.
