### PR TITLE
Use editor_name of programming language when rendering with Rouge

### DIFF
--- a/app/helpers/renderers/feedback_table_renderer.rb
+++ b/app/helpers/renderers/feedback_table_renderer.rb
@@ -298,7 +298,7 @@ class FeedbackTableRenderer
 
   def source(_, messages)
     @builder.div(class: 'code-table', 'data-submission-id': @submission.id) do
-      @builder << FeedbackCodeRenderer.new(@code, @submission.exercise.programming_language&.name)
+      @builder << FeedbackCodeRenderer.new(@code, @programming_language)
                                       .add_messages(@submission, messages, @user)
                                       .add_code
                                       .html

--- a/app/views/activities/info.html.erb
+++ b/app/views/activities/info.html.erb
@@ -187,7 +187,7 @@
                       <%= link_to t('.sample_solution_submit'), activity_scoped_url(activity: @activity, series: @series, course: @course, options: {from_solution: fname}), class: "btn-text" %>
                     </div>
                     <div class="code-table">
-                      <%= raw FeedbackCodeRenderer.new(code, @activity.programming_language&.name).add_code.html %>
+                      <%= raw FeedbackCodeRenderer.new(code, @activity.programming_language&.editor_name).add_code.html %>
                     </div>
                   </div>
                 <% end %>


### PR DESCRIPTION
This pull request changes the feedback renderer and info page to use the `editor_name` property instead of the `name`. The `@programming_language` variable in `feedback_table_renderer.rb` was meant for this; it wasn't used until now. The whole point of this property was for the rendering (in the ACE editor and rouge), so not sure what happened there.

Noticed this when introducing the new `Rmarkdown` programming language.