### PR TITLE
Make programming languages editable

### DIFF
--- a/app/assets/stylesheets/models.css.less
+++ b/app/assets/stylesheets/models.css.less
@@ -6,3 +6,4 @@
 @import "models/submissions.css.less";
 @import "models/users.css.less";
 @import "models/questions.css.less";
+@import "models/programming_languages.css.less";

--- a/app/assets/stylesheets/models/programming_languages.css.less
+++ b/app/assets/stylesheets/models/programming_languages.css.less
@@ -4,10 +4,6 @@
   }
 }
 
-.title-icon {
-  padding-right: 10px;
-}
-
 .control-icon {
   // Same as control-label
   padding-top: 7px;

--- a/app/assets/stylesheets/models/programming_languages.css.less
+++ b/app/assets/stylesheets/models/programming_languages.css.less
@@ -1,0 +1,14 @@
+.language-table {
+  th.type-icon, td.type-icon {
+    color: @text-secondary;
+  }
+}
+
+.title-icon {
+  padding-right: 10px;
+}
+
+.control-icon {
+  // Same as control-label
+  padding-top: 7px;
+}

--- a/app/policies/programming_language_policy.rb
+++ b/app/policies/programming_language_policy.rb
@@ -27,7 +27,7 @@ class ProgrammingLanguagePolicy < ApplicationPolicy
 
   def permitted_attributes
     if user&.zeus?
-      %i[name extension editor_name]
+      %i[name extension editor_name icon]
     else
       []
     end

--- a/app/views/programming_languages/_form.html.erb
+++ b/app/views/programming_languages/_form.html.erb
@@ -23,4 +23,18 @@
     <%= f.label :extension, :class => "col-sm-3 control-label" %>
     <div class="col-sm-4"><%= f.text_field :extension, class: "form-control" %></div>
   </div>
+
+  <div class="field form-group">
+    <%= f.label :icon, :class => "col-sm-3 control-label" %>
+    <div class="col-sm-4"><%= f.text_field :icon, class: "form-control" %></div>
+    <div class="control-icon">
+      <i id="icon-preview" class="mdi mdi-<%= f.object.icon %> icon"></i>
+    </div>
+  </div>
 <% end %>
+
+<script>
+  document.getElementById("programming_language_icon").addEventListener('input', (e) => {
+      document.getElementById("icon-preview").classList = `mdi icon mdi-${e.target.value}`;
+  })
+</script>

--- a/app/views/programming_languages/index.html.erb
+++ b/app/views/programming_languages/index.html.erb
@@ -13,9 +13,10 @@
       </div>
       <div class="card-supporting-text">
         <div class="table-scroll-wrapper">
-          <table class="table table-index table-resource">
+          <table class="table table-index table-resource language-table">
             <thead>
             <tr>
+              <th class='type-icon'></th>
               <th>
                 <%= ProgrammingLanguage.human_attribute_name("name") %>
               </th>
@@ -36,6 +37,9 @@
             <tbody>
             <% @programming_languages.each do |programming_language| %>
               <tr>
+                <td class='type-icon'>
+                  <i class="<%= "mdi mdi-#{programming_language.icon} mdi-18" %>"></i>
+                </td>
                 <td>
                   <%= link_to programming_language.name, programming_language %>
                 </td>

--- a/app/views/programming_languages/show.html.erb
+++ b/app/views/programming_languages/show.html.erb
@@ -2,7 +2,7 @@
   <div class="col-sm-10 col-sm-offset-1 col-xs-12">
     <div class="card">
       <div class="card-title card-title-colored">
-        <h2 class="card-title-text"><%= @programming_language.name %></h2>
+        <h2 class="card-title-text"><i class="mdi mdi-<%= @programming_language.icon %> icon title-icon"></i><%= @programming_language.name %></h2>
         <% if policy(@programming_language).edit? %>
           <div class="card-title-fab">
             <%= render 'application/fab_link', url: edit_programming_language_path(@programming_language), icon: 'pencil' %>

--- a/app/views/programming_languages/show.html.erb
+++ b/app/views/programming_languages/show.html.erb
@@ -2,12 +2,10 @@
   <div class="col-sm-10 col-sm-offset-1 col-xs-12">
     <div class="card">
       <div class="card-title card-title-colored">
-        <h2 class="card-title-text"><i class="mdi mdi-<%= @programming_language.icon %> icon title-icon"></i><%= @programming_language.name %></h2>
-        <% if policy(@programming_language).edit? %>
-          <div class="card-title-fab">
-            <%= render 'application/fab_link', url: edit_programming_language_path(@programming_language), icon: 'pencil' %>
-          </div>
-        <% end %>
+        <h2 class='card-title-text pull-right'>
+          <i class="mdi mdi-<%= @programming_language.icon %> icon"></i>
+        </h2>
+        <h2 class="card-title-text"><%= @programming_language.name %></h2>
       </div>
       <div class="card-supporting-text">
         <p>
@@ -23,6 +21,11 @@
           <%= @programming_language.extension %>
         </p>
       </div>
+      <% if policy(@programming_language).edit? %>
+        <div class="card-actions card-border">
+          <%= button_to t('programming_languages.edit.title'), edit_programming_language_path(@programming_language), method: :get, class: 'btn-text' %>
+        </div>
+      <% end %>
     </div>
   </div>
 </div>


### PR DESCRIPTION
This pull request:
- Adds the programming language icon to the list of programming languages.
- Adds the icon to the info page
- Makes the icon editable in the UI. I've included a bit of js to create a live preview of the icon as you type. 

![list](https://user-images.githubusercontent.com/1756811/93352011-ac41b380-f83a-11ea-9d94-704587001905.png)
![image](https://user-images.githubusercontent.com/1756811/93485630-8df3ba80-f903-11ea-9413-578f6f7c4661.png)
![edit](https://user-images.githubusercontent.com/1756811/93352036-b2379480-f83a-11ea-8c04-1585cf82876a.png)


Closes #2242.
