### PR TITLE
LTI authentication

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -71,7 +71,9 @@ gem 'ruby-saml', '~> 1.11.0'
 # omniauth
 gem 'omniauth-google-oauth2', '~> 0.8.0'
 gem 'omniauth-oauth2', '~> 1.6.0'
+gem 'omniauth_openid_connect', '~> 0.3.5'
 
+# Json webtokens
 gem 'jwt', '~> 2.2.1'
 
 # contact mail form

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,16 +66,19 @@ GEM
       zeitwerk (~> 2.2, >= 2.2.2)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
+    aes_key_wrap (1.1.0)
     airbrussh (1.4.0)
       sshkit (>= 1.6.1, != 1.7.0)
     annotate (3.1.1)
       activerecord (>= 3.2, < 7.0)
       rake (>= 10.4, < 14.0)
     ast (2.4.1)
+    attr_required (1.0.1)
     autoprefixer-rails (9.8.6.1)
       execjs
-    bcrypt (3.1.13)
+    bcrypt (3.1.15)
     bcrypt_pbkdf (1.0.1)
+    bindata (2.4.8)
     bindex (0.8.1)
     bootsnap (1.4.7)
       msgpack (~> 1.0)
@@ -87,7 +90,7 @@ GEM
       i18n
       rake (>= 10.0.0)
       sshkit (>= 1.9.0)
-    capistrano-bundler (2.0.0)
+    capistrano-bundler (2.0.1)
       capistrano (~> 3.1)
     capistrano-passenger (0.2.0)
       capistrano (~> 3.0)
@@ -151,7 +154,7 @@ GEM
     exception_notification (4.4.3)
       actionmailer (>= 4.0, < 7)
       activesupport (>= 4.0, < 7)
-    excon (0.75.0)
+    excon (0.76.0)
     execjs (2.7.0)
     factory_bot (6.1.0)
       activesupport (>= 5.0.0)
@@ -174,6 +177,7 @@ GEM
     httparty (0.18.1)
       mime-types (~> 3.0)
       multi_xml (>= 0.5.2)
+    httpclient (2.8.3)
     i18n (1.8.5)
       concurrent-ruby (~> 1.0)
     i18n-js (3.7.1)
@@ -184,6 +188,10 @@ GEM
     jbuilder (2.10.0)
       activesupport (>= 5.0.0)
     json (2.3.1)
+    json-jwt (1.13.0)
+      activesupport (>= 4.2)
+      aes_key_wrap
+      bindata
     json-schema (2.8.1)
       addressable (>= 2.4)
     jwt (2.2.1)
@@ -231,7 +239,7 @@ GEM
       minitest
     mocha (1.11.2)
     msgpack (1.3.3)
-    multi_json (1.14.1)
+    multi_json (1.15.0)
     multi_xml (0.6.0)
     multipart-post (2.1.1)
     mustermann (1.1.1)
@@ -259,12 +267,26 @@ GEM
     omniauth-oauth2 (1.6.0)
       oauth2 (~> 1.1)
       omniauth (~> 1.9)
+    omniauth_openid_connect (0.3.5)
+      addressable (~> 2.5)
+      omniauth (~> 1.9)
+      openid_connect (~> 1.1)
+    openid_connect (1.2.0)
+      activemodel
+      attr_required (>= 1.0.0)
+      json-jwt (>= 1.5.0)
+      rack-oauth2 (>= 1.6.1)
+      swd (>= 1.0.0)
+      tzinfo
+      validate_email
+      validate_url
+      webfinger (>= 1.0.1)
     orm_adapter (0.5.0)
     parallel (1.19.2)
     parser (2.7.1.4)
       ast (~> 2.4.1)
     possibly (1.0.1)
-    premailer (1.11.1)
+    premailer (1.12.1)
       addressable
       css_parser (>= 1.6.0)
       htmlentities (>= 4.0.0)
@@ -281,6 +303,12 @@ GEM
     rack (2.2.3)
     rack-mini-profiler (2.0.3)
       rack (>= 1.2.0)
+    rack-oauth2 (1.16.0)
+      activesupport
+      attr_required
+      httpclient
+      json-jwt (>= 1.11.0)
+      rack (>= 2.1.0)
     rack-protection (2.0.8.1)
       rack
     rack-proxy (0.6.5)
@@ -346,8 +374,8 @@ GEM
       rubocop-ast (>= 0.1.0, < 1.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 2.0)
-    rubocop-ast (0.2.0)
-      parser (>= 2.7.0.1)
+    rubocop-ast (0.3.0)
+      parser (>= 2.7.1.4)
     rubocop-rails (2.7.1)
       activesupport (>= 4.2.0)
       rack (>= 1.1)
@@ -388,6 +416,10 @@ GEM
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
     stackprof (0.2.15)
+    swd (1.2.0)
+      activesupport (>= 3)
+      attr_required (>= 0.0.5)
+      httpclient (>= 2.4)
     therubyracer (0.12.3)
       libv8 (~> 3.16.14.15)
       ref
@@ -399,6 +431,12 @@ GEM
     uglifier (4.2.0)
       execjs (>= 0.3.0, < 3)
     unicode-display_width (1.7.0)
+    validate_email (0.1.6)
+      activemodel (>= 3.0)
+      mail (>= 2.2.5)
+    validate_url (1.0.11)
+      activemodel (>= 3.0.0)
+      public_suffix
     warden (1.2.8)
       rack (>= 2.0.6)
     web-console (4.0.4)
@@ -406,12 +444,15 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
+    webfinger (1.1.0)
+      activesupport
+      httpclient (>= 2.4)
     webpacker (5.1.1)
       activesupport (>= 5.2)
       rack-proxy (>= 0.6.1)
       railties (>= 5.2)
       semantic_range (>= 2.3.0)
-    websocket-driver (0.7.2)
+    websocket-driver (0.7.3)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
     will_paginate (3.3.0)
@@ -473,6 +514,7 @@ DEPENDENCIES
   nokogiri (~> 1.10.10)
   omniauth-google-oauth2 (~> 0.8.0)
   omniauth-oauth2 (~> 1.6.0)
