### PR TITLE
Institution name is now pseudonymized

### DIFF
--- a/app/models/institution.rb
+++ b/app/models/institution.rb
@@ -21,6 +21,12 @@ class Institution < ApplicationRecord
 
   scope :of_course_by_members, ->(course) { joins(users: :courses).where(courses: { id: course.id }).distinct }
 
+  def name
+    return self[:name] unless Current.demo_mode
+    
+    Faker::University.name
+  end
+
   def preferred_provider
     Provider.find_by(institution: self, mode: :prefer)
   end

--- a/app/models/institution.rb
+++ b/app/models/institution.rb
@@ -24,6 +24,7 @@ class Institution < ApplicationRecord
   def name
     return self[:name] unless Current.demo_mode
 
+    Faker::Config.random = Random.new(id + Date.today.yday)
     Faker::University.name
   end
 

--- a/app/models/institution.rb
+++ b/app/models/institution.rb
@@ -23,7 +23,7 @@ class Institution < ApplicationRecord
 
   def name
     return self[:name] unless Current.demo_mode
-    
+
     Faker::University.name
   end
 

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -255,6 +255,13 @@ class UserTest < ActiveSupport::TestCase
     assert_not_equal username, user.username
   end
 
+  test 'institution name should return a name that is not equal to actual institutio name of the user when in demo mode' do
+    user = create :user
+    institution_name = user.institution&.name
+    Current.any_instance.stubs(:demo_mode).returns(true)
+    assert_not_equal institution_name, user.institution&.name
+  end
+
   test 'recent_exercises should return the 3 most recent exercises submissions have been submitted' do
     user = create :user
     exercise1 = create :exercise


### PR DESCRIPTION
When in demo mode the institution names are now pseudonymized.

Closes #1300

Previous Demo mode:
![image](https://user-images.githubusercontent.com/48768719/89169322-5d87d500-d57e-11ea-8e19-2ff54bdd0cd9.png)

New Demo mode:
![image](https://user-images.githubusercontent.com/48768719/89175513-333b1500-d588-11ea-9525-3ee4d9a4acd1.png)
