### PR TITLE
Add LTI provider to translations

### DIFF
--- a/config/locales/models/en.yml
+++ b/config/locales/models/en.yml
@@ -146,6 +146,7 @@ en:
         office365: Office 365
         smartschool: Smartschool
         google_oauth2: G Suite
+        lti: LTI
       event:
         event_type: Type
         user: User

--- a/config/locales/models/nl.yml
+++ b/config/locales/models/nl.yml
@@ -147,6 +147,7 @@ nl:
         office365: Office 365
         smartschool: Smartschool
         google_oauth2: G Suite
+        lti: LTI
       event:
         event_type: Type
         user: Gebruiker


### PR DESCRIPTION
Without these, the institution page crashes with `I18n::MissingTranslationData` in development if the institution has an LTI provider.