+  omniauth_openid_connect (~> 0.3.5)
   possibly (~> 1.0.1)
   premailer-rails (~> 1.11.1)
   pretender (~> 0.3.4)
@@ -507,4 +549,4 @@ RUBY VERSION
    ruby 2.6.6p146
 
 BUNDLED WITH
-   2.0.2
+   2.1.4

--- a/app/assets/stylesheets/lti.css.less
+++ b/app/assets/stylesheets/lti.css.less
@@ -1,0 +1,3 @@
+// Place all the styles related to the Lti controller here.
+// They will automatically be included in application.css.
+// You can use Less here: http://lesscss.org/

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -46,7 +46,7 @@ class ApplicationController < ActionController::Base
   end
 
   Warden::Manager.after_authentication do |user, _auth, _opts|
-    if user.email.blank? && !user.institution&.uses_smartschool?
+    if user.email.blank? && !user.institution&.uses_smartschool? && !user.institution&.uses_lti?
       raise "User with id #{user.id} should not have a blank email " \
             'if the provider is not smartschool'
     end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -48,7 +48,7 @@ class ApplicationController < ActionController::Base
   Warden::Manager.after_authentication do |user, _auth, _opts|
     if user.email.blank? && !user.institution&.uses_smartschool? && !user.institution&.uses_lti?
       raise "User with id #{user.id} should not have a blank email " \
-            'if the provider is not smartschool'
+            'if the provider is not smartschool and not LTI'
     end
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,8 @@ class ApplicationController < ActionController::Base
   include Pundit
   include SetCurrentRequestDetails
 
+  MAX_STORED_URL_LENGTH = 1024
+
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
 
   protect_from_forgery with: :null_session
@@ -137,7 +139,12 @@ class ApplicationController < ActionController::Base
   end
 
   def store_current_location
-    store_location_for(:user, request.url)
+    url = if request.url.length > MAX_STORED_URL_LENGTH
+            request.base_url + request.path
+          else
+            request.url
+          end
+    store_location_for :user, url
   end
 
   def look_for_token

--- a/app/controllers/auth/omniauth_callbacks_controller.rb
+++ b/app/controllers/auth/omniauth_callbacks_controller.rb
@@ -22,6 +22,10 @@ class Auth::OmniauthCallbacksController < Devise::OmniauthCallbacksController
     generic_oauth
   end
 
+  def lti
+    try_login!
+  end
+
   def saml
     try_login!
   end
@@ -46,7 +50,8 @@ class Auth::OmniauthCallbacksController < Devise::OmniauthCallbacksController
 
   def try_login!
     # Ensure the preferred provider is used.
-    return redirect_to_preferred_provider! unless provider.prefer?
+    # TODO add link providers.
+    # return redirect_to_preferred_provider! unless provider.prefer?
 
     # Find the identity.
     identity, user = find_identity_and_user

--- a/app/controllers/auth/omniauth_callbacks_controller.rb
+++ b/app/controllers/auth/omniauth_callbacks_controller.rb
@@ -141,7 +141,9 @@ class Auth::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   def flash_failure(reason)
     return unless is_navigational_format?
 
-    set_flash_message :notice, :failure, kind: auth_provider_type || 'OAuth2', reason: reason
+    # Get the provider type.
+    provider_type = auth_provider_type || request.env['omniauth.error.strategy']&.name || 'OAuth2'
+    set_flash_message :notice, :failure, kind: provider_type, reason: reason
   end
 
   def redirect_to_preferred_provider!
@@ -162,8 +164,8 @@ class Auth::OmniauthCallbacksController < Devise::OmniauthCallbacksController
         "#{auth_hash.pretty_inspect}"
 
     ApplicationMailer.with(authinfo: auth_hash, errors: resource.errors.inspect)
-                     .user_unable_to_log_in
-                     .deliver_later
+        .user_unable_to_log_in
+        .deliver_later
 
     redirect_with_flash! resource.errors.full_messages.to_sentence
   end
@@ -231,8 +233,8 @@ class Auth::OmniauthCallbacksController < Devise::OmniauthCallbacksController
       "#{auth_hash.pretty_inspect}"
 
     ApplicationMailer.with(authinfo: auth_hash)
-                     .institution_created
-                     .deliver_later
+        .institution_created
+        .deliver_later
   end
 
   def institution_create_failed(errors)
@@ -242,8 +244,8 @@ class Auth::OmniauthCallbacksController < Devise::OmniauthCallbacksController
       "#{errors}"
 
     ApplicationMailer.with(authinfo: auth_hash, errors: errors.inspect)
-                     .institution_creation_failed
-                     .deliver_later
+        .institution_creation_failed
+        .deliver_later
   end
 
   def provider_missing!

--- a/app/controllers/auth/omniauth_callbacks_controller.rb
+++ b/app/controllers/auth/omniauth_callbacks_controller.rb
@@ -5,9 +5,9 @@ class Auth::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   # ==> Failure route.
 
   def failure
-    flash_failure request.params['error_message'] \
-                                                   || request.params['error_description'] \
-                                                   || I18n.t('devise.omniauth_callbacks.unknown_failure')
+    flash_failure(request.params['error_message'] ||
+                      request.params['error_description'] ||
+                      I18n.t('devise.omniauth_callbacks.unknown_failure'))
     redirect_to root_path
   end
 
@@ -51,7 +51,7 @@ class Auth::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   def try_login!
     # Ensure the preferred provider is used.
     # TODO add link providers.
-    # return redirect_to_preferred_provider! unless provider.prefer?
+    return redirect_to_preferred_provider! unless provider.prefer?
 
     # Find the identity.
     identity, user = find_identity_and_user
@@ -69,7 +69,8 @@ class Auth::OmniauthCallbacksController < Devise::OmniauthCallbacksController
     return redirect_with_errors!(user) if user.errors.any?
 
     # User successfully updated, finish the authentication procedure.
-    sign_in_and_redirect user, event: :authentication
+    sign_in user, event: :authentication
+    redirect_to_target!(user)
   end
 
   # ==> Utilities.
@@ -140,6 +141,10 @@ class Auth::OmniauthCallbacksController < Devise::OmniauthCallbacksController
     redirect_to root_path
   end
 
