### PR TITLE
Fix static home json

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -18,7 +18,10 @@ class PagesController < ApplicationController
       @grouped_courses = @subscribed_courses.sort_by(&:year).reverse.group_by(&:year)
       @homepage_series = @subscribed_courses.map { |c| c.homepage_series(0) }.flatten.sort_by(&:deadline)
     else
-      render 'static_home'
+      respond_to do |format|
+        format.html { render :static_home }
+        format.json { render partial: 'static_home' }
+      end
     end
   end
 

--- a/app/views/pages/_static_home.json.jbuilder
+++ b/app/views/pages/_static_home.json.jbuilder
@@ -1,0 +1,2 @@
+json.version Dodona::Application::VERSION
+json.min_supported_client Dodona::Application::MIN_SUPPORTED_CLIENT

--- a/app/views/pages/home.json.jbuilder
+++ b/app/views/pages/home.json.jbuilder
@@ -7,5 +7,4 @@ if current_user
     json.partial! 'series/series', series: series
   end
 end
-json.version Dodona::Application::VERSION
-json.min_supported_client Dodona::Application::MIN_SUPPORTED_CLIENT
+json.partial! 'pages/static_home'

--- a/test/controllers/pages_controller_test.rb
+++ b/test/controllers/pages_controller_test.rb
@@ -8,6 +8,11 @@ class PagesControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test 'should get homepage as json' do
+    get root_url(format: :json)
+    assert_response :success
+  end
+
   test 'should get signed in homepage' do
     sign_in(create(:user))
     get root_url


### PR DESCRIPTION
This pull request restores the old behaviour of the json view of the homepage when the user is not logged in:

**http://dodona.localhost:3000/nl.json**
```json
{"version":"3.8.4","min_supported_client":"0.0.1"}
```