### PR TITLE
Improve sanitize performance

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -137,12 +137,7 @@ module ApplicationHelper
     sanitized = ActionController::Base.helpers.sanitize html,
                                                         tags: tags,
                                                         attributes: attributes
-    # If an anchor has a target, disable the referer
-    doc = Nokogiri::HTML::DocumentFragment.parse(sanitized)
-    doc.css('a[target*=\'_blank\']').each do |a|
-      a['rel'] = 'noopener noreferrer'
-    end
-    doc.to_html.html_safe
+    sanitized.html_safe
   end
 
   def markdown(source)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -129,14 +129,13 @@ module ApplicationHelper
   end
 
   def sanitize(html)
-    tags = Rails::Html::SafeListSanitizer.allowed_tags.to_a
-    tags += %w[table thead tbody tr td th colgroup col style svg circle line rect path summary details]
-    attributes = Rails::Html::SafeListSanitizer.allowed_attributes.to_a
-    attributes += %w[style target data-toggle data-parent data-tab data-line data-element id x1 y1 x2 y2 stroke stroke-width fill cx cy r]
-    # Filteres allowed tags and attributes
+    @tags ||= Rails::Html::SafeListSanitizer.allowed_tags.to_a + %w[table thead tbody tr td th colgroup col style svg circle line rect path summary details]
+    @attributes ||= Rails::Html::SafeListSanitizer.allowed_attributes.to_a + %w[style target data-toggle data-parent data-tab data-line data-element id x1 y1 x2 y2 stroke stroke-width fill cx cy r]
+
+    # Filters allowed tags and attributes
     sanitized = ActionController::Base.helpers.sanitize html,
-                                                        tags: tags,
-                                                        attributes: attributes
+                                                        tags: @tags,
+                                                        attributes: @attributes
     sanitized.html_safe
   end
 

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -81,12 +81,4 @@ class ApplicationHelperTest < ActiveSupport::TestCase
     clean_html = sanitize dirty_html
     assert_equal dirty_html, clean_html
   end
-
-  test 'sanitize helper should add \'rel="noopener noreferrer"\'' do
-    dirty_html = <<~HTML
-      <a target="_blank" href="cookies.com">
-    HTML
-    clean_html = sanitize dirty_html
-    assert_match(/rel="noopener noreferrer"/, clean_html)
-  end
 end


### PR DESCRIPTION
This pull request should in prove the performance of the sanitize functions which is called many many times when constructing a feedback table. I made 2 changes:

- The list of allowed tags and attributes is now constructed only once
- The addition of noopener and noreferrer to target blanks links was removed. For this last check, the entire string had to be parsed a second time. The removal of this opens a small attack surface: course admins and exercise creators could add a link to a malicious site. This site could then change the "parent" page to a look-alike of the sign in page. When the user closes the newly opened tab, he then sees this sign in page and could be tricked into trusting that page because Dodona was previously in that tab. The risk for this seems minimal:
  - Only semi-trusted users can create courses and exercises
  - Dodona has no sign in page, so it would have to target a page from the institution of the user
  - Browsers are working to preventing this exploit. This is already fixed in Safari and the Firefox nightly. A fix is also planned for Chromium.

I will amend this PR with some timings.