+  def redirect_to_target!(user)
+    redirect_to auth_target || after_sign_in_path_for(user)
+  end
+
   # ==> Shorthands.
 
   def auth_hash
@@ -154,6 +159,16 @@ class Auth::OmniauthCallbacksController < Devise::OmniauthCallbacksController
     return nil if auth_hash.blank?
 
     auth_hash.provider.to_sym
+  end
+
+  def auth_redirect_params
+    auth_hash.extra[:redirect_params].to_h || {}
+  end
+
+  def auth_target
+    return nil if auth_hash.extra[:target].blank?
+
+    "#{auth_hash.extra[:target]}?#{auth_redirect_params.to_param}"
   end
 
   def auth_uid

--- a/app/controllers/auth/omniauth_callbacks_controller.rb
+++ b/app/controllers/auth/omniauth_callbacks_controller.rb
@@ -75,8 +75,11 @@ class Auth::OmniauthCallbacksController < Devise::OmniauthCallbacksController
     # Link the stored identifier to the signed in user.
     create_linked_identity!(user)
 
-    # User successfully updated, finish the authentication procedure.
-    sign_in user, event: :authentication
+    # User successfully updated, finish the authentication procedure. Force is
+    # required to overwrite the current existing user.
+    sign_in user, event: :authentication, force: true
+
+    # Redirect the user to their destination.
     redirect_to_target!(user)
   end
 

--- a/app/controllers/auth/omniauth_callbacks_controller.rb
+++ b/app/controllers/auth/omniauth_callbacks_controller.rb
@@ -164,8 +164,8 @@ class Auth::OmniauthCallbacksController < Devise::OmniauthCallbacksController
         "#{auth_hash.pretty_inspect}"
 
     ApplicationMailer.with(authinfo: auth_hash, errors: resource.errors.inspect)
-        .user_unable_to_log_in
-        .deliver_later
+                     .user_unable_to_log_in
+                     .deliver_later
 
     redirect_with_flash! resource.errors.full_messages.to_sentence
   end
@@ -233,8 +233,8 @@ class Auth::OmniauthCallbacksController < Devise::OmniauthCallbacksController
       "#{auth_hash.pretty_inspect}"
 
     ApplicationMailer.with(authinfo: auth_hash)
-        .institution_created
-        .deliver_later
+                     .institution_created
+                     .deliver_later
   end
 
   def institution_create_failed(errors)
@@ -244,8 +244,8 @@ class Auth::OmniauthCallbacksController < Devise::OmniauthCallbacksController
       "#{errors}"
 
     ApplicationMailer.with(authinfo: auth_hash, errors: errors.inspect)
-        .institution_creation_failed
-        .deliver_later
+                     .institution_creation_failed
+                     .deliver_later
   end
 
   def provider_missing!

--- a/app/controllers/lti_controller.rb
+++ b/app/controllers/lti_controller.rb
@@ -1,0 +1,2 @@
+class LtiController < ApplicationController
+end

--- a/app/controllers/lti_controller.rb
+++ b/app/controllers/lti_controller.rb
@@ -1,2 +1,9 @@
+require_relative '../../lib/LTI/jwk.rb'
+
 class LtiController < ApplicationController
+  include LTI::JWK
+
+  def jwks
+    render json: { keys: keyset }
+  end
 end

--- a/app/helpers/lti_helper.rb
+++ b/app/helpers/lti_helper.rb
@@ -1,0 +1,2 @@
+module LtiHelper
+end

--- a/app/models/institution.rb
+++ b/app/models/institution.rb
@@ -32,6 +32,10 @@ class Institution < ApplicationRecord
     Provider.find_by(institution: self, mode: :prefer)
   end
 
+  def uses_lti?
+    providers.any? { |provider| provider.type == Provider::Lti.name }
+  end
+
   def uses_smartschool?
     providers.any? { |provider| provider.type == Provider::Smartschool.name }
   end

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -29,7 +29,7 @@ class Provider < ApplicationRecord
   has_many :identities, inverse_of: :provider, dependent: :destroy
 
   scope :gsuite, -> { where(type: Provider::GSuite.name) }
-  scope :lti, -> {where(type: Provider::Lti.name)}
+  scope :lti, -> { where(type: Provider::Lti.name) }
   scope :office365, -> { where(type: Provider::Office365.name) }
   scope :saml, -> { where(type: Provider::Saml.name) }
   scope :smartschool, -> { where(type: Provider::Smartschool.name) }

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -18,13 +18,14 @@
 class Provider < ApplicationRecord
   enum mode: { prefer: 0, redirect: 1 }
 
-  PROVIDERS = [Provider::GSuite, Provider::Office365, Provider::Saml, Provider::Smartschool].freeze
+  PROVIDERS = [Provider::GSuite, Provider::Lti, Provider::Office365, Provider::Saml, Provider::Smartschool].freeze
 
   belongs_to :institution, inverse_of: :providers
 
   has_many :identities, inverse_of: :provider, dependent: :destroy
 
   scope :gsuite, -> { where(type: Provider::GSuite.name) }
+  scope :lti, -> {where(type: Provider::Lti.name)}
   scope :office365, -> { where(type: Provider::Office365.name) }
   scope :saml, -> { where(type: Provider::Saml.name) }
   scope :smartschool, -> { where(type: Provider::Smartschool.name) }

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -2,18 +2,22 @@
 #
 # Table name: providers
 #
-#  id             :bigint           not null, primary key
-#  type           :string(255)      default("Provider::Saml"), not null
-#  institution_id :bigint           not null
-#  identifier     :string(255)
-#  certificate    :text(65535)
-#  entity_id      :string(255)
-#  slo_url        :string(255)
-#  sso_url        :string(255)
-#  created_at     :datetime         not null
-#  updated_at     :datetime         not null
-#  mode           :integer          default("prefer"), not null
-#  active         :boolean          default(TRUE)
+#  id                :bigint           not null, primary key
+#  type              :string(255)      default("Provider::Saml"), not null
+#  institution_id    :bigint           not null
+#  identifier        :string(255)
+#  certificate       :text(65535)
+#  entity_id         :string(255)
+#  slo_url           :string(255)
+#  sso_url           :string(255)
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  mode              :integer          default("prefer"), not null
+#  active            :boolean          default(TRUE)
+#  authorization_uri :string(255)
+#  client_id         :string(255)
+#  issuer            :string(255)
+#  jwks_uri          :string(255)
 #
 class Provider < ApplicationRecord
   enum mode: { prefer: 0, redirect: 1 }

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -20,7 +20,7 @@
 #  jwks_uri          :string(255)
 #
 class Provider < ApplicationRecord
