### PR TITLE
Add media path to exercises leading to activity

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -88,10 +88,10 @@ Rails.application.routes.draw do
     resources :courses do
       resources :series, only: %i[new index] do
         resources :activities, only: %i[show edit update], concerns: %i[mediable readable submitable infoable]
-        resources :activities, only: %i[show edit update], concerns: %i[submitable infoable], path: '/exercises'
+        resources :activities, only: %i[show edit update], concerns: %i[mediable readable submitable infoable], path: '/exercises', as: 'exercises'
       end
       resources :activities, only: %i[show edit update], concerns: %i[mediable readable submitable infoable]
-      resources :activities, only: %i[show edit update], concerns: %i[submitable infoable], path: '/exercises'
+      resources :activities, only: %i[show edit update], concerns: %i[mediable readable submitable infoable], path: '/exercises', as: 'exercises'
       resources :submissions, only: [:index]
       resources :members, only: %i[index show edit update], controller: :course_members do
         get 'download_labels_csv', on: :collection
@@ -128,7 +128,7 @@ Rails.application.routes.draw do
       end
     end
 
-    resources :activities, only: %i[index show edit update], concerns: %i[submitable infoable], path: '/exercises' do
+    resources :activities, only: %i[index show edit update], concerns: %i[mediable readable submitable infoable], path: '/exercises', as: 'exercises' do
       member do
         scope 'description/:token/' do
           constraints host: Rails.configuration.sandbox_host do

--- a/test/controllers/activities_controller_test.rb
+++ b/test/controllers/activities_controller_test.rb
@@ -117,6 +117,14 @@ class ActivitiesControllerTest < ActionDispatch::IntegrationTest
     assert_equal 'image/png', response.content_type
   end
 
+  test 'exercises media should redirect to activities media' do
+    Exercise.any_instance.stubs(:media_path).returns(Pathname.new('public'))
+    get media_exercise_url(@instance, 'icon.png')
+
+    assert_response :success
+    assert_equal response.content_type, 'image/png'
+  end
+
   test 'should not get private media' do
     sign_out :user
     Exercise.any_instance.stubs(:media_path).returns(Pathname.new('public'))


### PR DESCRIPTION
This pull request ensures that the exercises urls show the same behaviour as the activities urls.
Now media_exercise_url and media_activity_url lead to the same result without leading to a 500.
as: 'exercises' was required to avoid name clashing of routes.
- [x] Tests were added

Closes #2190  .
