### PR TITLE
Remove report-uri

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -33,8 +33,6 @@ Rails.application.config.content_security_policy do |policy|
 
   policy.style_src   :self, :unsafe_inline, 'https://fonts.googleapis.com',
                      'https://cdn.materialdesignicons.com'
-
-  policy.report_uri  'https://dodona.report-uri.com/r/d/csp/enforce'
 end
 
 # Rails.application.config.content_security_policy_report_only = true


### PR DESCRIPTION
This pull request removes report-uri from the CSP. We used the free tier of the service which only includes 10k reports per month. Our traffic is a lot higher so we don't get much use of it because we instantly go over the quotum which results in failed requests for the rest of the month.