-  enum mode: { prefer: 0, redirect: 1 }
+  enum mode: { prefer: 0, redirect: 1, link: 2 }
 
   PROVIDERS = [Provider::GSuite, Provider::Lti, Provider::Office365, Provider::Saml, Provider::Smartschool].freeze
 

--- a/app/models/provider/g_suite.rb
+++ b/app/models/provider/g_suite.rb
@@ -2,21 +2,26 @@
 #
 # Table name: providers
 #
-#  id             :bigint           not null, primary key
-#  type           :string(255)      default("Provider::Saml"), not null
-#  institution_id :bigint           not null
-#  identifier     :string(255)
-#  certificate    :text(65535)
-#  entity_id      :string(255)
-#  slo_url        :string(255)
-#  sso_url        :string(255)
-#  created_at     :datetime         not null
-#  updated_at     :datetime         not null
-#  mode           :integer          default("prefer"), not null
-#  active         :boolean          default(TRUE)
+#  id                :bigint           not null, primary key
+#  type              :string(255)      default("Provider::Saml"), not null
+#  institution_id    :bigint           not null
+#  identifier        :string(255)
+#  certificate       :text(65535)
+#  entity_id         :string(255)
+#  slo_url           :string(255)
+#  sso_url           :string(255)
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  mode              :integer          default("prefer"), not null
+#  active            :boolean          default(TRUE)
+#  authorization_uri :string(255)
+#  client_id         :string(255)
+#  issuer            :string(255)
+#  jwks_uri          :string(255)
 #
 class Provider::GSuite < Provider
   validates :certificate, :entity_id, :sso_url, :slo_url, absence: true
+  validates :authorization_uri, :client_id, :issuer, :jwks_uri, absence: true
   validates :identifier, uniqueness: { case_sensitive: false }, presence: true
 
   def self.sym

--- a/app/models/provider/lti.rb
+++ b/app/models/provider/lti.rb
@@ -1,0 +1,20 @@
+# == Schema Information
+#
+# Table name: providers
+#
+#  id             :bigint           not null, primary key
+#  type           :string(255)      default("Provider::Saml"), not null
+#  institution_id :bigint           not null
+#  identifier     :string(255)
+#  certificate    :text(65535)
+#  slo_url        :string(255)
+#  sso_url        :string(255)
+#  saml_entity_id :string(255)
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#
+class Provider::Lti < Provider
+  def self.sym
+    :lti
+  end
+end

--- a/app/models/provider/lti.rb
+++ b/app/models/provider/lti.rb
@@ -2,18 +2,28 @@
 #
 # Table name: providers
 #
-#  id             :bigint           not null, primary key
-#  type           :string(255)      default("Provider::Saml"), not null
-#  institution_id :bigint           not null
-#  identifier     :string(255)
-#  certificate    :text(65535)
-#  slo_url        :string(255)
-#  sso_url        :string(255)
-#  saml_entity_id :string(255)
-#  created_at     :datetime         not null
-#  updated_at     :datetime         not null
+#  id                :bigint           not null, primary key
+#  type              :string(255)      default("Provider::Saml"), not null
+#  institution_id    :bigint           not null
+#  identifier        :string(255)
+#  certificate       :text(65535)
+#  entity_id         :string(255)
+#  slo_url           :string(255)
+#  sso_url           :string(255)
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  mode              :integer          default("prefer"), not null
+#  active            :boolean          default(TRUE)
+#  authorization_uri :string(255)
+#  client_id         :string(255)
+#  issuer            :string(255)
+#  jwks_uri          :string(255)
 #
 class Provider::Lti < Provider
+  validates :certificate, :entity_id, :sso_url, :slo_url, absence: true
+  validates :identifier, absence: true
+  validates :authorization_uri, :client_id, :issuer, :jwks_uri, presence: true
+
   def self.sym
     :lti
   end

--- a/app/models/provider/office365.rb
+++ b/app/models/provider/office365.rb
@@ -2,21 +2,26 @@
 #
 # Table name: providers
 #
-#  id             :bigint           not null, primary key
-#  type           :string(255)      default("Provider::Saml"), not null
-#  institution_id :bigint           not null
-#  identifier     :string(255)
-#  certificate    :text(65535)
-#  entity_id      :string(255)
-#  slo_url        :string(255)
-#  sso_url        :string(255)
-#  created_at     :datetime         not null
-#  updated_at     :datetime         not null
-#  mode           :integer          default("prefer"), not null
-#  active         :boolean          default(TRUE)
+#  id                :bigint           not null, primary key
+#  type              :string(255)      default("Provider::Saml"), not null
+#  institution_id    :bigint           not null
+#  identifier        :string(255)
+#  certificate       :text(65535)
+#  entity_id         :string(255)
+#  slo_url           :string(255)
+#  sso_url           :string(255)
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  mode              :integer          default("prefer"), not null
+#  active            :boolean          default(TRUE)
+#  authorization_uri :string(255)
+#  client_id         :string(255)
+#  issuer            :string(255)
+#  jwks_uri          :string(255)
 #
 class Provider::Office365 < Provider
   validates :certificate, :entity_id, :sso_url, :slo_url, absence: true
+  validates :authorization_uri, :client_id, :issuer, :jwks_uri, absence: true
   validates :identifier, uniqueness: { case_sensitive: false }, presence: true
 
   def self.sym

--- a/app/models/provider/saml.rb
+++ b/app/models/provider/saml.rb
@@ -2,21 +2,26 @@
 #
 # Table name: providers
 #
