### PR TITLE
Don't store URL's with long query parameters in (cookie) session.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,8 @@ class ApplicationController < ActionController::Base
   include Pundit
   include SetCurrentRequestDetails
 
+  MAX_STORED_URL_LENGTH = 1024
+
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
 
   protect_from_forgery with: :null_session
@@ -137,7 +139,12 @@ class ApplicationController < ActionController::Base
   end
 
   def store_current_location
-    store_location_for(:user, request.url)
+    url = if request.url.length > MAX_STORED_URL_LENGTH
+            request.base_url + request.path
+          else
+            request.url
+          end
+    store_location_for :user, url
   end
 
   def look_for_token

--- a/test/controllers/application_controller_test.rb
+++ b/test/controllers/application_controller_test.rb
@@ -5,6 +5,21 @@ class ApplicationControllerTest < ActionDispatch::IntegrationTest
     @user = create :student
   end
 
+  test 'should store last location' do
+    location = root_path params: { foo: 'bar' }
+    get location
+    assert_response :success
+    assert_equal session[:user_return_to], location
+  end
+
+  test 'should not store last location if too big' do
+    location = root_path params: { foo: 'b' + ('a' * 1024) + 'r' }
+    get location
+    assert_response :success
+    assert_not_equal session[:user_return_to], location
+    assert session[:user_return_to].length < 100
+  end
+
   test 'should get unauthorized status when not logged in' do
     get course_url(@course, format: :json)
     assert_response :unauthorized


### PR DESCRIPTION
This pull request adds a check if the `stored_url_for` a user exceeds 1024 characters, it removes the query parameters before storing it in the session.

- [X] Tests were added
