### PR TITLE
Cleanup authentication remnants [depends on #2087]

### DIFF
--- a/app/models/institution.rb
+++ b/app/models/institution.rb
@@ -2,18 +2,12 @@
 #
 # Table name: institutions
 #
-#  id          :bigint           not null, primary key
-#  name        :string(255)
-#  short_name  :string(255)
-#  logo        :string(255)
-#  sso_url     :string(255)
-#  slo_url     :string(255)
-#  certificate :text(65535)
-#  created_at  :datetime         not null
-#  updated_at  :datetime         not null
-#  entity_id   :string(255)
-#  provider    :integer
-#  identifier  :string(255)
+#  id         :bigint           not null, primary key
+#  name       :string(255)
+#  short_name :string(255)
+#  logo       :string(255)
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
 #
 
 class Institution < ApplicationRecord

--- a/app/models/institution.rb
+++ b/app/models/institution.rb
@@ -19,10 +19,6 @@
 class Institution < ApplicationRecord
   NEW_INSTITUTION_NAME = 'n/a'.freeze
 
-  # TODO: remove this after 4.0 has been deployed. Will break
-  #       migration 20200619201239_extract_institution_auth_to_providers.
-  enum provider: { smartschool: 0, office365: 1, saml: 2, google_oauth2: 3 }
-
   has_many :users, dependent: :restrict_with_error
   has_many :providers, inverse_of: :institution, dependent: :restrict_with_error
   has_many :courses, dependent: :restrict_with_error

--- a/db/migrate/20200630084943_remove_authentication_data_from_institutions.rb
+++ b/db/migrate/20200630084943_remove_authentication_data_from_institutions.rb
@@ -1,0 +1,5 @@
+class RemoveAuthenticationDataFromInstitutions < ActiveRecord::Migration[6.0]
+  def change
+    remove_columns :institutions, :sso_url, :slo_url, :certificate, :entity_id, :identifier, :provider
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_29_113939) do
+ActiveRecord::Schema.define(version: 2020_06_30_084943) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -265,15 +265,8 @@ ActiveRecord::Schema.define(version: 2020_06_29_113939) do
     t.string "name"
     t.string "short_name"
     t.string "logo"
-    t.string "sso_url"
-    t.string "slo_url"
-    t.text "certificate"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "entity_id"
-    t.integer "provider"
-    t.string "identifier"
-    t.index ["identifier"], name: "index_institutions_on_identifier", unique: true
   end
 
   create_table "judges", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|

--- a/test/factories/institutions.rb
+++ b/test/factories/institutions.rb
@@ -2,18 +2,12 @@
 #
 # Table name: institutions
 #
-#  id          :bigint           not null, primary key
-#  name        :string(255)
-#  short_name  :string(255)
-#  logo        :string(255)
-#  sso_url     :string(255)
-#  slo_url     :string(255)
-#  certificate :text(65535)
-#  created_at  :datetime         not null
-#  updated_at  :datetime         not null
-#  entity_id   :string(255)
-#  provider    :integer
-#  identifier  :string(255)
+#  id         :bigint           not null, primary key
+#  name       :string(255)
+#  short_name :string(255)
+#  logo       :string(255)
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
 #
 
 FactoryBot.define do

--- a/test/models/institution_test.rb
+++ b/test/models/institution_test.rb
@@ -2,18 +2,12 @@
 #
 # Table name: institutions
 #
-#  id          :bigint           not null, primary key
-#  name        :string(255)
-#  short_name  :string(255)
-#  logo        :string(255)
-#  sso_url     :string(255)
-#  slo_url     :string(255)
-#  certificate :text(65535)
-#  created_at  :datetime         not null
-#  updated_at  :datetime         not null
-#  entity_id   :string(255)
-#  provider    :integer
-#  identifier  :string(255)
+#  id         :bigint           not null, primary key
+#  name       :string(255)
+#  short_name :string(255)
+#  logo       :string(255)
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
 #
 
 require 'test_helper'


### PR DESCRIPTION
This pull request removes authentication data from the institutions table. This is no longer required after the authentication rework, but it can't be fixed there since that would break the other migrations in #2065.

Closes #2067.
