### PR TITLE
Make separate series and empty submission

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -307,6 +307,10 @@ if Rails.env.development?
 
   # Add an empty Submission to the course
   exercise = Exercise.last
+  Series.create name: "Lege, foute inzending na deadline",
+                course: status_test,
+                deadline: deadline,
+                exercises: [exercise]
   Submission.create user: zeus,
                     exercise: exercise,
                     evaluate: false,
@@ -317,8 +321,5 @@ if Rails.env.development?
                     created_at: after_deadline,
                     code: '',
                     result: File.read(Rails.root.join('db', 'results', "#{exercise.judge.name}-result.json"))
-  Series.create name: "Lege, foute inzending na deadline",
-                course: status_test,
-                deadline: deadline,
-                exercises: [exercise]
+
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -220,8 +220,7 @@ if Rails.env.development?
                           status: before,
                           accepted: before == :correct,
                           created_at: before_deadline,
-                          # allow Status Test to contain empty submissions for layout testing
-                          code: rand() > 0.5 ? code : '',
+                          code: code,
                           result: File.read(Rails.root.join('db', 'results', "#{exercise.judge.name}-result.json"))
       end
       if after != :none
@@ -305,4 +304,21 @@ if Rails.env.development?
                 course: status_test,
                 deadline: deadline,
                 exercises: [status_exercises[:none][:correct], status_exercises[:none][:none]]
+
+  # Add an empty Submission to the course
+  exercise = Exercise.last
+  Submission.create user: zeus,
+                    exercise: exercise,
+                    evaluate: false,
+                    skip_rate_limit_check: true,
+                    course: status_test,
+                    status: :wrong,
+                    accepted: false,
+                    created_at: after_deadline,
+                    code: '',
+                    result: File.read(Rails.root.join('db', 'results', "#{exercise.judge.name}-result.json"))
+  Series.create name: "Lege, foute inzending na deadline",
+                course: status_test,
+                deadline: deadline,
+                exercises: [exercise]
 end

--- a/public/javascripts/i18n.js
+++ b/public/javascripts/i18n.js
@@ -679,7 +679,7 @@
       var s = scope.split('.').slice(-1)[0];
       //replace underscore with space && camelcase with space and lowercase letter
       return (this.missingTranslationPrefix.length > 0 ? this.missingTranslationPrefix : '') +
-          s.replace('_',' ').replace(/([a-z])([A-Z])/g,
+          s.replace(/_/g,' ').replace(/([a-z])([A-Z])/g,
           function(match, p1, p2) {return p1 + ' ' + p2.toLowerCase()} );
     }
 


### PR DESCRIPTION
This pull request makes the testing of empty submissions more deterministic.
Part of #2132 but it was merged before I could get this to work.
Finalises work on #2053 

A new series now contains a single, empty submission by the Zeus user.
