### PR TITLE
Make links to public files link to actual file

### DIFF
--- a/app/views/repositories/show.html.erb
+++ b/app/views/repositories/show.html.erb
@@ -72,7 +72,7 @@
                     <% @files.each do |file| %>
                       <tr>
                         <td><%= file.to_s %></td>
-                        <td><%= link_to public_repository_url(@repository, file) %></td>
+                        <td><%= link_to nil, public_repository_url(@repository, media: file) %></td>
                       </tr>
                     <% end %>
                   </tbody>


### PR DESCRIPTION
This pull request fixes the links to the public repository files. Apparently if you use `link_to` with only an URL, it uses the URL as link content and the current path as `href` :facepalm:.
