### PR TITLE
Prompt when logging in from LTI

### DIFF
--- a/app/controllers/concerns/set_lti_message.rb
+++ b/app/controllers/concerns/set_lti_message.rb
@@ -1,0 +1,18 @@
+require_relative '../../../lib/LTI/jwk.rb'
+require_relative '../../../lib/LTI/messages.rb'
+
+module SetLtiMessage
+  extend ActiveSupport::Concern
+
+  include LTI::JWK
+  include LTI::Messages
+
+  def set_lti_message
+    @lti_message = parse_message(params[:id_token], params[:provider_id])
+    @lti_launch = @lti_message.is_a?(LTI::Messages::Types::ResourceLaunchRequest)
+  end
+
+  def set_lti_provider
+    @provider = Provider::Lti.find(params[:provider_id]) if params[:provider_id].present?
+  end
+end

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -1,5 +1,9 @@
 class CoursesController < ApplicationController
+  include SetLtiMessage
+
   before_action :set_course_and_current_membership, except: %i[index new create]
+  before_action :set_lti_message, only: %i[show]
+  before_action :set_lti_provider, only: %i[show]
 
   has_scope :by_filter, as: 'filter'
   has_scope :by_institution, as: 'institution_id'
@@ -233,7 +237,7 @@ class CoursesController < ApplicationController
 
   def subscribe
     redirect_unless_secret_correct if @course.secret_required?(current_user)
-    return if performed? # return if redirect happenned
+    return if performed? # return if redirect happened
 
     respond_to do |format|
       if current_user.member_of? @course
@@ -392,7 +396,7 @@ class CoursesController < ApplicationController
   end
 
   def subscription_succeeded_response(format)
-    format.html { redirect_to @course, notice: I18n.t('courses.registration.subscribed_successfully') }
+    format.html { redirect_back(fallback_location: @course, notice: I18n.t('courses.registration.subscribed_successfully')) }
     format.json { render :show, status: :created, location: @course }
   end
 

--- a/app/controllers/lti_controller.rb
+++ b/app/controllers/lti_controller.rb
@@ -1,10 +1,5 @@
-require_relative '../../lib/LTI/jwk.rb'
-require_relative '../../lib/LTI/messages.rb'
-
 class LtiController < ApplicationController
-  include LtiHelper
-  include LTI::JWK
-  include LTI::Messages
+  include SetLtiMessage
 
   before_action :set_lti_message, only: %i[content_selection]
   before_action :set_lti_provider, only: %i[content_selection]
@@ -59,22 +54,12 @@ class LtiController < ApplicationController
 
     # Build a new response message.
     response = LTI::Messages::Types::DeepLinkingResponse.new(@lti_message)
-    response.items += lti_resource_links_from(params)
+    response.items += helpers.lti_resource_links_from(params)
 
     render json: { payload: encode_and_sign(response) }
   end
 
   def jwks
     render json: { keys: keyset }
-  end
-
-  private
-
-  def set_lti_message
-    @lti_message = parse_message(params[:id_token], params[:provider_id])
-  end
-
-  def set_lti_provider
-    @provider = Provider::Lti.find(params[:provider_id])
   end
 end

--- a/app/controllers/series_controller.rb
+++ b/app/controllers/series_controller.rb
@@ -1,9 +1,11 @@
 class SeriesController < ApplicationController
   include ExportHelper
+  include SetLtiMessage
 
   before_action :set_series, except: %i[index new create indianio_download]
-
   before_action :check_token, only: %i[show overview]
+  before_action :set_lti_message, only: %i[show]
+  before_action :set_lti_provider, only: %i[show]
 
   has_scope :at_least_one_started, type: :boolean, only: :scoresheet do |controller, scope|
     scope.at_least_one_started_in_series(Series.find(controller.params[:id]))
@@ -30,6 +32,7 @@ class SeriesController < ApplicationController
   # GET /series/1.json
   def show
     @course = @series.course
+    @current_membership = CourseMembership.where(course: @course, user: current_user).first
     @title = @series.name
     @crumbs = [[@course.name, course_path(@course)], [@series.name, '#']]
     @user = User.find(params[:user_id]) if params[:user_id] && current_user&.course_admin?(@course)

--- a/app/helpers/lti_helper.rb
+++ b/app/helpers/lti_helper.rb
@@ -1,6 +1,9 @@
 require_relative '../../lib/LTI/messages.rb'
 
 module LtiHelper
