### PR TITLE
Disable read button after submit

### DIFF
--- a/app/assets/stylesheets/models/activities.css.less
+++ b/app/assets/stylesheets/models/activities.css.less
@@ -92,6 +92,10 @@
     left: 10px;
   }
 
+  #content_page_read_action {
+    display: inline-flex;
+  }
+
   .next {
     position: absolute;
     right: 10px;

--- a/app/views/activities/_content_page_read_button.erb
+++ b/app/views/activities/_content_page_read_button.erb
@@ -8,9 +8,11 @@
   <span id='content_page_read_action'>
     <% read_url = read_activity_url(activity) %>
     <% read_url = read_course_activity_url(course, activity) if course.present? %>
-    <%= link_to read_url, method: :post, remote: true, class: 'btn btn-primary with-text btn-fab-extended' do %>
-      <i class="mdi mdi-clipboard-check-outline icon"></i>
-      <span class="text"><%= t('activities.show.mark_as_read') %></span>
+    <%= form_tag read_url, method: :post, remote: true do %>
+      <%= button_tag class: 'btn btn-primary with-text btn-fab-extended', data: {disable_with: t('general.please_wait')} do %>
+        <i class="mdi mdi-clipboard-check-outline icon"></i>
+        <span class="text"><%= t('activities.show.mark_as_read') %></span>
+      <% end %>
     <% end %>
   </span>
 <% end %>

--- a/config/locales/views/defaults/en.yml
+++ b/config/locales/views/defaults/en.yml
@@ -58,6 +58,7 @@ en:
     are_you_sure: "Are you sure?"
     confirm_reset_token: 'Are you sure? The old token/link will not be usable anymore when you generate a new one.'
     generate_token: 'Generate new'
+    please_wait: 'Please wait...'
   errors:
     no_rights: Sorry, you are not allowed to access this page.
     validation_errors:

--- a/config/locales/views/defaults/nl.yml
+++ b/config/locales/views/defaults/nl.yml
@@ -58,6 +58,7 @@ nl:
     are_you_sure: "Ben je zeker?"
     confirm_reset_token: 'Ben je zeker? De oude token/link zal niet meer bruikbaar zijn als je een nieuwe genereert.'
     generate_token: 'Genereer nieuw'
+    please_wait: 'Even geduld...'
   errors:
     no_rights: Sorry, je hebt geen toegangsrechten tot deze pagina.
     validation_errors:


### PR DESCRIPTION
This pull request disables the "Mark activity as read" button after clicking it, to prevent double clicking. If, for whatever reason, the request has failed, the original button will re-appear and become clickable again.

This has been implemented using a built-in Rails feature, which requires the button to be an actual `button`, rather than an `a`.

![example](https://user-images.githubusercontent.com/6131398/84662063-9232c500-af1b-11ea-9966-dbb63dbe2134.gif)

ges, add a screenshot -->

Closes #2039  .
