### PR TITLE
API token improvements

### DIFF
--- a/app/assets/stylesheets/components.css.less
+++ b/app/assets/stylesheets/components.css.less
@@ -25,7 +25,7 @@
   flex-grow: 1;
 }
 
-.h3-info-text, .h4-info-text, .header-info-text {
+.h3-info-text, .h4-info-text, .h5-info-text, .header-info-text {
   font-size: 85%;
   color: @text-muted;
 }
@@ -36,6 +36,10 @@
 
 .h4-info-text {
   margin-top: -12px;
+}
+
+.h5-info-text {
+  margin-top: -6px;
 }
 
 .page-subtitle {

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -60,6 +60,11 @@ class PagesController < ApplicationController
     end
   end
 
+  def profile
+    authorize :pages
+    redirect_to user_path(current_user)
+  end
+
   private
 
   def contact_params

--- a/app/policies/pages_policy.rb
+++ b/app/policies/pages_policy.rb
@@ -6,4 +6,8 @@ class PagesPolicy < ApplicationPolicy
   def toggle_dark_mode?
     true
   end
+
+  def profile?
+    user.present?
+  end
 end

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -10,25 +10,6 @@
       <div class="card-supporting-text">
         <%= render 'form', user: @user %>
       </div>
-
-    </div>
-    <div class="card">
-      <div class="card-supporting-text card-border">
-        <div class="col-xs-12">
-          <h4><%= t '.api_tokens' %></h4>
-          <p class="h4-info-text"><%= t ".token_help_html" %></p>
-          <div id="fresh-token">
-          </div>
-          <h5><%= t '.create_new_token' %></h5>
-          <div id="new-token-form">
-            <%= render 'api_tokens/form', user: @user %>
-          </div>
-          <h5><%= t '.active_tokens' %></h5>
-          <div id="token-table-placeholder">
-            <%= render 'api_tokens/table', user: @user %>
-          </div>
-        </div>
-      </div>
     </div>
   </div>
 </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -108,6 +108,27 @@
         </div>
       <% end %>
     </div>
+    <% if policy(@user).edit? %>
+      <div class="card">
+        <div class="card-supporting-text card-border">
+          <div class="col-xs-12">
+            <h4><%= t '.api_tokens' %></h4>
+            <p class="h4-info-text"><%= t ".token_help_html" %></p>
+            <div id="fresh-token">
+            </div>
+            <h5><%= t '.create_new_token' %></h5>
+            <p class="h5-info-text"><%= t ".description_help" %></p>
+            <div id="new-token-form">
+              <%= render 'api_tokens/form', user: @user %>
+            </div>
+            <h5><%= t '.active_tokens' %></h5>
+            <div id="token-table-placeholder">
+              <%= render 'api_tokens/table', user: @user %>
+            </div>
+          </div>
+        </div>
+      </div>
+    <% end %>
     <div class="card visualizations">
       <div class="card-supporting-text">
         <%= render partial: 'visualizations/punchcard', locals: {user: @user} %>

--- a/config/locales/views/users/en.yml
+++ b/config/locales/views/users/en.yml
@@ -32,15 +32,15 @@ en:
       timezone: Your timezone is set to
       stats: Statistics
       download_my_submissions: Export my submissions
+      api_tokens: API tokens
+      active_tokens: Active tokens
+      create_new_token: Create new token
+      token_help_html: API tokens allow other tools such as the <a href="https://github.com/thepieterdc/dodona-plugin-jetbrains">Dodona plugin for Jetbrains IDEs</a> to access Dodona on your behalf without having to share your password. These tools will have full access to your account, but you can easily revoke that access by removing the token on this page.
+      description_help: The description helps you to remember which program uses a certain token. This allows you to easily withdram permissions without having to delete all your tokens.
     users_table:
       staff: Staff
       zeus: Zeus
       course_admin: Course administrator
       no_institution: This user has no institution
-    edit:
-      api_tokens: API tokens
-      active_tokens: Active tokens
-      create_new_token: Create new token
-      token_help_html: API tokens allow other tools such as the <a href="https://github.com/thepieterdc/dodona-plugin-jetbrains">Dodona plugin for Jetbrains IDEs</a> to access Dodona on your behalf without having to share your password. These tools will have full access to your account, but you can easily revoke that access by removing the token on this page.
     repository_users_table:
       no_institution: "No institution"

--- a/config/locales/views/users/en.yml
+++ b/config/locales/views/users/en.yml
@@ -36,7 +36,7 @@ en:
       active_tokens: Active tokens
       create_new_token: Create new token
       token_help_html: API tokens allow other tools such as the <a href="https://github.com/thepieterdc/dodona-plugin-jetbrains">Dodona plugin for Jetbrains IDEs</a> to access Dodona on your behalf without having to share your password. These tools will have full access to your account, but you can easily revoke that access by removing the token on this page.
-      description_help: The description helps you to remember which program uses a certain token. This allows you to easily withdram permissions without having to delete all your tokens.
+      description_help: The description helps you to remember which program uses a certain token. This allows you to easily withdraw permissions without having to delete all your tokens.
     users_table:
       staff: Staff
       zeus: Zeus

--- a/config/locales/views/users/nl.yml
+++ b/config/locales/views/users/nl.yml
@@ -32,15 +32,15 @@ nl:
       timezone: Je tijdzone staat ingesteld op
       stats: Statistieken
       download_my_submissions: Mijn oplossingen exporteren
+      api_tokens: API tokens
+      active_tokens: Actieve tokens
+      create_new_token: Nieuw token aanmaken
+      token_help_html: API tokens laten andere programma's zoals de <a href="https://github.com/thepieterdc/dodona-plugin-jetbrains">Dodona plugin voor Jetbrains IDE's</a> toe om voor jou Dodona te gebruiken zonder je wachtwoord te moeten delen. Deze programma's zullen volledige toegang hebben tot jouw account, maar je kan die toegang gemakkelijk intrekken door het token te verwijderen onderaan deze pagina.
+      description_help: De beschrijving is een geheugensteuntje zodat jij weet welk programma een bepaalde token gebruikt. Zo kan je eenvoudig bepaalde permissies intrekken zonder je andere tokens te moeten verwijderen.
     users_table:
       staff: Beheerder
       zeus: Zeus
       course_admin: cursusbeheerder
       no_institution: Deze gebruiker heeft geen onderwijsinstelling
-    edit:
-      api_tokens: API tokens
-      active_tokens: Actieve tokens
-      create_new_token: Nieuw token aanmaken
-      token_help_html: API tokens laten andere programma's zoals de <a href="https://github.com/thepieterdc/dodona-plugin-jetbrains">Dodona plugin voor Jetbrains IDE's</a> toe om voor jou Dodona te gebruiken zonder je wachtwoord te moeten delen. Deze programma's zullen volledige toegang hebben tot jouw account, maar je kan die toegang gemakkelijk intrekken door het token te verwijderen onderaan deze pagina.
     repository_users_table:
       no_institution: "Geen onderwijsinstelling"

--- a/config/locales/views/users/nl.yml
+++ b/config/locales/views/users/nl.yml
@@ -36,7 +36,7 @@ nl:
       active_tokens: Actieve tokens
       create_new_token: Nieuw token aanmaken
       token_help_html: API tokens laten andere programma's zoals de <a href="https://github.com/thepieterdc/dodona-plugin-jetbrains">Dodona plugin voor Jetbrains IDE's</a> toe om voor jou Dodona te gebruiken zonder je wachtwoord te moeten delen. Deze programma's zullen volledige toegang hebben tot jouw account, maar je kan die toegang gemakkelijk intrekken door het token te verwijderen onderaan deze pagina.
-      description_help: De beschrijving is een geheugensteuntje zodat jij weet welk programma een bepaalde token gebruikt. Zo kan je eenvoudig bepaalde permissies intrekken zonder je andere tokens te moeten verwijderen.
+      description_help: De beschrijving is een geheugensteuntje zodat jij weet welk programma een bepaalde token gebruikt. Zo kan je eenvoudig de toegang van één programma kan ontzeggen zonder alle tokens te moeten verwijderen.
     users_table:
       staff: Beheerder
       zeus: Zeus

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,6 +27,7 @@ Rails.application.routes.draw do
     get '/about' => 'pages#about'
     get '/data' => 'pages#data'
     get '/privacy' => 'pages#privacy'
+    get '/profile' => 'pages#profile', as: 'profile'
 
     get '/contact' => 'pages#contact'
     post '/contact' => 'pages#create_contact', as: 'create_contact'

--- a/test/controllers/pages_controller_test.rb
+++ b/test/controllers/pages_controller_test.rb
@@ -49,4 +49,18 @@ class PagesControllerTest < ActionDispatch::IntegrationTest
     end
     assert_redirected_to root_url
   end
+
+  test 'should get profile when logged in' do
+    user = create :user
+    sign_in user
+    get profile_url
+    assert_response :redirect
+    assert_redirected_to user_path(user)
+  end
+
+  test 'should not get profile when logged out' do
+    get profile_url
+    assert_response :redirect
+    assert_redirected_to sign_in_url
+  end
 end


### PR DESCRIPTION
This pull request adds a /profile URL to allow easier access to a user's profile for faster API token generation and also improves accessibility of this feature.

Visuals of placement of form on users/show:
![token-show](https://user-images.githubusercontent.com/53743234/89897126-dd491b80-dbde-11ea-9bf4-6b170eb49f62.png)


- [x] Tests were added
--pages_controller_test.rb has 2 profile tests
- [x] Documentation update can be found at dodona-edu/dodona-edu.github.io#
https://github.com/dodona-edu/dodona-edu.github.io/pull/71
Closes #2095  .
