### PR TITLE
Fix I18n for deadline at evaluation screen

### DIFF
--- a/app/models/evaluation.rb
+++ b/app/models/evaluation.rb
@@ -76,7 +76,7 @@ class Evaluation < ApplicationRecord
   private
 
   def deadline_in_past
-    errors.add(:deadline, 'should be in the past') if deadline.present? && deadline > Time.current
+    errors.add(:deadline, I18n.t('deadlines.validate.should_be_in_past')) if deadline.present? && deadline > Time.current
   end
 
   def manage_feedbacks

--- a/config/locales/views/deadline/en.yml
+++ b/config/locales/views/deadline/en.yml
@@ -1,7 +1,8 @@
 en:
   deadlines:
-    missed:
-      "missed deadline"
+    missed: missed deadline
     relative:
       ago: "%{time_ago} ago"
       in: "in %{time_left}"
+    validate:
+      should_be_in_past: 'should be in the past'

--- a/config/locales/views/deadline/nl.yml
+++ b/config/locales/views/deadline/nl.yml
@@ -1,7 +1,8 @@
 nl:
   deadlines:
-    missed:
-      "deadline gemist"
+    missed: deadline gemist
     relative:
       ago: "%{time_ago} geleden"
       in: "binnen %{time_left}"
+    validate:
+      should_be_in_past: 'moet in het verleden liggen'


### PR DESCRIPTION
This pull request fixes the dutch translation for an error message at the evaluation screen.

<!-- If there are visual changes, add a screenshot -->
![image](https://user-images.githubusercontent.com/6131398/84659752-2ef36380-af18-11ea-9e1e-bc31b64822ae.png)
