### PR TITLE
Zero submission message now uses full row

### DIFF
--- a/app/views/feedbacks/show.html.erb
+++ b/app/views/feedbacks/show.html.erb
@@ -15,7 +15,7 @@
       </div>
       <div class="card-supporting-text card-border">
         <div class="row">
-        <% if (@feedback.submission.present? && @feedback.later_attempts + @feedback.previous_attempts > 0) || @feedback.total_attempts > 0 %>
+        <% if @feedback.total_attempts > 0 %>
           <div class="col-sm-6 col-sm-push-6">
             <div class="feedback-metadata-submission">
               <p>

--- a/app/views/feedbacks/show.html.erb
+++ b/app/views/feedbacks/show.html.erb
@@ -15,6 +15,7 @@
       </div>
       <div class="card-supporting-text card-border">
         <div class="row">
+        <% if (@feedback.submission.present? && @feedback.later_attempts + @feedback.previous_attempts > 0) || @feedback.total_attempts > 0 %>
           <div class="col-sm-6 col-sm-push-6">
             <div class="feedback-metadata-submission">
               <p>
@@ -38,6 +39,9 @@
             </div>
           </div>
           <div class="col-sm-6 col-sm-pull-6">
+          <% else %>
+          <div class="col-sm-12">
+          <% end %>
             <% if @feedback.submission.present? %>
               <% submission = @feedback.submission %>
               <div class="submission-summary clearfix">


### PR DESCRIPTION
Previous:
![image](https://user-images.githubusercontent.com/5736113/84390739-4ec51780-abf8-11ea-90d4-3dd8caf7725b.png)

Now:
![image](https://user-images.githubusercontent.com/48768719/89273253-98057680-d63f-11ea-9d42-349ce17f5b1e.png)
Closes #2052.
