### PR TITLE
Redirect providers [depends on #2065]

### DIFF
--- a/app/controllers/auth/omniauth_callbacks_controller.rb
+++ b/app/controllers/auth/omniauth_callbacks_controller.rb
@@ -124,8 +124,8 @@ class Auth::OmniauthCallbacksController < Devise::OmniauthCallbacksController
         "#{auth_hash.pretty_inspect}"
 
     ApplicationMailer.with(authinfo: auth_hash, errors: resource.errors.inspect)
-        .user_unable_to_log_in
-        .deliver_later
+                     .user_unable_to_log_in
+                     .deliver_later
 
     redirect_with_flash! resource.errors.full_messages.to_sentence
   end
@@ -133,10 +133,6 @@ class Auth::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   def redirect_with_flash!(message)
     flash_failure message
     redirect_to root_path
-  end
-
-  def ugent_saml_provider
-    Provider::Saml.find_by(entity_id: UGENT_SAML_ENTITY_ID)
   end
 
   # ==> Shorthands.
@@ -181,8 +177,8 @@ class Auth::OmniauthCallbacksController < Devise::OmniauthCallbacksController
       "#{auth_hash.pretty_inspect}"
 
     ApplicationMailer.with(authinfo: auth_hash)
-        .institution_created
-        .deliver_later
+                     .institution_created
+                     .deliver_later
   end
 
   def institution_create_failed(errors)
@@ -192,8 +188,8 @@ class Auth::OmniauthCallbacksController < Devise::OmniauthCallbacksController
       "#{errors}"
 
     ApplicationMailer.with(authinfo: auth_hash, errors: errors.inspect)
-        .institution_creation_failed
-        .deliver_later
+                     .institution_creation_failed
+                     .deliver_later
   end
 
   def provider_missing!

--- a/app/controllers/auth/omniauth_callbacks_controller.rb
+++ b/app/controllers/auth/omniauth_callbacks_controller.rb
@@ -1,18 +1,4 @@
 class Auth::OmniauthCallbacksController < Devise::OmniauthCallbacksController
-  # Saml entity id for UGent.
-  UGENT_SAML_ENTITY_ID = 'https://identity.ugent.be/simplesaml/saml2/idp/metadata.php'.freeze
-
-  # Tenant ID's of known Office365 organisations
-  # who should use another sign in method
-  # TODO refactor using redirect providers
-  #      https://github.com/dodona-edu/dodona/issues/2067
-  UGENT_TID = 'd7811cde-ecef-496c-8f91-a1786241b99c'.freeze
-  WAREGEM_TID = '9fdf506a-3be0-4f07-9e03-908ceeae50b4'.freeze
-  TSM_TID = 'https://tsm.smartschool.be'.freeze
-  CVO_TSM_TID = 'https://cvotsm.smartschool.be'.freeze
-  MAERLANT_TID = 'https://kabl-sgr25.smartschool.be'.freeze
-  BLACKLIST = [UGENT_TID, WAREGEM_TID, TSM_TID, CVO_TSM_TID, MAERLANT_TID].freeze
-
   # Disable CSRF since the token information is lost.
   skip_before_action :verify_authenticity_token
 
@@ -20,8 +6,8 @@ class Auth::OmniauthCallbacksController < Devise::OmniauthCallbacksController
 
   def failure
     flash_failure request.params['error_message'] \
-                                                  || request.params['error_description'] \
-                                                  || I18n.t('devise.omniauth_callbacks.unknown_failure')
+                                                   || request.params['error_description'] \
+                                                   || I18n.t('devise.omniauth_callbacks.unknown_failure')
     redirect_to root_path
   end
 
@@ -50,7 +36,6 @@ class Auth::OmniauthCallbacksController < Devise::OmniauthCallbacksController
 
   def generic_oauth
     return provider_missing! if oauth_provider_id.blank?
-    return provider_blacklisted! if BLACKLIST.include?(oauth_provider_id)
 
     # Find the provider for the current institution. If no provider exists yet,
     # a new one will be created.
@@ -60,6 +45,9 @@ class Auth::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   end
 
   def try_login!
+    # Ensure the preferred provider is used.
+    return redirect_to_preferred_provider! unless provider.prefer?
+
     # Find the identity.
     identity, user = find_identity_and_user
     if identity.blank?
@@ -123,13 +111,21 @@ class Auth::OmniauthCallbacksController < Devise::OmniauthCallbacksController
     set_flash_message :notice, :failure, kind: auth_provider_type || 'OAuth2', reason: reason
   end
 
+  def redirect_to_preferred_provider!
+    # Find the preferred provider for the current institution.
+    preferred_provider = provider.institution.preferred_provider
+
+    # Redirect to the provider.
+    redirect_to omniauth_authorize_path(:user, preferred_provider.class.sym, provider: preferred_provider)
+  end
+
   def redirect_with_errors!(resource)
     logger.info "User was unable to login because of reason: '#{resource.errors.full_messages.to_sentence}'. More info about the request below:\n" \
         "#{auth_hash.pretty_inspect}"
 
     ApplicationMailer.with(authinfo: auth_hash, errors: resource.errors.inspect)
-                     .user_unable_to_log_in
-                     .deliver_later
+        .user_unable_to_log_in
+        .deliver_later
 
     redirect_with_flash! resource.errors.full_messages.to_sentence
   end
@@ -185,8 +181,8 @@ class Auth::OmniauthCallbacksController < Devise::OmniauthCallbacksController
       "#{auth_hash.pretty_inspect}"
 
     ApplicationMailer.with(authinfo: auth_hash)
-                     .institution_created
-                     .deliver_later
+        .institution_created
+        .deliver_later
   end
 
   def institution_create_failed(errors)
@@ -196,25 +192,8 @@ class Auth::OmniauthCallbacksController < Devise::OmniauthCallbacksController
       "#{errors}"
 
     ApplicationMailer.with(authinfo: auth_hash, errors: errors.inspect)
-                     .institution_creation_failed
-                     .deliver_later
-  end
-
-  def provider_blacklisted!
-    if oauth_provider_id == WAREGEM_TID
-      # College Waregem uses two emails,
-      # but we only allow <name>@sgpaulus.eu
-      flash_failure I18n.t('auth.sign_in.blacklist.sgpaulus')
-      redirect_to sign_in_path
-    elsif oauth_provider_id == UGENT_TID
-      # If an UGent-user logs in using Office365,
-      # redirect to saml login
-      redirect_to omniauth_authorize_path(:user, Provider::Saml.sym, provider: ugent_saml_provider)
-    elsif oauth_provider_id == TSM_TID || oauth_provider_id == CVO_TSM_TID
-      redirect_to omniauth_authorize_path(:user, Provider::Office365.sym)
-    elsif oauth_provider_id == MAERLANT_TID
-      redirect_to omniauth_authorize_path(:user, Provider::GSuite.sym)
-    end
+        .institution_creation_failed
+        .deliver_later
   end
 
   def provider_missing!

--- a/app/models/institution.rb
+++ b/app/models/institution.rb
@@ -31,6 +31,10 @@ class Institution < ApplicationRecord
 
   scope :of_course_by_members, ->(course) { joins(users: :courses).where(courses: { id: course.id }).distinct }
 
+  def preferred_provider
+    Provider.find_by(institution: self, mode: :prefer)
+  end
+
   def uses_smartschool?
     providers.any? { |provider| provider.type == Provider::Smartschool.name }
   end

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -45,7 +45,7 @@ class Provider < ApplicationRecord
     return if institution.blank?
 
     # Find the current preferred provider.
-    preferred_provider = Provider.find_by(institution: institution, mode: :prefer)
+    preferred_provider = institution.preferred_provider
 
     # Already a preferred provider.
     return if preferred_provider.present?
@@ -61,7 +61,7 @@ class Provider < ApplicationRecord
     return if institution.blank?
 
     # Find the current preferred provider.
-    preferred_provider = Provider.find_by(institution: institution, mode: :prefer)
+    preferred_provider = institution.preferred_provider
 
     # No preferred provider yet.
     return if preferred_provider.blank?

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -12,6 +12,8 @@
 #  sso_url        :string(255)
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
+#  mode           :integer          default("prefer"), not null
+#  active         :boolean          default(TRUE)
 #
 class Provider < ApplicationRecord
   enum mode: { prefer: 0, redirect: 1 }

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -14,6 +14,8 @@
 #  updated_at     :datetime         not null
 #
 class Provider < ApplicationRecord
+  enum mode: { prefer: 0, redirect: 1 }
+
   PROVIDERS = [Provider::GSuite, Provider::Office365, Provider::Saml, Provider::Smartschool].freeze
 
   belongs_to :institution, inverse_of: :providers
@@ -24,6 +26,8 @@ class Provider < ApplicationRecord
   scope :office365, -> { where(type: Provider::Office365.name) }
   scope :saml, -> { where(type: Provider::Saml.name) }
   scope :smartschool, -> { where(type: Provider::Smartschool.name) }
+
+  validates :mode, presence: true
 
   def self.for_sym(sym)
     sym = sym.to_sym

--- a/app/models/provider/g_suite.rb
+++ b/app/models/provider/g_suite.rb
@@ -1,3 +1,20 @@
+# == Schema Information
+#
+# Table name: providers
+#
+#  id             :bigint           not null, primary key
+#  type           :string(255)      default("Provider::Saml"), not null
+#  institution_id :bigint           not null
+#  identifier     :string(255)
+#  certificate    :text(65535)
+#  entity_id      :string(255)
+#  slo_url        :string(255)
+#  sso_url        :string(255)
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  mode           :integer          default("prefer"), not null
+#  active         :boolean          default(TRUE)
+#
 class Provider::GSuite < Provider
   validates :certificate, :entity_id, :sso_url, :slo_url, absence: true
   validates :identifier, uniqueness: { case_sensitive: false }, presence: true

--- a/app/models/provider/office365.rb
+++ b/app/models/provider/office365.rb
@@ -1,3 +1,20 @@
+# == Schema Information
+#
+# Table name: providers
+#
+#  id             :bigint           not null, primary key
+#  type           :string(255)      default("Provider::Saml"), not null
+#  institution_id :bigint           not null
+#  identifier     :string(255)
+#  certificate    :text(65535)
+#  entity_id      :string(255)
+#  slo_url        :string(255)
+#  sso_url        :string(255)
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  mode           :integer          default("prefer"), not null
+#  active         :boolean          default(TRUE)
+#
 class Provider::Office365 < Provider
   validates :certificate, :entity_id, :sso_url, :slo_url, absence: true
   validates :identifier, uniqueness: { case_sensitive: false }, presence: true

--- a/app/models/provider/saml.rb
+++ b/app/models/provider/saml.rb
@@ -7,11 +7,13 @@
 #  institution_id :bigint           not null
 #  identifier     :string(255)
 #  certificate    :text(65535)
+#  entity_id      :string(255)
 #  slo_url        :string(255)
 #  sso_url        :string(255)
-#  saml_entity_id :string(255)
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
+#  mode           :integer          default("prefer"), not null
+#  active         :boolean          default(TRUE)
 #
 class Provider::Saml < Provider
   validates :certificate, :entity_id, :sso_url, :slo_url, presence: true

--- a/app/models/provider/smartschool.rb
+++ b/app/models/provider/smartschool.rb
@@ -1,3 +1,20 @@
+# == Schema Information
+#
+# Table name: providers
+#
+#  id             :bigint           not null, primary key
+#  type           :string(255)      default("Provider::Saml"), not null
+#  institution_id :bigint           not null
+#  identifier     :string(255)
+#  certificate    :text(65535)
+#  entity_id      :string(255)
+#  slo_url        :string(255)
+#  sso_url        :string(255)
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  mode           :integer          default("prefer"), not null
+#  active         :boolean          default(TRUE)
+#
 class Provider::Smartschool < Provider
   validates :certificate, :entity_id, :sso_url, :slo_url, absence: true
   validates :identifier, uniqueness: { case_sensitive: false }, presence: true

--- a/db/migrate/20200629113939_add_mode_and_active_to_provider.rb
+++ b/db/migrate/20200629113939_add_mode_and_active_to_provider.rb
@@ -1,0 +1,10 @@
+class AddModeAndActiveToProvider < ActiveRecord::Migration[6.0]
+  def change
+    add_column :providers, :mode, :integer, null: false, default: 0
+    add_column :providers, :active, :boolean, default: true
+
+    Provider.all.each do |prov|
+      prov.update(mode: :prefer)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_25_150204) do
+ActiveRecord::Schema.define(version: 2020_06_29_113939) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -324,6 +324,8 @@ ActiveRecord::Schema.define(version: 2020_06_25_150204) do
     t.string "sso_url"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "mode", default: 0, null: false
