### PR TITLE
Added light-only and dark-only css classes to hide when needed

### DIFF
--- a/app/assets/stylesheets/theme/theme-dark.css.less
+++ b/app/assets/stylesheets/theme/theme-dark.css.less
@@ -111,6 +111,6 @@
     }
 
     .dark-only {
-        display: block;
+        display: unset;
     }
 }

--- a/app/assets/stylesheets/theme/theme-dark.css.less
+++ b/app/assets/stylesheets/theme/theme-dark.css.less
@@ -105,12 +105,12 @@
 
 @table-hover-bg: @body-bg;
 
+.activity-description {
+    .light-only {
+        display: none;
+    }
 
-.light-only {
-    visibility: hidden;
-    display: none;
+    .dark-only {
+        display: block;
+    }
 }
-
-.dark-only {
-    visibility: visible;
-} 

--- a/app/assets/stylesheets/theme/theme-dark.css.less
+++ b/app/assets/stylesheets/theme/theme-dark.css.less
@@ -104,3 +104,13 @@
 @punchcard-fg: @light-blue-900;
 
 @table-hover-bg: @body-bg;
+
+
+.light-only {
+    visibility: hidden;
+    display: none;
+}
+
+.dark-only {
+    visibility: visible;
+} 

--- a/app/assets/stylesheets/theme/theme-light.css.less
+++ b/app/assets/stylesheets/theme/theme-light.css.less
@@ -177,6 +177,6 @@
     }
 
     .light-only {
-        display: block;
+        display: unset;
     }
 }

--- a/app/assets/stylesheets/theme/theme-light.css.less
+++ b/app/assets/stylesheets/theme/theme-light.css.less
@@ -171,7 +171,12 @@
 
 @table-hover-bg: @grey-50;
 
-.dark-only {
-    visibility: hidden;
-    display: none;
+.activity-description {
+    .dark-only {
+        display: none;
+    }
+
+    .light-only {
+        display: block;
+    }
 }

--- a/app/assets/stylesheets/theme/theme-light.css.less
+++ b/app/assets/stylesheets/theme/theme-light.css.less
@@ -170,3 +170,8 @@
 @heatmap-hover-fg: @grey-200;
 
 @table-hover-bg: @grey-50;
+
+.dark-only {
+    visibility: hidden;
+    display: none;
+}


### PR DESCRIPTION
This pull request add the `light-only` and `dark-only` css classes that can be used to hide elements in dark and light mode. As the names suggest `light-only` will only be visible in light mode while `dark-only` will only be visible in dark mode.

- [x] Added documentation at [dodona-edu/dodona-edu.github.io#69](https://github.com/dodona-edu/dodona-edu.github.io/pull/69)

Closes #1397.
