### PR TITLE
Make annotation icon in submissions table a link to code tab

### DIFF
--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -171,7 +171,7 @@ class Submission < ApplicationRecord
   end
 
   def annotated?
-    annotations.any?
+    annotations.left_joins(:evaluation).released.any?
   end
 
   def skip_rate_limit_check?

--- a/app/views/submissions/_submission.html.erb
+++ b/app/views/submissions/_submission.html.erb
@@ -2,7 +2,9 @@
   <td>
     <%= submission_status_icon(submission) %>
     <% if submission.annotated? %>
-      <i class="mdi mdi-comment-text-outline mdi-18 colored-secondary" data-toggle="tooltip" data-placement="top" title="<%= t('submissions.submissions_table.annotated') %>"></i>
+      <%= link_to submission_url(submission, anchor: "code"), title: t('submissions.submissions_table.annotated'), data: { toggle: "tooltip", placement: "top" } do %>
+        <i class="mdi mdi-comment-text-outline mdi-18 colored-secondary"></i>
+      <% end %>
     <% end %>
   </td>
   <% if user.nil? && (current_user.admin? || current_user.administrating_courses.any?) %>


### PR DESCRIPTION
This pull request also changes the condition for the icon to be shown to only include annotations from released evaluation (or without an evaluation).

Closes #1873.
