### PR TITLE
Fix activities info page

### DIFF
--- a/app/views/activities/info.html.erb
+++ b/app/views/activities/info.html.erb
@@ -187,7 +187,7 @@
                       <%= link_to t('.sample_solution_submit'), activity_scoped_url(activity: @activity, series: @series, course: @course, options: {from_solution: fname}), class: "btn-text" %>
                     </div>
                     <div class="code-table">
-                      <%= raw FeedbackCodeRenderer.new(code, @activity.programming_language.name).add_code.html %>
+                      <%= raw FeedbackCodeRenderer.new(code, @activity.programming_language&.name).add_code.html %>
                     </div>
                   </div>
                 <% end %>

--- a/test/controllers/activities_controller_test.rb
+++ b/test/controllers/activities_controller_test.rb
@@ -84,6 +84,13 @@ class ActivitiesControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test 'should show activity info when programming language is nil' do
+    stub_all_activities!
+    @instance.update(programming_language: nil)
+    get info_activity_url(@instance)
+    assert_response :success
+  end
+
   test 'should rescue from exercise not found' do
     not_id = Random.rand(10_000)
     begin


### PR DESCRIPTION
This pull request fixes a crash with the rendering of the activities info page.

A nil programming language probably means an incomplete configuration, but the feedback table should still be rendered. Is the text-icon instead of the actual language a sufficient hint their configuration is incomplete or do we want to warn them here aswell? 

Closes  #2210 .