### PR TITLE
Update google font loading

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -21,7 +21,7 @@
   <link rel="shortcut icon" href="<%= @unread_notifications&.any? ? "/favicon-not.ico" : "/favicon.ico" %>">
   <link rel="manifest" href="/manifest.json">
   <title>Dodona<%= " - #{@title}" if @title %></title>
-  <link href='https://fonts.googleapis.com/css?family=Roboto:400,400italic,300,500,700' rel='stylesheet' type='text/css'>
+  <link href="https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,300;0,400;0,500;0,700;1,400&display=swap" rel="stylesheet">
   <link href="https://cdn.materialdesignicons.com/3.6.95/css/materialdesignicons.min.css"
         rel="stylesheet" type='text/css'>
   <% if session[:dark].nil? && current_user.present? %>

--- a/app/views/layouts/frame.html.erb
+++ b/app/views/layouts/frame.html.erb
@@ -9,7 +9,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <%= yield :meta_tags %>
   <meta property="og:image" content="<%= root_url(locale: nil) %>icon.png">
-  <link href='https://fonts.googleapis.com/css?family=Roboto:400,400italic,300,500,700' rel='stylesheet' type='text/css'>
+  <link href="https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,300;0,400;0,500;0,700;1,400&display=swap" rel="stylesheet">
   <link href="https://cdn.materialdesignicons.com/3.6.95/css/materialdesignicons.min.css" rel="stylesheet" type='text/css'>
   <% if params[:dark].nil? %>
     <%= stylesheet_link_tag "application-dark", media: '(prefers-color-scheme: dark)' %>


### PR DESCRIPTION
This pull request updates the google font include. There are 2 changes:
- The url format is slightly different (but the returned css is identical)
- There is now support for `font-display: swap` which will render the page in the fallback font while the webfont is being loaded (instead of showing nothing). This improves the first contentful paint time.

Can anyone test this locally if this still works with the csp. I expect no issues, but can't test is locally because I have Roboto installed as a system font (so it never loads the webfont).