+    t.boolean "active", default: true
     t.index ["institution_id"], name: "fk_rails_ba691498dd"
   end
 

--- a/test/factories/providers.rb
+++ b/test/factories/providers.rb
@@ -7,11 +7,13 @@
 #  institution_id :bigint           not null
 #  identifier     :string(255)
 #  certificate    :text(65535)
+#  entity_id      :string(255)
 #  slo_url        :string(255)
 #  sso_url        :string(255)
-#  saml_entity_id :string(255)
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
+#  mode           :integer          default("prefer"), not null
+#  active         :boolean          default(TRUE)
 #
 FactoryBot.define do
   factory :gsuite_provider, class: Provider::GSuite do

--- a/test/models/institution_test.rb
+++ b/test/models/institution_test.rb
@@ -22,4 +22,12 @@ class InstitutionTest < ActiveSupport::TestCase
   test 'institution factory' do
     create :institution
   end
+
+  test 'get prefered provider' do
+    institution = create :institution
+    prefered = create :provider, institution: institution
+    create_list :provider, 4, institution: institution, mode: :redirect
+
+    assert prefered, institution.preferred_provider
+  end
 end

--- a/test/models/provider_test.rb
+++ b/test/models/provider_test.rb
@@ -12,6 +12,8 @@
 #  sso_url        :string(255)
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
+#  mode           :integer          default("prefer"), not null
+#  active         :boolean          default(TRUE)
 #
 require 'test_helper'
 

