### PR TITLE
Fix bug when wrapping long lines

### DIFF
--- a/app/assets/stylesheets/components/code_listing.css.less
+++ b/app/assets/stylesheets/components/code_listing.css.less
@@ -245,7 +245,9 @@
   .annotation.machine-annotation {
     .annotation-text {
       font-family: @font-family-monospace;
+      // pre-wrap for browsers that don't support break-spaces.
       white-space: pre-wrap;
+      white-space: break-spaces;
     }
   }
 


### PR DESCRIPTION
This pull request fixes #2221.

Very long uninterrupted sequences of spaces cause the line to overflow in Blink-based browsers (Chrome, Edge). This is not an issue on Firefox. Using the newer attribute "break-spaces" fixes this in Chrome and has no effect in Firefox, so it seems like a good solution to me.
