### PR TITLE
Use scoped activity url when submitting sample

### DIFF
--- a/app/views/activities/info.html.erb
+++ b/app/views/activities/info.html.erb
@@ -184,7 +184,7 @@
                 <% solutions.each_with_index do |(fname, code), i| %>
                   <div id="solution-<%= i %>" class="tab-pane feedback-table">
                     <div class="feedback-table-options">
-                      <%= link_to t('.sample_solution_submit'), activity_url(@activity, from_solution: fname), class: "btn-text" %>
+                      <%= link_to t('.sample_solution_submit'), activity_scoped_url(activity: @activity, series: @series, course: @course, options: {from_solution: fname}), class: "btn-text" %>
                     </div>
                     <div class="code-table">
                       <%= raw FeedbackCodeRenderer.new(code, @activity.programming_language.name).add_code.html %>


### PR DESCRIPTION
I think it makes sense that when submitting a sample solution whilst viewing the exercise as part of a series/course, the submission should happen in the series/course.