--- a/test/models/provider_test.rb
+++ b/test/models/provider_test.rb
@@ -21,4 +21,21 @@ class ProviderTest < ActiveSupport::TestCase
       create provider
     end
   end
+
+  test 'at least one preferred provider per institution' do
+    institution = create :institution
+
+    redirect_prov = build :provider, institution: institution, mode: :redirect
+    assert_not redirect_prov.valid?
+
+    create :provider, institution: institution
+  end
+
+  test 'at most one preferred provider per institution' do
+    institution = create :institution
+    create :provider, institution: institution
+
+    second = build :provider, institution: institution
+    assert_not second.valid?
+  end
 end


### PR DESCRIPTION
This pull request removes the institution blacklist in favour of redirect providers.

**New providers:**
When a user logs in with an unknown OAuth2 (GSuite/Office365/SmartSchool) provider, a new institution will be created with the current provider as the default provider for that institution.

**Post-merge actions:**
After this PR has been merged, the current blacklisted institutions must be created as providers manually:

```
UGENT_TID = 'd7811cde-ecef-496c-8f91-a1786241b99c'
WAREGEM_TID = '9fdf506a-3be0-4f07-9e03-908ceeae50b4'
TSM_TID = 'https://tsm.smartschool.be'
CVO_TSM_TID = 'https://cvotsm.smartschool.be'
MAERLANT_TID = 'https://kabl-sgr25.smartschool.be'
```