### PR TITLE
Fix translation location

### DIFF
--- a/config/locales/views/activities/en.yml
+++ b/config/locales/views/activities/en.yml
@@ -79,7 +79,7 @@ en:
         next: Next activity
       mark_as_read: Mark as read
       read_at: "Marked as read at %{timestamp}"
-    series_exercises_table:
+    series_activities_add_table:
       course_added_to_usable: "Adding this exercise will allow this course to use all private exercises in this exercise's repository. Are you sure?"
     edit:
       courses: "Courses using this exercise"

--- a/config/locales/views/activities/nl.yml
+++ b/config/locales/views/activities/nl.yml
@@ -79,7 +79,7 @@ nl:
         next: Volgende activiteit
       mark_as_read: Markeren als gelezen
       read_at: "Gelezen op %{timestamp}"
-    series_exercises_table:
+    series_activities_add_table:
       course_added_to_usable: "Deze oefening toevoegen zal deze cursus toegang geven tot alle privé oefeningen in de repository van deze oefening. Ben je zeker?"
     edit:
       courses: "Cursussen die deze oefening gebruiken"


### PR DESCRIPTION
This pull request fixes #2182.
Ill formatting was caused by a missing translation due to renaming of the file earlier on.  Only visible when private exercises are used, which don't exist on develop.
