### PR TITLE
Enable new rubocop cops by default

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,6 +13,7 @@ AllCops:
     - "vendor/**/*"
     - "node_modules/**/*"
   TargetRubyVersion: 2.7
+  NewCops: enable
 
 Layout/FirstArrayElementIndentation:
   EnforcedStyle: consistent

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -72,3 +72,5 @@ Style/MultilineBlockChain:
   Enabled: false
 Style/NumericPredicate:
   Enabled: false
+Style/OptionalBooleanParameter:
+  Enabled: false

--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -130,7 +130,7 @@ class ActivitiesController < ApplicationController
   end
 
   def read
-    @course = nil if @course.blank? || !@course.subscribed_members.include?(current_user)
+    @course = nil if @course.blank? || @course.subscribed_members.exclude?(current_user)
     read_state = ActivityReadState.new activity: @activity,
                                        course: @course,
                                        user: current_user

--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -51,7 +51,7 @@ class ActivitiesController < ApplicationController
 
     unless @activities.empty?
       @activities = apply_scopes(@activities)
-      @activities = @activities.order('name_' + I18n.locale.to_s).order(path: :asc).paginate(page: parse_pagination_param(params[:page]))
+      @activities = @activities.order("name_#{I18n.locale}").order(path: :asc).paginate(page: parse_pagination_param(params[:page]))
     end
     @labels = policy_scope(Label.all)
     @programming_languages = policy_scope(ProgrammingLanguage.all)
@@ -67,7 +67,7 @@ class ActivitiesController < ApplicationController
     @activities = policy_scope(Activity)
     @activities = @activities.or(Activity.where(repository: @course.usable_repositories))
     @activities = apply_scopes(@activities)
-    @activities = @activities.order('name_' + I18n.locale.to_s).order(path: :asc).paginate(page: parse_pagination_param(params[:page]))
+    @activities = @activities.order("name_#{I18n.locale}").order(path: :asc).paginate(page: parse_pagination_param(params[:page]))
   end
 
   def show

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -104,8 +104,10 @@ class ApplicationController < ActionController::Base
   def user_not_authorized
     if remote_request? || sandbox?
       if current_user.nil?
+        # rubocop:disable Rails/RenderInline
         render status: :unauthorized,
                inline: 'You are not authorized to view this page.'
+        # rubocop:enable Rails/RenderInline
       else
         head :forbidden
       end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -134,7 +134,7 @@ class ApplicationController < ActionController::Base
   end
 
   def trailing_slash?
-    request.env['REQUEST_URI'].match(/[^\?]+/).to_s.last == '/'
+    request.env['REQUEST_URI'].match(/[^?]+/).to_s.last == '/'
   end
 
   def store_current_location
@@ -153,7 +153,7 @@ class ApplicationController < ActionController::Base
     # Sessions are not needed for the JSON API
     skip_session
 