-#  id             :bigint           not null, primary key
-#  type           :string(255)      default("Provider::Saml"), not null
-#  institution_id :bigint           not null
-#  identifier     :string(255)
-#  certificate    :text(65535)
-#  entity_id      :string(255)
-#  slo_url        :string(255)
-#  sso_url        :string(255)
-#  created_at     :datetime         not null
-#  updated_at     :datetime         not null
-#  mode           :integer          default("prefer"), not null
-#  active         :boolean          default(TRUE)
+#  id                :bigint           not null, primary key
+#  type              :string(255)      default("Provider::Saml"), not null
+#  institution_id    :bigint           not null
+#  identifier        :string(255)
+#  certificate       :text(65535)
+#  entity_id         :string(255)
+#  slo_url           :string(255)
+#  sso_url           :string(255)
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  mode              :integer          default("prefer"), not null
+#  active            :boolean          default(TRUE)
+#  authorization_uri :string(255)
+#  client_id         :string(255)
+#  issuer            :string(255)
+#  jwks_uri          :string(255)
 #
 class Provider::Saml < Provider
   validates :certificate, :entity_id, :sso_url, :slo_url, presence: true
+  validates :authorization_uri, :client_id, :issuer, :jwks_uri, absence: true
   validates :entity_id, uniqueness: { case_sensitive: false }
 
   validates :identifier, absence: true

--- a/app/models/provider/smartschool.rb
+++ b/app/models/provider/smartschool.rb
@@ -2,21 +2,26 @@
 #
 # Table name: providers
 #
-#  id             :bigint           not null, primary key
-#  type           :string(255)      default("Provider::Saml"), not null
-#  institution_id :bigint           not null
-#  identifier     :string(255)
-#  certificate    :text(65535)
-#  entity_id      :string(255)
-#  slo_url        :string(255)
-#  sso_url        :string(255)
-#  created_at     :datetime         not null
-#  updated_at     :datetime         not null
-#  mode           :integer          default("prefer"), not null
-#  active         :boolean          default(TRUE)
+#  id                :bigint           not null, primary key
+#  type              :string(255)      default("Provider::Saml"), not null
+#  institution_id    :bigint           not null
+#  identifier        :string(255)
+#  certificate       :text(65535)
+#  entity_id         :string(255)
+#  slo_url           :string(255)
+#  sso_url           :string(255)
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  mode              :integer          default("prefer"), not null
+#  active            :boolean          default(TRUE)
+#  authorization_uri :string(255)
+#  client_id         :string(255)
+#  issuer            :string(255)
+#  jwks_uri          :string(255)
 #
 class Provider::Smartschool < Provider
   validates :certificate, :entity_id, :sso_url, :slo_url, absence: true
+  validates :authorization_uri, :client_id, :issuer, :jwks_uri, absence: true
   validates :identifier, uniqueness: { case_sensitive: false }, presence: true
 
   def self.sym

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -101,7 +101,7 @@ class User < ApplicationRecord
 
   has_many :annotations, dependent: :restrict_with_error
 
-  devise :omniauthable, omniauth_providers: %i[google_oauth2 office365 saml smartschool]
+  devise :omniauthable, omniauth_providers: %i[google_oauth2 lti office365 saml smartschool]
 
   validates :username, uniqueness: { case_sensitive: false, allow_blank: true, scope: :institution }
   validates :email, uniqueness: { case_sensitive: false, allow_blank: true }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -128,7 +128,7 @@ class User < ApplicationRecord
   scope :at_least_one_started_in_course, ->(course) { where(id: Submission.where(course_id: course.id, exercise_id: course.exercises).select('DISTINCT(user_id)')) }
 
   def email_only_blank_if_smartschool
-    errors.add(:email, 'should not be blank when institution does not use smartschool') if email.blank? && !institution&.uses_smartschool?
+    errors.add(:email, 'should not be blank when institution does not use smartschool') if email.blank? && !institution&.uses_smartschool? && !institution&.uses_lti?
   end
 
   def max_one_institution

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -1,3 +1,6 @@
+## LTI.
+require_relative '../../lib/LTI/auth.rb'
+
 ## SAML.
 require_relative '../../lib/SAML/strategy.rb'
 require_relative '../../lib/SAML/setup.rb'
@@ -251,6 +254,8 @@ Devise.setup do |config|
   config.omniauth :google_oauth2,
                   Rails.application.credentials.google_client_id,
                   Rails.application.credentials.google_client_secret
+
+  config.omniauth :lti, setup: LTI::Auth::OmniAuth::Setup
 
   config.omniauth :office365,
                   Rails.application.credentials.office365_client_id,

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -30,6 +30,7 @@ en:
       user_not_created: "user creation failed"
       unknown_failure: "an unknown failure has occurred"
       failure: "Could not authenticate you from %{kind} because \"%{reason}\"."
+      linked: Because you had not signed in to Dodona via Ufora before, we could not execute the requested operation. Now that your UGent-account has successfully been linked, this should work. Retry clicking on the link in Ufora to try again.
       success: "Successfully authenticated from %{kind} account."
     passwords:
       no_token: "You can't access this page without coming from a password reset email. If you do come from a password reset email, please make sure you used the full URL provided."

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -30,7 +30,7 @@ en:
       user_not_created: "user creation failed"
       unknown_failure: "an unknown failure has occurred"
       failure: "Could not authenticate you from %{kind} because \"%{reason}\"."
-      linked: Because you had not signed in to Dodona via Ufora before, we could not execute the requested operation. Now that your UGent-account has successfully been linked, this should work. Retry clicking on the link in Ufora to try again.
+      linked: Because you have not signed in to Dodona via Ufora before, we could not execute the requested operation. Now that your UGent-account has successfully been linked, this should work. Retry clicking on the link in Ufora to try again.
       success: "Successfully authenticated from %{kind} account."
     passwords:
       no_token: "You can't access this page without coming from a password reset email. If you do come from a password reset email, please make sure you used the full URL provided."

--- a/config/locales/devise.nl.yml
+++ b/config/locales/devise.nl.yml
@@ -28,6 +28,7 @@ nl:
       user_not_created: "kan gebruiker niet aanmaken"
       unknown_failure: "een onbekende fout is opgetreden"
       failure: "Kan je niet aanmelden met %{kind}, reden: \"%{reason}\"."