+  include LTI::JWK
+  include LTI::Messages
+
   def lti_resource_links_from(params)
     activity_ids = params[:lti][:activities] || []
     series_id = params[:lti][:series]

--- a/app/helpers/lti_helper.rb
+++ b/app/helpers/lti_helper.rb
@@ -1,9 +1,6 @@
 require_relative '../../lib/LTI/messages.rb'
 
 module LtiHelper
-  include LTI::JWK
-  include LTI::Messages
-
   def lti_resource_links_from(params)
     activity_ids = params[:lti][:activities] || []
     series_id = params[:lti][:series]

--- a/app/views/activities/show.html.erb
+++ b/app/views/activities/show.html.erb
@@ -7,6 +7,10 @@
 <% end %>
 <%= render 'navbar_links' %>
 
+<% if @not_registered && @lti_launch %>
+  <%= render 'courses/not_a_member_dialog' %>
+<% end %>
+
 <% if @series.present?
   previous_activity, next_activity = previous_next_activity_path(@series, @activity)
   previous_link = previous_activity || breadcrumb_series_path(@series, current_user)

--- a/app/views/courses/_not_a_member_dialog.html.erb
+++ b/app/views/courses/_not_a_member_dialog.html.erb
@@ -6,17 +6,10 @@
         <h4 class="modal-title"><%= t 'courses.registration.lti_title' %></h4>
       </div>
       <div class="modal-body">
-        <div class="row">
-          <div class="col-md-2">
-            <%= image_tag "idp/#{@provider.institution.logo}", class: "img-responsive" %>
-          </div>
-          <div class="col-md-10">
-            <p><%= t('courses.registration.lti', lms: @lti_message.platform_name || t('courses.registration.lms_default')) %></p>
-            <% if @course.moderated %>
-              <p><%= t 'courses.registration.moderated' %></p>
-            <% end %>
-          </div>
-        </div>
+        <p><%= t('courses.registration.lti', lms: @lti_message.platform_name || t('courses.registration.lms_default')) %></p>
+        <% if @course.moderated %>
+          <p><%= t 'courses.registration.moderated' %></p>
+        <% end %>
       </div>
       <div class="modal-footer">
         <% if @course.closed? %>

--- a/app/views/courses/_not_a_member_dialog.html.erb
+++ b/app/views/courses/_not_a_member_dialog.html.erb
@@ -1,0 +1,39 @@
+<div class="modal fade" tabindex="-1" role="dialog" id="ltiModal" data-backdrop="static">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+        <h4 class="modal-title"><%= t 'courses.registration.lti_title' %></h4>
+      </div>
+      <div class="modal-body">
+        <div class="row">
+          <div class="col-md-2">
+            <%= image_tag "idp/#{@provider.institution.logo}", class: "img-responsive" %>
+          </div>
+          <div class="col-md-10">
+            <p><%= t('courses.registration.lti', lms: @lti_message.platform_name || t('courses.registration.lms_default')) %></p>
+            <% if @course.moderated %>
+              <p><%= t 'courses.registration.moderated' %></p>
+            <% end %>
+          </div>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <% if @course.closed? %>
+          <%= t 'courses.registration.closed' %>
+        <% else %>
+          <% if @current_membership&.pending? %>
+            <%= t 'courses.registration.pending' %>
+          <% else %>
+            <%= registration_action_for course: @course, membership: @current_membership, secret: (@course.secret if @course.secret_required?(current_user)) %>
+          <% end %>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>
+<script type="text/javascript">
+    $(window).on('load',function(){
+        $('#ltiModal').modal('show');
+    });
+</script>

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -38,6 +38,9 @@
           </div>
           <% if current_user&.member_of?(@course).! %>
             <%= render partial: 'not_a_member_card' %>
+            <% if @lti_launch %>
+              <%= render partial: 'not_a_member_dialog' %>
+            <% end %>
           <% end %>
         </div>
       <% end %>

--- a/app/views/series/show.html.erb
+++ b/app/views/series/show.html.erb
@@ -1,3 +1,7 @@
+<% if !current_user&.member_of?(@course) && @lti_launch %>
+  <%= render 'courses/not_a_member_dialog' %>
+<% end %>
+
 <div class="row">
   <div class="col-sm-10 col-sm-offset-1 col-xs-12">
     <h2><%= @series.course.name %></h2><br>

--- a/config/locales/views/courses/en.yml
+++ b/config/locales/views/courses/en.yml
@@ -144,6 +144,9 @@ en:
       not_logged_in: You need to be logged in to register
       key_mismatch: "The key didn't match"
       registration_closed: "Registration closed."
