### PR TITLE
Use role based icon

### DIFF
--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -38,7 +38,14 @@
           <% end %>
           <li class="dropdown">
             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
-              <i class="mdi mdi-24 mdi-account-circle"></i>
+              <% if current_user.zeus? %>
+                <% user_icon = 'android' %>
+              <% elsif current_user.staff? %>
+                <% user_icon = 'school' %>
+              <% else %>
+                <% user_icon = 'account-circle' %>
+              <% end %>
+              <i class="<%= "mdi mdi-24 mdi-#{user_icon}"%>"></i>
               <span class="dropdown-title"><%= current_user.first_name || current_user.last_name %></span>
               <span class="caret"></span>
             </a>


### PR DESCRIPTION
This pull request updates the user icon in the navbar.
Nothing changes for regular users.
If a zeus member is logged in:
![navbar-zeus](https://user-images.githubusercontent.com/53743234/91954144-aeb3f180-ed01-11ea-9206-4497d387a243.PNG)
If a staff member is logged in:
![navbar-staff](https://user-images.githubusercontent.com/53743234/91954160-b07db500-ed01-11ea-9cc3-93d6cf904379.PNG)


Closes #2206  .
