### PR TITLE
Allow to expand individual annotations

### DIFF
--- a/app/assets/javascripts/code_listing/code_listing.ts
+++ b/app/assets/javascripts/code_listing/code_listing.ts
@@ -203,6 +203,15 @@ export class CodeListing {
             dot.id = `dot-${line}`;
             row.querySelector<HTMLTableDataCellElement>(".rouge-gutter").prepend(dot);
 
+            // Add a click listener to the dot.
+            dot.addEventListener("click", () => {
+                if (annotation.html.classList.contains("hide")) {
+                    annotation.show();
+                } else {
+                    annotation.hide();
+                }
+            });
+
             // Create annotation groups.
             ANNOTATION_ORDER.forEach((type: string) => {
                 const group = document.createElement("div") as HTMLDivElement;

--- a/app/assets/stylesheets/components/code_listing.css.less
+++ b/app/assets/stylesheets/components/code_listing.css.less
@@ -93,6 +93,7 @@
         }
 
         .dot {
+          cursor: pointer;
           float: left;
           margin-left: 4px;
           margin-top: 4px;


### PR DESCRIPTION
This pull request allows the user to show individual annotations by clicking on the dots. Currently, the dots do not disappear when the annotation is shown, to allow the user to re-hide it.

**Limitation:** Since the `annotate-this-line` button appears on top of the dot, it is only possible to click the dot as a student.

<!-- If there are visual changes, add a screenshot -->

![visual](https://user-images.githubusercontent.com/6131398/84664447-dc697580-af1e-11ea-9945-aa99574bbd7d.gif)



Closes #2037  .
