### PR TITLE
Add public status dashboard link to footer

### DIFF
--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -8,6 +8,7 @@
       <i class="mdi mdi-18 mdi-twitter"></i>
     </a>
     <%= link_to 'Contact', contact_path %>
+    <%= link_to 'Status', status_path, target: "_blank", rel: "noopener" %>
     <%= link_to t("layout.footer.privacy_statement"), privacy_path %>
     <%= link_to t("layout.footer.your_data"), data_path %>
     <% version_info = "Dodona #{Dodona::Application::VERSION}" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,8 @@ Rails.application.routes.draw do
     post '/toggle_demo_mode' => 'pages#toggle_demo_mode'
     post '/toggle_dark_mode' => 'pages#toggle_dark_mode'
 
+    get '/status' => redirect("https://p.datadoghq.com/sb/sil3oh7xurb0ujwu-3dfa8d0b077b83f3afbee49f0641abfd"), :as => :status
+
     concern :mediable do
       member do
         constraints host: Rails.configuration.default_host do


### PR DESCRIPTION
This pull request adds a redirect from `/status` to https://p.datadoghq.com/sb/sil3oh7xurb0ujwu-3dfa8d0b077b83f3afbee49f0641abfd which is our public status dashboard. It also adds a link to this page in the footer.