-    token.gsub!(/Token token=\"(.*)\"/, '\1')
+    token.gsub!(/Token token="(.*)"/, '\1')
     # only allow urlsafe base64 characters to pass
     token.gsub!(/[^A-Za-z0-9_\-]/, '')
 

--- a/app/controllers/auth/saml_controller.rb
+++ b/app/controllers/auth/saml_controller.rb
@@ -1,4 +1,4 @@
-require_relative '../../../lib/SAML/metadata.rb'
+require_relative '../../../lib/SAML/metadata'
 
 class Auth::SamlController < ApplicationController
   def metadata

--- a/app/controllers/concerns/set_lti_message.rb
+++ b/app/controllers/concerns/set_lti_message.rb
@@ -1,5 +1,5 @@
-require_relative '../../../lib/LTI/jwk.rb'
-require_relative '../../../lib/LTI/messages.rb'
+require_relative '../../../lib/LTI/jwk'
+require_relative '../../../lib/LTI/messages'
 
 module SetLtiMessage
   extend ActiveSupport::Concern

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -376,10 +376,7 @@ class CoursesController < ApplicationController
     membership = CourseMembership.where(user: user, course: @course).first
     return false unless membership
 
-    if membership.course_admin?
-      authorize @course, :update_course_admin_membership? unless user == current_user
-    end
-
+    authorize @course, :update_course_admin_membership? if membership.course_admin? && user != current_user
     authorize @course, :update_course_admin_membership? if status == 'course_admin'
 
     membership.update(status: status).tap do |success|

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -41,7 +41,7 @@ class SubmissionsController < ApplicationController
   end
 
   def show
-    @title = I18n.t('submissions.show.submission') + ' - ' + @submission.exercise.name
+    @title = "#{I18n.t('submissions.show.submission')} - #{@submission.exercise.name}"
     course = @submission.course
     @crumbs = if course.present?
                 [[course.name, course_path(course)], [@submission.exercise.name, course_activity_path(course, @submission.exercise)], [I18n.t('submissions.show.submission'), '#']]

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -57,9 +57,7 @@ class SubmissionsController < ApplicationController
     para[:code].gsub!(/\r\n?/, "\n")
     para[:evaluate] = true # immediately evaluate after create
     course = Course.find(para[:course_id]) if para[:course_id].present?
-    if para[:course_id].present?
-      para.delete(:course_id) unless course.subscribed_members.include?(current_user)
-    end
+    para.delete(:course_id) if para[:course_id].present? && course.subscribed_members.exclude?(current_user)
     submission = Submission.new(para)
     can_submit = true
     if submission.exercise.present?

--- a/app/helpers/activity_helper.rb
+++ b/app/helpers/activity_helper.rb
@@ -106,8 +106,7 @@ module ActivityHelper
     include ApplicationHelper
     include ActivityHelper
 
-    attr_reader :footnote_urls
-    attr_reader :first_image
+    attr_reader :footnote_urls, :first_image
 
     def initialize(activity, request)
       @activity = activity

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -92,7 +92,7 @@ module ApplicationHelper
     render partial: 'navbar_link', locals: locals
   end
 
-  def activatable_link_to(url, options = nil)
+  def activatable_link_to(url, options = nil, &block)
     if current_page?(url)
       options ||= {}
       if options[:class]
@@ -101,9 +101,7 @@ module ApplicationHelper
         options[:class] = 'active'
       end
     end
-    link_to url, options do
-      yield
-    end
+    link_to url, options, &block
   end
 
   def clipboard_button_for(selector)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -204,10 +204,6 @@ module ApplicationHelper
   end
 
   class AjaxLinkRenderer < ::WillPaginate::ActionView::LinkRenderer
-    def initialize
-      # @base_url_params.delete(:format)
-    end
-
     protected
 
     def html_container(html)

--- a/app/helpers/export_helper.rb
+++ b/app/helpers/export_helper.rb
@@ -19,14 +19,15 @@ module ExportHelper
       @options = get_options(kwargs[:options])
       @list = kwargs[:list]
       @users = kwargs[:users]
-      if @item.is_a?(Series)
+      case @item
+      when Series
         @list = @item.exercises if all?
         @users = @item.course.users if @users.nil?
-      elsif @item.is_a?(Course)
+      when Course
         @list = @item.series if all?
         @users = @item.users if @users.nil?
         initialize_series_per_exercise # depends on @list
-      elsif @item.is_a?(User)
+      when User
         @list = @item.courses if all?
         @users = [@item]
         initialize_series_per_exercise
@@ -212,11 +213,12 @@ module ExportHelper
     end
 
     def bundle
-      if @item.is_a?(Series)
+      case @item
+      when Series
         @options[:deadline] = @item.deadline || Time.current.tomorrow if deadline? # Prevent nil-deadline if series has no deadline
         submissions = get_submissions_for_series(@list, @users)
         exercises = @list
-      elsif @item.is_a?(Course)
+      when Course
         submissions = get_submissions_for_course(@list, @users)
         exercises = @list.map(&:exercises).flatten
       else # is User

--- a/app/helpers/lti_helper.rb
+++ b/app/helpers/lti_helper.rb
@@ -1,4 +1,4 @@
-require_relative '../../lib/LTI/messages.rb'
+require_relative '../../lib/LTI/messages'
 
 module LtiHelper
   def lti_resource_links_from(params)

--- a/app/helpers/renderers/feedback_table_renderer.rb
+++ b/app/helpers/renderers/feedback_table_renderer.rb
@@ -7,6 +7,7 @@ class FeedbackTableRenderer
   @renderers = [FeedbackTableRenderer]
 
   def self.inherited(cl)
+    super
     @renderers << cl
   end
 

--- a/app/helpers/renderers/feedback_table_renderer.rb
+++ b/app/helpers/renderers/feedback_table_renderer.rb
@@ -70,10 +70,10 @@ class FeedbackTableRenderer
           @builder.li(class: ('active' if i.zero?)) do
             id = "##{(t[:description] || 'test').parameterize}-#{i}"
             @builder.a(href: id, 'data-toggle': 'tab') do
-              @builder.text!((t[:description] || 'Test').upcase_first + ' ')
+              @builder.text!("#{(t[:description] || 'Test').upcase_first} ")
               # Choose between the pythonic devil and the deep blue sea.
               badge_id = t[:data] && t[:data][:source_annotations] ? 'code' : id
-              @builder.span(class: 'badge', id: 'badge_' + badge_id) do
+              @builder.span(class: 'badge', id: "badge_#{badge_id}") do
                 @builder.text! tab_count(t)
               end
             end
@@ -82,7 +82,7 @@ class FeedbackTableRenderer
         if show_code_tab
           @builder.li(class: ('active' if submission[:groups].blank?)) do
             @builder.a(href: '#code-tab', 'data-toggle': 'tab') do
-              @builder.text!(I18n.t('submissions.show.code') + ' ')
+              @builder.text!("#{I18n.t('submissions.show.code')} ")
               @builder.span(class: 'badge', id: 'badge_code')
             end
           end
@@ -317,7 +317,7 @@ class FeedbackTableRenderer
   end
 
   def determine_diff_type(test)
-    output = (test[:expected].to_s || '') + "\n" + (test[:generated].to_s || '')
+    output = "#{(test[:expected].to_s || '')}\n#{(test[:generated].to_s || '')}"
     if output.split("\n", -1).map(&:length).max < 55
       'split'
     else

--- a/app/helpers/renderers/feedback_table_renderer.rb
+++ b/app/helpers/renderers/feedback_table_renderer.rb
@@ -222,9 +222,10 @@ class FeedbackTableRenderer
     @builder.div(class: 'messages') do
       msgs.each do |msg|
         permission = msg.is_a?(Hash) && msg.key?(:permission) ? msg[:permission] : 'student'
-        tooltip = if permission == 'zeus'
+        tooltip = case permission
+                  when 'zeus'
                     I18n.t('submissions.show.message_zeus')
-                  elsif permission == 'staff'
+                  when 'staff'
                     I18n.t('submissions.show.message_staff')
                   else
                     ''

--- a/app/helpers/renderers/pythia_renderer.rb
+++ b/app/helpers/renderers/pythia_renderer.rb
@@ -1,10 +1,6 @@
 class PythiaRenderer < FeedbackTableRenderer
   include ActionView::Helpers::JavaScriptHelper
 
-  def initialize(submission, user)
-    super(submission, user)
-  end
-
   def parse
     tutor_init
     super

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -109,7 +109,7 @@ class Activity < ApplicationRecord
   end
 
   def name
-    first_string_present send('name_' + I18n.locale.to_s),
+    first_string_present send("name_#{I18n.locale}"),
                          name_nl,
                          name_en,
                          path&.split('/')&.last
@@ -178,7 +178,7 @@ class Activity < ApplicationRecord
   end
 
   def merged_dirconfig
-    Pathname.new('./' + path).parent.descend # all parent directories
+    Pathname.new("./#{path}").parent.descend # all parent directories
             .map { |dir| read_dirconfig dir } # try reading their dirconfigs
             .compact # remove nil entries
             .reduce { |h1, h2| deep_merge_configs h1, h2 } # reduce into single hash
@@ -186,7 +186,7 @@ class Activity < ApplicationRecord
   end
 
   def merged_dirconfig_locations
-    Pathname.new('./' + path).parent.descend # all parent directories
+    Pathname.new("./#{path}").parent.descend # all parent directories
             .map { |dir| read_dirconfig_locations dir } # try reading their dirconfigs
             .compact # remove nil entries
             .reduce { |h1, h2| deep_merge_configs h1, h2 } # reduce into single hash
@@ -339,7 +339,7 @@ class Activity < ApplicationRecord
   end
 
   def self.determine_format(full_exercise_path)
-    if !Dir.glob(full_exercise_path + DESCRIPTION_DIR + 'description.*.html').empty?
+    if !Dir.glob(full_exercise_path.join(DESCRIPTION_DIR, 'description.*.html')).empty?
       'html'
     else
       'md'

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -59,12 +59,12 @@ class Activity < ApplicationRecord
   token_generator :repository_token, length: 64
   token_generator :access_token
 
+  before_save :check_validity
+  before_save :generate_access_token, if: :access_changed?
   before_create :generate_id
   before_create :generate_repository_token,
                 if: ->(ex) { ex.repository_token.nil? }
   before_create :generate_access_token
-  before_save :check_validity
-  before_save :generate_access_token, if: :access_changed?
   before_update :update_config
 
   scope :content_pages, -> { where(type: ContentPage.name) }

--- a/app/models/activity_status.rb
+++ b/app/models/activity_status.rb
@@ -36,10 +36,9 @@ class ActivityStatus < ApplicationRecord
   scope :in_series, ->(series) { where(series: series) }
   scope :for_user, ->(user) { where(user: user) }
 
+  before_validation :initialise_series_id_non_nil, if: -> { new_record? }
   before_create :initialise_values_for_content_page, if: -> { activity.content_page? }
   before_create :initialise_values_for_exercise, if: -> { activity.exercise? }
-
-  before_validation :initialise_series_id_non_nil, if: -> { new_record? }
 
   def best_is_last?
     accepted == solved

--- a/app/models/annotation.rb
+++ b/app/models/annotation.rb
@@ -30,8 +30,8 @@ class Annotation < ApplicationRecord
   scope :by_user, ->(user_id) { where(user_id: user_id) }
   scope :released, -> { where(evaluation_id: nil).or(where(evaluations: { released: true })) }
 
-  after_save :create_notification
   after_destroy :destroy_notification
+  after_save :create_notification
 
   private
 

--- a/app/models/concerns/gitable.rb
+++ b/app/models/concerns/gitable.rb
@@ -37,6 +37,6 @@ module Gitable
   end
 
   def github_remote?
-    remote =~ %r{^(git@)|(https:\/\/)(github|gitlab)}
+    remote =~ %r{^(git@)|(https://)(github|gitlab)}
   end
 end

--- a/app/models/concerns/tokenable.rb
+++ b/app/models/concerns/tokenable.rb
@@ -19,7 +19,7 @@ module Tokenable
                                   .tr('1lL0oO', '')
                                   .slice(0, length)
         end until (new_token.length == length) && \
-          !(unique && self.class.where(token_name => new_token).exists?)
+          !(unique && self.class.exists?(token_name => new_token))
         self[token_name] = new_token
       end
     end

--- a/app/models/course_membership.rb
+++ b/app/models/course_membership.rb
@@ -24,9 +24,9 @@ class CourseMembership < ApplicationRecord
   validate :at_least_one_admin_per_course
 
   before_create { self.status ||= :student }
+  after_destroy :invalidate_caches
   after_save :invalidate_caches
   after_save :delete_unused_course_labels
-  after_destroy :invalidate_caches
 
   scope :by_institution, ->(institution) { where(user: User.by_institution(institution)) }
   scope :by_permission, ->(permission) { where(user: User.by_permission(permission)) }

--- a/app/models/evaluation.rb
+++ b/app/models/evaluation.rb
@@ -24,8 +24,8 @@ class Evaluation < ApplicationRecord
   validate :deadline_in_past
 
   before_save :manage_feedbacks
-  after_save :manage_user_notifications
   before_destroy :destroy_notification
+  after_save :manage_user_notifications
 
   def users=(new_users)
     removed = users - new_users

--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -22,10 +22,10 @@ class Feedback < ApplicationRecord
   delegate :user, to: :evaluation_user
   delegate :exercise, to: :evaluation_exercise
 
+  before_save :manage_annotations_after_submission_update
   before_create :generate_id
   before_create :determine_submission
   before_destroy :destroy_related_annotations
-  before_save :manage_annotations_after_submission_update
 
   validate :submission_user_exercise_correct
 

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -78,9 +78,11 @@ class Repository < ApplicationRecord
                'Dodona <dodona@ugent.be>'
              end
     _out, error, status = Open3.capture3('git', 'commit', "--author=\"#{author}\"", '-am', "#{msg}\n\nThis commit was created automatically by Dodona.", chdir: full_path.to_path)
+    # rubocop:disable Style/SoleNestedConditional
     if Rails.env.production?
       _out, error, status = Open3.capture3('git push', chdir: full_path.to_path) if status.success?
     end
+    # rubocop:enable Style/SoleNestedConditional
     [status.success?, error]
   end
 

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -140,7 +140,7 @@ class Repository < ApplicationRecord
 
     repository_activities = Activity.where(repository_id: id)
     repository_activities.reject { |a| handled_activity_ids.include? a.id }.each do |act|
-      if dirs.include?(act.full_path) && !handled_directories.include?(act.full_path)
+      if dirs.include?(act.full_path) && handled_directories.exclude?(act.full_path)
         handled_directories.push act.full_path
         if activity_dirs_and_configs.select { |d, _| d == act.full_path }.first.nil?
           act.update(status: :not_valid)

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -117,8 +117,7 @@ class Repository < ApplicationRecord
                           .map { |d, c| [d, Activity.find_by(repository_token: c['internals']['token'], repository_id: id)] }
                           .reject { |_, e| e.nil? }
                           .group_by { |_, e| e }
-                          .map { |e, l| [e, l.map { |elem| elem[0] }] }
-                          .to_h
+                          .transform_values { |l| l.map { |elem| elem[0] } }
     handled_directories = []
     handled_activity_ids = []
     new_activities = []

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -44,8 +44,8 @@ class Series < ApplicationRecord
   token_generator :access_token, length: 5
   token_generator :indianio_token
 
-  before_create :generate_access_token
   before_save :regenerate_activity_tokens, if: :visibility_changed?
+  before_create :generate_access_token
   after_save :invalidate_activity_statuses, if: :saved_change_to_deadline?
 
   scope :visible, -> { where(visibility: :open) }

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -156,11 +156,11 @@ class Submission < ApplicationRecord
 
   def clear_fs
     # If we were destroyed or if we were never saved to the database, delete this submission's directory
-    # rubocop:disable Style/GuardClause
+    # rubocop:disable Style/GuardClause, Style/SoleNestedConditional
     if destroyed? || new_record?
       FileUtils.remove_entry_secure(fs_path) if File.exist?(fs_path)
     end
-    # rubocop:enable Style/GuardClause
+    # rubocop:enable Style/GuardClause, Style/SoleNestedConditional
   end
 
   def on_filesystem?

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -180,9 +180,10 @@ class Submission < ApplicationRecord
   end
 
   def evaluate_delayed(priority = :normal)
-    queue = if priority == :high
+    queue = case priority
+            when :high
               'high_priority_submissions'
-            elsif priority == :low
+            when :low
               'low_priority_submissions'
             else
               'submissions'

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -38,13 +38,13 @@ class Submission < ApplicationRecord
   validate :maximum_code_length, on: :create
   validate :not_rate_limited?, on: :create, unless: :skip_rate_limit_check?
 
-  before_update :update_fs
   before_save :report_if_internal_error
   after_create :evaluate_delayed, if: :evaluate?
-  after_save :update_exercise_status
-  after_save :invalidate_caches
+  before_update :update_fs
   after_destroy :invalidate_caches
   after_destroy :clear_fs
+  after_save :update_exercise_status
+  after_save :invalidate_caches
   after_rollback :clear_fs
 
   default_scope { order(id: :desc) }

--- a/app/models/transient/aggregated_config_errors.rb
+++ b/app/models/transient/aggregated_config_errors.rb
@@ -5,6 +5,7 @@ class AggregatedConfigErrors < StandardError
               :errors
 
   def initialize(repository, errors)
+    super()
     @repository = repository
     @errors = errors.uniq(&:path)
   end

--- a/app/models/transient/config_parse_error.rb
+++ b/app/models/transient/config_parse_error.rb
@@ -5,6 +5,7 @@ class ConfigParseError < StandardError
               :json
 
   def initialize(repository, path, parse_error)
+    super()
     @repository = repository
     @path = path
     # ew.

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -114,9 +114,9 @@ class User < ApplicationRecord
   before_save :set_token
   before_save :set_time_zone
   before_save :split_last_name, unless: :first_name?, if: :last_name?
-  before_update :check_permission_change
   before_save :nullify_empty_username
   before_save :nullify_empty_email
+  before_update :check_permission_change
 
   accepts_nested_attributes_for :identities, limit: 1
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -137,7 +137,7 @@ class User < ApplicationRecord
   end
 
   def full_name
-    name = (first_name || '') + ' ' + (last_name || '')
+    name = "#{(first_name || '')} #{(last_name || '')}"
     first_string_present name, 'n/a'
   end
 

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -11,7 +11,7 @@ class ApplicationPolicy
   end
 
   def show?
-    scope.where(id: record.id).exists?
+    scope.exists?(id: record.id)
   end
 
   def create?

--- a/app/runners/result_constructor.rb
+++ b/app/runners/result_constructor.rb
@@ -5,6 +5,7 @@ class ResultConstructorError < StandardError
   attr_accessor :title, :description
 
   def initialize(title, description = nil)
+    super()
     @title = title
     @description = description
   end

--- a/test/controllers/activities_controller_test.rb
+++ b/test/controllers/activities_controller_test.rb
@@ -370,7 +370,7 @@ class ActivitiesControllerTest < ActionDispatch::IntegrationTest
     @instance = create(:exercise, :description_html)
     Exercise.any_instance.stubs(:media_path).returns(Pathname.new('public'))
 
-    get(activity_url(@instance) + '/media/robots.txt')
+    get("#{activity_url(@instance)}/media/robots.txt")
 
     assert_response :success
     assert_equal response.content_type, 'text/plain; charset=utf-8'
@@ -471,7 +471,7 @@ class ActivitiesPermissionControllerTest < ActionDispatch::IntegrationTest
     @instance = create(:exercise, :description_html)
     Exercise.any_instance.stubs(:media_path).returns(Pathname.new('public'))
 
-    get(activity_url(@instance) + '/media/icon.png')
+    get("#{activity_url(@instance)}/media/icon.png")
 
     assert_response :success
     assert_equal response.content_type, 'image/png'
@@ -483,7 +483,7 @@ class ActivitiesPermissionControllerTest < ActionDispatch::IntegrationTest
     create :submission, exercise: @instance, user: @user
     Exercise.any_instance.stubs(:media_path).returns(Pathname.new('public'))
 
-    get(activity_url(@instance) + '/media/icon.png')
+    get("#{activity_url(@instance)}/media/icon.png")
 
     assert_response :success
     assert_equal response.content_type, 'image/png'
@@ -500,7 +500,7 @@ class ActivitiesPermissionControllerTest < ActionDispatch::IntegrationTest
     get course_series_activity_url(series.course, series, @instance)
     assert_response :success, 'should have access to activity'
 
-    get(course_series_activity_url(series.course, series, @instance) + 'media/icon.png')
+    get("#{course_series_activity_url(series.course, series, @instance)}media/icon.png")
 
     assert_response :success, 'should have access to activity media'
     assert_equal response.content_type, 'image/png'
@@ -511,7 +511,7 @@ class ActivitiesPermissionControllerTest < ActionDispatch::IntegrationTest
     Exercise.any_instance.stubs(:ok?).returns(false)
     Exercise.any_instance.stubs(:media_path).returns(Pathname.new('public'))
 
-    get(activity_url(@instance) + 'media/icon.png')
+    get("#{activity_url(@instance)}media/icon.png")
 
     assert_redirected_to root_url
   end
@@ -521,7 +521,7 @@ class ActivitiesPermissionControllerTest < ActionDispatch::IntegrationTest
     Exercise.any_instance.stubs(:ok?).returns(false)
     Exercise.any_instance.stubs(:media_path).returns(Pathname.new('public'))
     sign_out @user
-    get(activity_url(@instance) + 'media/icon.png')
+    get("#{activity_url(@instance)}media/icon.png")
 
     assert_redirected_to sign_in_url
   end
@@ -529,7 +529,7 @@ class ActivitiesPermissionControllerTest < ActionDispatch::IntegrationTest
   test 'should not have access to activity media when user has no access to private activity' do
     @instance = create(:exercise, :description_html, access: :private)
     Exercise.any_instance.stubs(:media_path).returns(Pathname.new('public'))
-    get(activity_url(@instance) + 'media/icon.png')
+    get("#{activity_url(@instance)}media/icon.png")
 
     assert_redirected_to root_url
   end

--- a/test/controllers/application_controller_test.rb
+++ b/test/controllers/application_controller_test.rb
@@ -13,7 +13,7 @@ class ApplicationControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should not store last location if too big' do
-    location = root_path params: { foo: 'b' + ('a' * 1024) + 'r' }
+    location = root_path params: { foo: "b#{('a' * 1024)}r" }
     get location
     assert_response :success
     assert_not_equal session[:user_return_to], location

--- a/test/controllers/exports_controller_test.rb
+++ b/test/controllers/exports_controller_test.rb
@@ -63,7 +63,7 @@ class ExportsControllerTest < ActionDispatch::IntegrationTest
         subs = [1] if subs.empty?
         subs
       end
-    end .flatten.length
+    end.flatten.length
 
     post series_exports_path(@series), params: { all: true, all_students: true }
     assert_redirected_to exports_path
@@ -93,7 +93,7 @@ class ExportsControllerTest < ActionDispatch::IntegrationTest
         subs = [1] if subs.empty?
         subs
       end
-    end .flatten.length
+    end.flatten.length
     assert_zip ActiveStorage::Blob.last.download, solution_count: zip_submission_count, data: @data
   end
 
@@ -112,7 +112,7 @@ class ExportsControllerTest < ActionDispatch::IntegrationTest
       sample_exercises.map do |ex|
         ex.submissions.of_user(u).in_course(@series.course).before_deadline(@series.deadline).limit(1).first
       end
-    end .flatten.length
+    end.flatten.length
     post series_exports_path(@series), params: options
     assert_zip ActiveStorage::Blob.last.download, options
   end
@@ -158,9 +158,9 @@ class ExportsControllerTest < ActionDispatch::IntegrationTest
       @course.users.map do |user|
         series.exercises.map do |exercise|
           [exercise.submissions.of_user(user).in_course(@course).count, 1].max
-        end .sum
-      end .sum
-    end .sum
+        end.sum
+      end.sum
+    end.sum
     post courses_exports_path(@course), params: options
     options[:group_by] = 'series'
     assert_zip ActiveStorage::Blob.last.download, options

--- a/test/factories/content_pages.rb
+++ b/test/factories/content_pages.rb
@@ -23,7 +23,7 @@
 #  type                    :string(255)      default("Exercise"), not null
 #
 
-require File.dirname(__FILE__) + '/../testhelpers/stub_helper.rb'
+require "#{File.dirname(__FILE__)}/../testhelpers/stub_helper.rb"
 using StubHelper
 
 FactoryBot.define do

--- a/test/factories/exercises.rb
+++ b/test/factories/exercises.rb
@@ -23,7 +23,7 @@
 #  type                    :string(255)      default("Exercise"), not null
 #
 
-require File.dirname(__FILE__) + '/../testhelpers/stub_helper.rb'
+require "#{File.dirname(__FILE__)}/../testhelpers/stub_helper.rb"
 using StubHelper
 
 FactoryBot.define do

--- a/test/factories/judges.rb
+++ b/test/factories/judges.rb
@@ -12,7 +12,7 @@
 #  remote     :string(255)
 #
 
-require File.dirname(__FILE__) + '/../testhelpers/stub_helper.rb'
+require "#{File.dirname(__FILE__)}/../testhelpers/stub_helper.rb"
 using StubHelper
 
 FactoryBot.define do

--- a/test/factories/providers.rb
+++ b/test/factories/providers.rb
@@ -43,8 +43,8 @@ FactoryBot.define do
     institution
 
     entity_id { Faker::Internet.url }
-    sso_url { entity_id + '/SSO' }
-    slo_url { entity_id + '/SLO' }
+    sso_url { "#{entity_id}/SSO" }
+    slo_url { "#{entity_id}/SLO" }
     certificate { Faker::Crypto.sha256 }
   end
 

--- a/test/factories/repositories.rb
+++ b/test/factories/repositories.rb
@@ -11,7 +11,7 @@
 #  updated_at :datetime         not null
 #
 
-require File.dirname(__FILE__) + '/../testhelpers/stub_helper.rb'
+require "#{File.dirname(__FILE__)}/../testhelpers/stub_helper.rb"
 using StubHelper
 
 FactoryBot.define do

--- a/test/models/exercise_test.rb
+++ b/test/models/exercise_test.rb
@@ -609,11 +609,11 @@ class ExerciseRemoteTest < ActiveSupport::TestCase
   end
 
   test 'dirconfig_file? should return true if the basename is "dirconfig.json"' do
-    assert Exercise.dirconfig_file?(@exercise.full_path + '/dirconfig.json')
+    assert Exercise.dirconfig_file?(@exercise.full_path.join('dirconfig.json'))
   end
 
   test 'dirconfig_file? should return false if the basename is not "dirconfig.json"' do
-    assert_not Exercise.dirconfig_file?(@exercise.full_path + '/otherconfig.json')
+    assert_not Exercise.dirconfig_file?(@exercise.full_path.join('otherconfig.json'))
   end
 
   test 'safe_delete should not destroy exercise if status is not removed' do

--- a/test/models/repository_test.rb
+++ b/test/models/repository_test.rb
@@ -93,7 +93,7 @@ class EchoRepositoryTest < ActiveSupport::TestCase
 
   test 'should not create new labels when they are already present' do
     Label.create(name: 'label4')
-    @remote.update_json(@echo.path + '/config.json') do |json|
+    @remote.update_json("#{@echo.path}/config.json") do |json|
       json['labels'] << 'label4'
       json
     end
@@ -204,7 +204,7 @@ class EchoRepositoryTest < ActiveSupport::TestCase
   test 'should copy valid token for new exercise' do
     new_dir = 'echo2'
     @remote.copy_dir(@echo.path, new_dir)
-    @remote.update_json(new_dir + '/config.json', 'add token to new exercise') do |json|
+    @remote.update_json("#{new_dir}/config.json", 'add token to new exercise') do |json|
       json['internals']['token'] = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
       json
     end
@@ -225,7 +225,7 @@ class EchoRepositoryTest < ActiveSupport::TestCase
   end
 
   test 'should overwrite memory limit that is too high' do
-    @remote.update_json(@echo.path + '/config.json', 'set a ridiculous memory limit') do |json|
+    @remote.update_json("#{@echo.path}/config.json", 'set a ridiculous memory limit') do |json|
       json['evaluation']['memory_limit'] = 500_000_000_000
       json
     end
@@ -235,7 +235,7 @@ class EchoRepositoryTest < ActiveSupport::TestCase
   end
 
   test 'should convert to content page' do
-    @remote.update_json(@echo.path + '/config.json', 'convert to content page') do |json|
+    @remote.update_json("#{@echo.path}/config.json", 'convert to content page') do |json|
       json['type'] = 'content'
       json
     end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -110,7 +110,7 @@ class UserTest < ActiveSupport::TestCase
     assert_equal user.first_name, user.short_name
 
     user.first_name = nil
-    assert_equal ' ' + user.last_name, user.short_name
+    assert_equal " #{user.last_name}", user.short_name
 
     user.last_name = nil
     assert_equal 'n/a', user.short_name

--- a/test/renderers/renderers_test.rb
+++ b/test/renderers/renderers_test.rb
@@ -29,7 +29,7 @@ class RenderersTest < ActiveSupport::TestCase
   end
 
   test 'should not strip for exercise marked unsafe' do
-    json = (FILES_LOCATION + 'output.json').read
+    json = FILES_LOCATION.join('output.json').read
     exercise = create :exercise
     exercise.update(allow_unsafe: true)
     submission = create :submission, result: json, user: create(:zeus), exercise: exercise, status: :correct
@@ -38,7 +38,7 @@ class RenderersTest < ActiveSupport::TestCase
   end
 
   test 'should not strip for exercise marked unsafe (pythia)' do
-    json = (FILES_LOCATION + 'pythia_output.json').read
+    json = FILES_LOCATION.join('pythia_output.json').read
     exercise = create :exercise
     exercise.update(allow_unsafe: true)
     submission = create :submission, result: json, user: create(:zeus), exercise: exercise, status: :correct
@@ -47,7 +47,7 @@ class RenderersTest < ActiveSupport::TestCase
   end
 
   test 'should include exercise token if exercise rendered for is private' do
-    json = (FILES_LOCATION + 'output.json').read
+    json = FILES_LOCATION.join('output.json').read
     exercise = create :exercise
     exercise.update(access: :private)
     submission = create :submission, result: json, user: create(:zeus), exercise: exercise, status: :correct

--- a/test/testhelpers/delayed_job_helper.rb
+++ b/test/testhelpers/delayed_job_helper.rb
@@ -1,7 +1,5 @@
 module DelayedJobHelper
-  def assert_jobs_enqueued(number)
-    assert_difference('Delayed::Job.count', number) do
-      yield
-    end
+  def assert_jobs_enqueued(number, &block)
+    assert_difference('Delayed::Job.count', number, &block)
   end
 end

--- a/test/testhelpers/remote_helper.rb
+++ b/test/testhelpers/remote_helper.rb
@@ -1,7 +1,7 @@
 require 'pathname'
 require 'fileutils'
 
-require 'testhelpers/git_helper.rb'
+require 'testhelpers/git_helper'
 
 module RemoteHelper
   def local_remote(sample_dir = nil)

--- a/test/testhelpers/remote_helper.rb
+++ b/test/testhelpers/remote_helper.rb
@@ -62,7 +62,7 @@ class TempRepository < GitRepository
   end
 
   def add_dir(src_path, msg: nil)
-    FileUtils.cp_r Dir[src_path + '/*'], @path
+    FileUtils.cp_r Dir["#{src_path}/*"], @path
     msg ||= "add #{src_path}"
     commit msg
   end

--- a/test/testhelpers/stub_helper.rb
+++ b/test/testhelpers/stub_helper.rb
@@ -9,7 +9,7 @@ module StubHelper
 
   def stub_status(exercise, status)
     exercise.stubs(:status).returns(status)
-    Exercise.statuses.keys.each do |key|
+    Exercise.statuses.each_key do |key|
       exercise.stubs("#{key}?".to_sym).returns(key == status)
     end
   end


### PR DESCRIPTION
This pull request is split over a few commits. The first commit adds the relevant configuration to `.rubocop.yml`. The second commit adds all autocorrections deemed safe by the rubocop developers. The third commit applies the (unsafe) autocorrection for the `Style/StringInterpolation` cop and includes some manual fixes (it broke tests due to `Pathname` concatenation being seen as string concatenation). The fix was to use `join` when using `Pathname` objects. The fourth commit applies the other "unsafe" autocorrections. The last commit applies some manual fixes where no autocorrection was possible.

Closes #2283.
