### PR TITLE
Fix feedback#show with nil submission

### DIFF
--- a/app/views/feedbacks/show.html.erb
+++ b/app/views/feedbacks/show.html.erb
@@ -1,6 +1,6 @@
 <% content_for :javascripts do %>
   <%= javascript_pack_tag 'submission' %>
-  <%= javascript_pack_tag 'pythia_submission' if @feedback.submission.judge.renderer == PythiaRenderer %>
+  <%= javascript_pack_tag 'pythia_submission' if @feedback.submission&.judge&.renderer == PythiaRenderer %>
 <% end %>
 
 <div class="row" id="feedback-page">


### PR DESCRIPTION
This pull request fixes a small bug where the feedback#show page would crash when there was no submission.

- [X] Tests were added
