### PR TITLE
Fix webpacker warnings about deprecated config

### DIFF
--- a/config/initializers/webpacker.rb
+++ b/config/initializers/webpacker.rb
@@ -1,1 +1,0 @@
-Webpacker::Compiler.watched_paths << 'app/assets/javascripts'


### PR DESCRIPTION
The `additional_paths` option in webpacker.yml was already set correctly.
