### PR TITLE
Fix double border in code blocks in global annotations

### DIFF
--- a/app/assets/stylesheets/components/code_listing.css.less
+++ b/app/assets/stylesheets/components/code_listing.css.less
@@ -177,6 +177,17 @@
       display: block;
       word-break: break-word;
 
+      // Override the normal pre padding & coloring
+      pre {
+        padding: 0;
+        background-color: transparent;
+        margin-bottom: 0;
+        border: none;
+        border-radius: 0;
+        white-space: pre-wrap;
+        line-height: 20px;
+      }
+
       // Stylize the embedded code block
       .highlighter-rouge div.highlight {
         padding: 5px 10px;


### PR DESCRIPTION
This pull request fixes #2224.

I've simply duplictated the style applied on the code listing `pre` elements, thus applying it on all code annotation `pre` elements. As these are two semantically different `pre` elements, I don't think it's a problem the style is duplicated.

![image](https://user-images.githubusercontent.com/1756811/92399362-7f025080-f12a-11ea-900b-cf3be064ba59.png)