+      lti_title: Welkom
+      lti: "We've noticed you followed a link from %{lms}, but you're not registered for this course yet. Click on register to enable the course administrator to follow your progress."
+      lms_default: "another learning environment"
     favorite:
       succeeded: "Course favorited"
       failed: "Failed favoriting course"

--- a/config/locales/views/courses/en.yml
+++ b/config/locales/views/courses/en.yml
@@ -144,7 +144,7 @@ en:
       not_logged_in: You need to be logged in to register
       key_mismatch: "The key didn't match"
       registration_closed: "Registration closed."
-      lti_title: Welkom
+      lti_title: Welcome
       lti: "We've noticed you followed a link from %{lms}, but you're not registered for this course yet. Click on register to enable the course administrator to follow your progress."
       lms_default: "another learning environment"
     favorite:

--- a/config/locales/views/courses/en.yml
+++ b/config/locales/views/courses/en.yml
@@ -144,8 +144,8 @@ en:
       not_logged_in: You need to be logged in to register
       key_mismatch: "The key didn't match"
       registration_closed: "Registration closed."
-      lti_title: Welcome
-      lti: "We've noticed you followed a link from %{lms}, but you're not registered for this course yet. Click on register to enable the course administrator to follow your progress."
+      lti_title: Welcome to Dodona!
+      lti: "You followed a link from %{lms} to this page. To correctly store your submissions, you should register for this course on Dodona. You can do this easily by clicking the "register" button below, or later from the course page."
       lms_default: "another learning environment"
     favorite:
       succeeded: "Course favorited"

--- a/config/locales/views/courses/en.yml
+++ b/config/locales/views/courses/en.yml
@@ -145,7 +145,7 @@ en:
       key_mismatch: "The key didn't match"
       registration_closed: "Registration closed."
       lti_title: Welcome to Dodona!
-      lti: "You followed a link from %{lms} to this page. To correctly store your submissions, you should register for this course on Dodona. You can do this easily by clicking the "register" button below, or later from the course page."
+      lti: You followed a link from %{lms} to this page. To correctly store your submissions, you should register for this course on Dodona. You can do this easily by clicking the "register" button below, or later from the course page.
       lms_default: "another learning environment"
     favorite:
       succeeded: "Course favorited"

--- a/config/locales/views/courses/nl.yml
+++ b/config/locales/views/courses/nl.yml
@@ -140,8 +140,8 @@ nl:
       not_logged_in: Je moet ingelogd zijn om je te registreren
       key_mismatch: De sleutel kwam niet overeen
       registration_closed: "Registratie gesloten."
-      lti_title: Welkom
-      lti: "We merken dat je een link volgde uit %{lms}, maar dat je nog niet bent ingeschreven voor deze cursus. Klik op registreren om dat wel te doen zodat de lesgever je kan opvolgen."
+      lti_title: Welkom op Dodona!
+      lti: "Je volgde een link uit %{lms} naar deze pagina. Om je ingediende oplossingen correct bij te houden is het nodig om je op Dodona te registreren voor deze cursus. Dat kan eenvoudig door hieronder op registreren te klikken, of later vanaf de cursuspagina."
       lms_default: "een andere leeromgeving"
     favorite:
       succeeded: "Cursus aan favorieten toegevoegd"

--- a/config/locales/views/courses/nl.yml
+++ b/config/locales/views/courses/nl.yml
@@ -140,6 +140,9 @@ nl:
       not_logged_in: Je moet ingelogd zijn om je te registreren
       key_mismatch: De sleutel kwam niet overeen
       registration_closed: "Registratie gesloten."
+      lti_title: Welkom
+      lti: "We merken dat je een link volgde uit %{lms}, maar dat je nog niet bent ingeschreven voor deze cursus. Klik op registreren om dat wel te doen zodat de lesgever je kan opvolgen."
+      lms_default: "een andere leeromgeving"
     favorite:
       succeeded: "Cursus aan favorieten toegevoegd"
       failed: "Cursus aan favorieten toevoegen mislukt"

--- a/lib/LTI/messages.rb
+++ b/lib/LTI/messages.rb
@@ -18,6 +18,8 @@ module LTI
       message_type = parsed_token[::LTI::Messages::Claims::MESSAGE_TYPE]
       if message_type == ::LTI::Messages::Types::DeepLinkingRequest::TYPE
         return ::LTI::Messages::Types::DeepLinkingRequest.new(parsed_token)