+      linked: Omdat je nog niet eerder op Dodona inlogde vanaf Ufora, konden we de gevraagde actie niet uitvoeren. Nu we je UGent-account gekoppeld hebben, zou dit wel moeten lukken. Klik opnieuw op de link in Ufora om opnieuw te proberen.
       success: "Succesvol geautoriseerd met %{kind} account."
     passwords:
       no_token: "Je kunt deze pagina niet bereiken als je geen e-mail hebt ontvangen met wachtwoord reset instructies. Mocht je dit wel hebben ontvangen kijk dan het URL na in je mail of vraag de instructies opnieuw aan."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -205,6 +205,10 @@ Rails.application.routes.draw do
     end
     resources :feedbacks, only: %i[show edit update]
 
+    scope 'lti', controller: 'lti' do
+      get 'jwks', to: 'lti#jwks'
+    end
+
     scope 'stats', controller: 'statistics' do
       get 'heatmap', to: 'statistics#heatmap'
       get 'punchcard', to: 'statistics#punchcard'

--- a/db/migrate/20200701135727_add_lti_settings_to_providers.rb
+++ b/db/migrate/20200701135727_add_lti_settings_to_providers.rb
@@ -1,0 +1,8 @@
+class AddLtiSettingsToProviders < ActiveRecord::Migration[6.0]
+  def change
+    add_column :providers, :authorization_uri, :string, null: true
+    add_column :providers, :client_id, :string, null: true
+    add_column :providers, :issuer, :string, null: true
+    add_column :providers, :jwks_uri, :string, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_30_084943) do
+ActiveRecord::Schema.define(version: 2020_07_01_135727) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -319,6 +319,10 @@ ActiveRecord::Schema.define(version: 2020_06_30_084943) do
     t.datetime "updated_at", precision: 6, null: false
     t.integer "mode", default: 0, null: false
     t.boolean "active", default: true
+    t.string "authorization_uri"
+    t.string "client_id"
+    t.string "issuer"
+    t.string "jwks_uri"
     t.index ["institution_id"], name: "fk_rails_ba691498dd"
   end
 

--- a/lib/LTI/auth.rb
+++ b/lib/LTI/auth.rb
@@ -1,0 +1,7 @@
+module LTI
+  module Auth
+    require_relative 'auth/settings.rb'
+    require_relative 'auth/setup.rb'
+    require_relative 'auth/strategy.rb'
+  end
+end

--- a/lib/LTI/auth/settings.rb
+++ b/lib/LTI/auth/settings.rb
@@ -1,0 +1,37 @@
+require 'omniauth'
+
+module LTI
+  module Auth
+    module Settings
+      def base_settings
+        # This configuration is tailored according to the LTI specification.
+        # To support other OpenID providers, simply move certain properties
+        # from this method to the for_provider method below, to make them
+        # provider-specific.
+        {
+            client_options: {
+                redirect_uri: "https://#{Rails.configuration.default_host}/users/auth/lti/callback"
+            },
+            discovery: false,
+            prompt: :none,
+            response_mode: :form_post,
+            response_type: :id_token,
+            scope: [:openid]
+        }
+      end
+
+      def provider_settings(provider)
+        raise 'Not an LTI provider.' unless provider.is_a?(Provider::Lti)
+
+        {
+            client_options: {
+                authorization_endpoint: provider.authorization_uri,
+                jwks_uri: provider.jwks_uri,
+                identifier: provider.client_id
+            },
+            issuer: provider.issuer
+        }
+      end
+    end
+  end
+end

--- a/lib/LTI/auth/setup.rb
+++ b/lib/LTI/auth/setup.rb
@@ -1,0 +1,61 @@
+module LTI
+  module Auth
+    module OmniAuth
+      class Setup
+        include LTI::Auth::Settings
+
+        def self.call(env)
+          new(env).setup
+        end
+
+        def initialize(env)
+          @env = env
+        end
+
+        def setup
+          @env['omniauth.params'] ||= {}
+          @env['omniauth.strategy'].options.merge!(base_settings)
+          @env['omniauth.strategy'].options.merge!(configure)
+        end
+
+        private
+
+        def configure
+          # Obtain the openid parameters for the provider.
+          _provider = provider
+          return failure! if _provider.blank?
+
+          _provider_settings = provider_settings(_provider)
+          _provider_settings.merge({
+                                       extra_authorize_params: {
+                                           lti_message_hint: params[:lti_message_hint]
+                                       }
+                                   })
+        end
+
+        def failure!
+          raise "Invalid or unknown LTI provider."
+        end
+
+        def params
+          @params ||= Rack::Request.new(@env).params.symbolize_keys
+        end
+
+        def provider
+          # Get the provider from the provider parameter.
+          return Provider::Lti.find_by(id: params[:provider]) if params[:provider].present?
+
+          # Get the provider from the issuer parameter.
+          return Provider::Lti.find_by(issuer: params[:iss]) if params[:iss].present?
+
+          # If there is a JWT available, we can parse that to find the issuer.
+          return nil if params[:id_token].blank?
+
+          # Parse the JWT token.
+          jwt_token = JSON::JWT.decode params[:id_token], :skip_verification
+          Provider::Lti.find_by(issuer: jwt_token[:iss])
+        end
+      end
+    end
+  end
+end

--- a/lib/LTI/auth/strategy.rb
+++ b/lib/LTI/auth/strategy.rb
@@ -1,0 +1,57 @@
+require_relative '../jwk.rb'
+require_relative '../messages/claims.rb'
+require 'openid_connect'
+
+# This strategy augments the existing oidc strategy for Dodona.
+module OmniAuth
+  module Strategies
+    class LTI < OmniAuth::Strategies::OpenIDConnect
+      include ::LTI::JWK
+
+      option :name, 'lti'
+
+      def key_or_secret
+        parse_jwks_uri(options.client_options.jwks_uri)
+      end
+
+      def callback_phase
+        begin
+          super
+        rescue
+          # Error handling.
+          fail!(:invalid_response, $!)
+        end
+      end
+
+      def id_token_callback_phase
+        # Parse the JWT to obtain the raw response.
+        jwt_token = params.symbolize_keys[:id_token]
+        raw_info = decode_id_token(jwt_token).raw_attributes
+
+        # Configure the info hashes.
+        env['omniauth.auth'] = AuthHash.new(
+            provider: name,
+            uid: raw_info[:sub],
+            info: {
+                username: raw_info[:sub],
+                first_name: raw_info[:given_name],
+                last_name: raw_info[:family_name],
+                email: raw_info[:email]
+            },
+            extra: {
+                provider: Provider::Lti.find_by(issuer: raw_info[:iss]),
+                redirect_params: {
+                    id_token: jwt_token,
+                    issuer: raw_info[:iss]
+                },
+                target: raw_info[::LTI::Messages::Claims::TARGET_LINK_URI]
+            }
+        )
+
+        call_app!
+      end
+    end
+  end
+end
+
+OmniAuth.config.add_camelization 'lti', 'LTI'

