### PR TITLE
Disable multithreading in system tests

### DIFF
--- a/.github/workflows/system-test.yml
+++ b/.github/workflows/system-test.yml
@@ -61,6 +61,7 @@ jobs:
       env:
         CI: true
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        PARALLEL_WORKERS: 1
       run: |
         git config --global user.email "dodona@ugent.be"
         git config --global user.name "Dodona"


### PR DESCRIPTION
This pull request disables multithreading in system tests to avoid race conditions.