### PR TITLE
Hide copy button on empty submission

### DIFF
--- a/app/helpers/renderers/feedback_code_renderer.rb
+++ b/app/helpers/renderers/feedback_code_renderer.rb
@@ -19,10 +19,12 @@ class FeedbackCodeRenderer
   def add_code
     @builder.div(class: 'code-listing-container') do
       parse
-
-      # Not possible to use clipboard_button_for here since the behaviour is different.
-      @builder.button(class: 'btn btn-default copy-btn', id: "copy-to-clipboard-#{@instance}", title: I18n.t('js.code.copy-to-clipboard'), 'data-toggle': 'tooltip', 'data-placement': 'top') do
-        @builder.i(class: 'mdi mdi-clipboard-text mdi-18') {}
+      # Only display copy button when the submission is not empty
+      if @code.present?
+        # Not possible to use clipboard_button_for here since the behaviour is different.
+        @builder.button(class: 'btn btn-default copy-btn', id: "copy-to-clipboard-#{@instance}", title: I18n.t('js.code.copy-to-clipboard'), 'data-toggle': 'tooltip', 'data-placement': 'top') do
+          @builder.i(class: 'mdi mdi-clipboard-text mdi-18') {}
+        end
       end
       @builder.script(type: 'application/javascript') do
         @builder << <<~HEREDOC

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -220,7 +220,8 @@ if Rails.env.development?
                           status: before,
                           accepted: before == :correct,
                           created_at: before_deadline,
-                          code: code,
+                          # allow Status Test to contain empty submissions for layout testing
+                          code: rand() > 0.5 ? code : '',
                           result: File.read(Rails.root.join('db', 'results', "#{exercise.judge.name}-result.json"))
       end
       if after != :none


### PR DESCRIPTION
This pull request hides the copy button when the submission is empty.

Visuals now:
![empty_code](https://user-images.githubusercontent.com/53743234/89175628-67aed100-d588-11ea-94da-9e64e8fe3d31.png)
Previous visuals can be found in:
https://github.com/dodona-edu/dodona/issues/2053

- [ ] Tests:
Seed was changed to sometimes submit empty code to allow this case to be tested more easily.

Closes #2053 .