--- a/lib/LTI/jwk.rb
+++ b/lib/LTI/jwk.rb
@@ -1,0 +1,11 @@
+module LTI
+  module JWK
+    def parse_jwks_uri(uri)
+      # Download the jwks keyset from the provider.
+      keys = JSON.parse(HTTPClient.new.get_content(uri)).with_indifferent_access
+
+      # Parse the keys.
+      JSON::JWK::Set.new keys[:keys]
+    end
+  end
+end

--- a/lib/LTI/jwk.rb
+++ b/lib/LTI/jwk.rb
@@ -1,5 +1,16 @@
 module LTI
   module JWK
+    KEY_PATH = '/home/dodona/key.pem'.freeze
+
+    def keyset
+      # Only load the key if it exists (staging / production).
+      return {} unless File.file?(KEY_PATH)
+
+      # Parse the key.
+      jwk = JWT::JWK.create_from(OpenSSL::PKey::RSA.new File.read(KEY_PATH))
+      [jwk.export]
+    end
+
     def parse_jwks_uri(uri)
       # Download the jwks keyset from the provider.
       keys = JSON.parse(HTTPClient.new.get_content(uri)).with_indifferent_access

--- a/lib/LTI/messages/claims.rb
+++ b/lib/LTI/messages/claims.rb
@@ -1,0 +1,6 @@
+module LTI::Messages
+  module Claims
+    # Common.
+    TARGET_LINK_URI = 'https://purl.imsglobal.org/spec/lti/claim/target_link_uri'.freeze
+  end
+end

--- a/test/controllers/application_controller_test.rb
+++ b/test/controllers/application_controller_test.rb
@@ -5,6 +5,21 @@ class ApplicationControllerTest < ActionDispatch::IntegrationTest
     @user = create :student
   end
 
+  test 'should store last location' do
+    location = root_path params: { foo: 'bar' }
+    get location
+    assert_response :success
+    assert_equal session[:user_return_to], location
+  end
+
+  test 'should not store last location if too big' do
+    location = root_path params: { foo: 'b' + ('a' * 1024) + 'r' }
+    get location
+    assert_response :success
+    assert_not_equal session[:user_return_to], location
+    assert session[:user_return_to].length < 100
+  end
+
   test 'should get unauthorized status when not logged in' do
     get course_url(@course, format: :json)
     assert_response :unauthorized

--- a/test/controllers/auth/omniauth_callbacks_controller_test.rb
+++ b/test/controllers/auth/omniauth_callbacks_controller_test.rb
@@ -140,7 +140,9 @@ class OmniauthCallbacksControllerTest < ActionDispatch::IntegrationTest
       get omniauth_url(provider)
       follow_redirect!
 
-      assert_equal user, @controller.current_user
+      # Compare the id to the session since @controller.current_user is not
+      # correct in this case (limitation of omniauth testing).
+      assert_equal user.id, session['warden.user.user.key'][0][0]
 
       # Setup #2.
       provider2 = create provider_name
@@ -152,7 +154,9 @@ class OmniauthCallbacksControllerTest < ActionDispatch::IntegrationTest
       get omniauth_url(provider2)
       follow_redirect!
 
-      assert_equal user2, @controller.current_user
+      # Compare the id to the session since @controller.current_user is not
+      # correct in this case (limitation of omniauth testing).
+      assert_equal user2.id, session['warden.user.user.key'][0][0]
 
       # Cleanup.
       sign_out user2

