### PR TITLE
Made order of series in course scoresheet logical

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -248,7 +248,7 @@ class Course < ApplicationRecord
   end
 
   def scoresheet
-    sorted_series = series.reverse
+    sorted_series = series
     sorted_users = subscribed_members.order('course_memberships.status ASC')
                                      .order(permission: :asc)
                                      .order(last_name: :asc, first_name: :asc)


### PR DESCRIPTION
The order of series in course scoresheet is now the same as the order of the series in the course homepage.

Closes #1538.

