### PR TITLE
Always init masonry roots

### DIFF
--- a/app/assets/javascripts/home_page.js
+++ b/app/assets/javascripts/home_page.js
@@ -4,6 +4,7 @@ import { Masonry } from "./masonry";
 function initHomePageCards() {
     const masonry = new Masonry();
     function init() {
+        masonry.initMasonryRoots();
         $(".favorite-button").click(toggleFavorite);
     }
 

--- a/app/assets/javascripts/masonry.ts
+++ b/app/assets/javascripts/masonry.ts
@@ -12,8 +12,7 @@ export class Masonry {
     roots: CustomElement[];
 
     constructor() {
-        // subscribe to load and resize events
-        window.addEventListener("load", () => this.initMasonryRoots());
+        // subscribe to resize events
         window.addEventListener("resize", () => this.setCellLayout());
     }
 


### PR DESCRIPTION
The load event isn't triggered when returning from another page or when the listener is installed after the event has already triggered. Both things happened regularly on my machine (Firefox on Linux). This pull request moves the initialisation of the roots from the event handler to the init function of the homepage javascript. This fixes all issues for me. I also tested chromium on my machine, everything still works as expected there as well.

@bmesuere Can you test Safari, Chrome and Firefox on macOS?
@niknetniko Can you test Edge, Chrome and Firefox on windows?