+      elsif message_type == ::LTI::Messages::Types::ResourceLaunchRequest::TYPE
+        return ::LTI::Messages::Types::ResourceLaunchRequest.new(parsed_token)
       end
 
       # Not implemented / invalid type.

--- a/lib/LTI/messages/claims.rb
+++ b/lib/LTI/messages/claims.rb
@@ -7,6 +7,7 @@ module LTI::Messages
     DEPLOYMENT_ID = 'https://purl.imsglobal.org/spec/lti/claim/deployment_id'.freeze
     RESOURCE_LINK = 'https://purl.imsglobal.org/spec/lti/claim/resource_link'.freeze
     LAUNCH_PRESENTATION = 'https://purl.imsglobal.org/spec/lti/claim/launch_presentation'.freeze
+    PLATFORM = 'https://purl.imsglobal.org/spec/lti/claim/tool_platform'.freeze
 
     # Deep Linking.
     DEEP_LINKING_CONTENT_ITEMS = 'https://purl.imsglobal.org/spec/lti-dl/claim/content_items'.freeze

--- a/lib/LTI/messages/types/resource_launch_request.rb
+++ b/lib/LTI/messages/types/resource_launch_request.rb
@@ -14,10 +14,17 @@ module LTI::Messages::Types
     # Claims in the launch presentation
     LAUNCH_PRESENTATION_LOCALE = 'locale'.freeze
 
-    attr_reader :resource_link_id
-    attr_reader :resource_link_description
-    attr_reader :resource_link_title
+    # Claims in the platform properties
+    PLATFORM_GUID = 'guid'.freeze
+    PLATFORM_CONTACT_EMAIL = 'contact_email'.freeze
+    PLATFORM_DESCRIPTION = 'description'.freeze
+    PLATFORM_NAME = 'name'.freeze
+    PLATFORM_URL = 'url'.freeze
+
+
+    attr_reader :resource_link_id, :resource_link_description, :resource_link_title
     attr_reader :launch_presentation_locale
+    attr_reader :platform_guid, :platform_contact_email, :platform_description, :platform_name, :platform_url
 
     def initialize(token_body)
       super(token_body)
@@ -27,6 +34,12 @@ module LTI::Messages::Types
       @resource_link_title = resource_link[RESOURCE_LINK_TITLE]
       launch_presentation = token_body[LTI::Messages::Claims::LAUNCH_PRESENTATION] || {}
       @launch_presentation_locale = launch_presentation[LAUNCH_PRESENTATION_LOCALE]
+      platform = token_body[LTI::Messages::Claims::PLATFORM] || {}
+      @platform_guid = platform[PLATFORM_GUID]
+      @platform_contact_email = platform[PLATFORM_CONTACT_EMAIL]
+      @platform_description = platform[PLATFORM_DESCRIPTION]
+      @platform_name = platform[PLATFORM_NAME]
+      @platform_url = platform[PLATFORM_URL]
     end
 
     def as_json(options = nil)
@@ -39,6 +52,13 @@ module LTI::Messages::Types
       lp = {}
       lp[LAUNCH_PRESENTATION_LOCALE] = launch_presentation_locale if launch_presentation_locale.present?
       base[LTI::Messages::Claims::LAUNCH_PRESENTATION] = lp if lp.present?
+      platform = {}
+      platform[PLATFORM_GUID] = platform_guid if platform_guid.present?
+      platform[PLATFORM_CONTACT_EMAIL] = platform_contact_email if platform_contact_email.present?
+      platform[PLATFORM_DESCRIPTION] = platform_description if platform_description.present?
+      platform[PLATFORM_NAME] = platform_name if platform_name.present?
+      platform[PLATFORM_URL] = platform_url if platform_url.present?
+      base[LTI::Messages::Claims::PLATFORM] = platform if platform.present?
       base
     end
   end


### PR DESCRIPTION
This pull request adds a prompt when logging in from LTI. Technically, opening a link via LTI is a `LtiResourceLinkRequest`, so we use that to detect LTI and extract some data (we use the name of the learning platform if available, otherwise "een andere leeromgeving").

The dialog is shown on:

- The course page (also when linking to series)
- The series page (e.g. a hidden series)
- The activity page

Currently the dialog looks like this:
![image](https://user-images.githubusercontent.com/1756811/93466759-fedba800-f8ec-11ea-8364-ab406b411e62.png)


Closes #2212.

Tasks:

- [x] Deploy & test on naos