--- a/test/controllers/auth/omniauth_callbacks_controller_test.rb
+++ b/test/controllers/auth/omniauth_callbacks_controller_test.rb
@@ -6,23 +6,23 @@ class OmniauthCallbacksControllerTest < ActionDispatch::IntegrationTest
   def omniauth_mock_identity(identity, params = {})
     # Generic hash.
     auth_hash = {
-        provider: identity.provider.class.sym.to_s,
-        uid: identity.identifier,
-        info: {
-            email: identity.user.email,
-            first_name: identity.user.first_name,
-            last_name: identity.user.last_name,
-            institution: identity.provider.identifier
-        },
-        extra: {
-            raw_info: {
-                hd: identity.provider.identifier
-            }
+      provider: identity.provider.class.sym.to_s,
+      uid: identity.identifier,
+      info: {
+        email: identity.user.email,
+        first_name: identity.user.first_name,
+        last_name: identity.user.last_name,
+        institution: identity.provider.identifier
+      },
+      extra: {
+        raw_info: {
+          hd: identity.provider.identifier
         }
+      }
     }.deep_merge(params)
 
     # LTI and SAML include the provider.
-    auth_hash = auth_hash.deep_merge({extra: {provider: identity.provider}}) if [Provider::Lti, Provider::Saml].include?(identity.provider.class)
+    auth_hash = auth_hash.deep_merge({ extra: { provider: identity.provider } }) if [Provider::Lti, Provider::Saml].include?(identity.provider.class)
 
     OmniAuth.config.mock_auth[:default] = OmniAuth::AuthHash.new(auth_hash)
   end
@@ -118,7 +118,7 @@ class OmniauthCallbacksControllerTest < ActionDispatch::IntegrationTest
     omniauth_mock_identity identity,
                            provider: redirect_provider.class.sym,
                            info: {
-                               institution: redirect_provider.identifier
+                             institution: redirect_provider.identifier
                            }
 
     get omniauth_url(redirect_provider)
@@ -171,8 +171,8 @@ class OmniauthCallbacksControllerTest < ActionDispatch::IntegrationTest
       identity = create :identity, provider: provider, user: user
       omniauth_mock_identity identity,
                              info: {
-                                 first_name: 'Flip',
-                                 last_name: 'Flapstaart'
+                               first_name: 'Flip',
+                               last_name: 'Flapstaart'
                              }
 
       get omniauth_url(provider)
@@ -198,7 +198,7 @@ class OmniauthCallbacksControllerTest < ActionDispatch::IntegrationTest
 
       omniauth_mock_identity identity,
                              info: {
-                                 email: other_user.email
+                               email: other_user.email
                              }
 
       assert_emails 1 do

--- a/test/controllers/lti_controller_test.rb
+++ b/test/controllers/lti_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class LtiControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/factories/providers.rb
+++ b/test/factories/providers.rb
@@ -2,18 +2,22 @@
 #
 # Table name: providers
 #
-#  id             :bigint           not null, primary key
-#  type           :string(255)      default("Provider::Saml"), not null
-#  institution_id :bigint           not null
-#  identifier     :string(255)
-#  certificate    :text(65535)
-#  entity_id      :string(255)
-#  slo_url        :string(255)
-#  sso_url        :string(255)
-#  created_at     :datetime         not null
-#  updated_at     :datetime         not null
-#  mode           :integer          default("prefer"), not null
-#  active         :boolean          default(TRUE)
+#  id                :bigint           not null, primary key
+#  type              :string(255)      default("Provider::Saml"), not null
+#  institution_id    :bigint           not null
+#  identifier        :string(255)
+#  certificate       :text(65535)
+#  entity_id         :string(255)
+#  slo_url           :string(255)
+#  sso_url           :string(255)
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  mode              :integer          default("prefer"), not null
+#  active            :boolean          default(TRUE)
+#  authorization_uri :string(255)
+#  client_id         :string(255)
+#  issuer            :string(255)
+#  jwks_uri          :string(255)
 #
 FactoryBot.define do
   factory :gsuite_provider, class: Provider::GSuite do

--- a/test/factories/providers.rb
+++ b/test/factories/providers.rb
@@ -25,6 +25,15 @@ FactoryBot.define do
     identifier { SecureRandom.uuid }
   end
 
+  factory :lti_provider, class: Provider::Lti do
+    institution
+
+    authorization_uri { Faker::Internet.url }
+    client_id { SecureRandom.uuid }
+    issuer { Faker::Internet.url }
+    jwks_uri { Faker::Internet.url }
+  end
+
   factory :office365_provider, class: Provider::Office365 do
     institution
     identifier { SecureRandom.uuid }

--- a/test/models/provider_test.rb
+++ b/test/models/provider_test.rb
@@ -2,18 +2,22 @@
 #
 # Table name: providers
 #
-#  id             :bigint           not null, primary key
-#  type           :string(255)      default("Provider::Saml"), not null
-#  institution_id :bigint           not null
-#  identifier     :string(255)
-#  certificate    :text(65535)
-#  entity_id      :string(255)
-#  slo_url        :string(255)
-#  sso_url        :string(255)
-#  created_at     :datetime         not null
-#  updated_at     :datetime         not null
-#  mode           :integer          default("prefer"), not null
-#  active         :boolean          default(TRUE)
+#  id                :bigint           not null, primary key
+#  type              :string(255)      default("Provider::Saml"), not null
+#  institution_id    :bigint           not null
+#  identifier        :string(255)
+#  certificate       :text(65535)
+#  entity_id         :string(255)
+#  slo_url           :string(255)
+#  sso_url           :string(255)
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  mode              :integer          default("prefer"), not null
+#  active            :boolean          default(TRUE)
+#  authorization_uri :string(255)
+#  client_id         :string(255)
+#  issuer            :string(255)
+#  jwks_uri          :string(255)
 #
 require 'test_helper'
 

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -159,15 +159,17 @@ class UserTest < ActiveSupport::TestCase
     assert_user_exercises user, 3, 2, 1
   end
 
-  test 'only smartschool users can have blank email' do
-    # Validate that smartschool institutions are valid.
-    smartschool = create :smartschool_provider
-    smartschool_user = build :user, institution: smartschool.institution
-    smartschool_user.email = nil
-    assert smartschool.valid?
+  test 'only lti and smartschool users can have blank email' do
+    # Validate that lti and smartschool institutions are valid.
+    %i[lti_provider smartschool_provider].each do |provider_name|
+      provider = create provider_name
+      user = build :user, institution: provider.institution
+      user.email = nil
+      assert user.valid?
+    end
 
     # Validate that every other institution is invalid.
-    (AUTH_PROVIDERS - [:smartschool_provider]).each do |provider_name|
+    (AUTH_PROVIDERS - %i[lti_provider smartschool_provider]).each do |provider_name|
       provider = create provider_name
       user = build :user, institution: provider.institution
       user.email = nil

--- a/test/testhelpers/constants.rb
+++ b/test/testhelpers/constants.rb
@@ -1,4 +1,4 @@
 module Constants
   OAUTH_PROVIDERS = %i[gsuite_provider office365_provider smartschool_provider].freeze
-  AUTH_PROVIDERS = %i[saml_provider].concat(OAUTH_PROVIDERS).freeze
+  AUTH_PROVIDERS = %i[lti_provider saml_provider].concat(OAUTH_PROVIDERS).freeze
 end


### PR DESCRIPTION
This pull request implements LTI 1.3 authentication through OpenID Connect, as described in https://www.imsglobal.org/spec/security/v1p0/#openid_connect_launch_flow.

If a user logs in using a link provider for the first time, they wil be redirected to the default provider for that institution and the id of the current LTI provider will be stored in the session. Upon returning from the default provider, both identities will be linked together for future use.

This implementation has been tested using Moodle. The CSP violation errors can be "solved" by including the below fragment in the application controller. However, this has not been implemented here, as we will require that the LMS does not embed us but rather opens Dodona in an existing/new window. This will be required for Deep Linking support, but there it can be added in the upcoming LtiController.

```ruby
  content_security_policy do |policy|
    policy.frame_ancestors '*'
  end
```