### PR TITLE
Point Windows users to WSL 2 instead of WSL 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,26 +53,6 @@ If this does not work out of the box you can add the following lines to your `/e
 
 ## Running on Windows
 
-Some gems (such as therubyracer) are not supported on Windows. However it is possible to run Dodona using [WSL](https://docs.microsoft.com/en-us/windows/wsl/about). Note: using [WSL2](https://docs.microsoft.com/en-us/windows/wsl/wsl2-index), these steps are probably not necessary.
-
-* Dodona itself must be run in WSL. The Ubuntu WSL distribution is known to work.
-* The database can be run in either Windows or WSL. If you run the database in Windows, you must change `host` from `localhost` to `127.0.0.1` (in `config/database.yml`). Otherwise Ruby will attempt to connect using sockets, which won't work.
-
-### Docker
-
-Docker runs in Windows, and requires some tweaks to communicate with WSL.
-
-* Enable the TCP daemon in the [Docker settings](https://docs.docker.com/docker-for-windows/#general).
-* Set the environment variable `DOCKER_URL` to the url of the Docker daemon. Otherwise Ruby will again attempt to connect using sockets.
-* Dodona uses [bind mounts](https://docs.docker.com/storage/bind-mounts/) to share a folder with the container. As Dodona runs in WSL and Docker in Windows, this does not work out of the box.
-  * By default, WSL uses paths of the form `/mnt/c/users/blabla`. However, Docker uses `/c/users/blabla`. You need to change the mount location in WSL. (See also [in this blog post](https://nickjanetakis.com/blog/setting-up-docker-for-windows-and-wsl-to-work-flawlessly#ensure-volume-mounts-work) and the [reference documentation](https://docs.microsoft.com/en-us/windows/wsl/wsl-config#set-wsl-launch-settings).)
-  * Open or create the config file by running `sudo nano /etc/wsl.conf` in WSL and insert this:
-    ```
-    [automount]
-    root = /
-    options = "metadata,umask=22,fmask=11"
-    ```
-    This will also give Windows folders proper permissions in WSL.
-  
-  * There is another problem: Dodona creates a temporary folder in `/tmp` (inside WSL), which is not accessible to Docker. A solution is setting the `TMPDIR` environment variable (in WSL when running Dodona). Set `TMPDIR` to a folder on your Windows drive, like `/c/ubuntu-tmp`. As Dodona will then pass `/c/ubuntu-tmp` to Docker, it will be able to access the folder.
-* This is not specific to Dodona, but when you build Docker images in Windows, you need special care to ensure files have the proper permissions (executable) and have the correct line endings.
+Some gems (such as therubyracer) and dependencies (such as memcached) do not work on Windows.
+You should use [WSL 2](https://docs.microsoft.com/en-us/windows/wsl/about) instead, and run everything inside WSL.
+This means you use WSL for the database, memcached, git, Docker, etc.


### PR DESCRIPTION
The WSL 1 instructions were one big hack and the result was rather slow. Developing in WSL 2 should be much more stable, faster and just works ™️ 