### PR TITLE
Catch invalid providers

### DIFF
--- a/lib/SAML/setup.rb
+++ b/lib/SAML/setup.rb
@@ -31,13 +31,9 @@ module OmniAuth
 
           # Obtain the saml parameters for the provider.
           provider = Provider::Saml.find_by(id: id)
-          return failure! if provider.blank?
+          return {} if provider.blank?
 
           OmniAuth::Strategies::SAML::Settings.for_provider(provider)
-        end
-
-        def failure!
-          raise "Invalid provider."
         end
       end
     end

--- a/lib/SAML/strategy.rb
+++ b/lib/SAML/strategy.rb
@@ -24,6 +24,8 @@ module OmniAuth
           # Redirect the user to the federated sign-in page.
           redirect saml_auth_request.create(settings)
         end
+      rescue RuntimeError
+        fail!(:invalid_response, $!)
       end
 
       # User has signed in at IDP and is returned to Dodona.


### PR DESCRIPTION
This pull request catches invalid SAML providers and redirects the user to the homepage, rather than raising a 500 error. This should keep the notifications channel a bit more clean.