### PR TITLE
Fixes for LTI series URL

### DIFF
--- a/app/helpers/lti_helper.rb
+++ b/app/helpers/lti_helper.rb
@@ -2,7 +2,7 @@ require_relative '../../lib/LTI/messages'
 
 module LtiHelper
   def lti_resource_links_from(params)
-    activity_ids = params[:lti][:activities] || []
+    activity_ids = params[:lti][:activities]&.reject(&:blank?) || []
     series_id = params[:lti][:series]
     course_id = params[:lti][:course]
 

--- a/app/helpers/lti_helper.rb
+++ b/app/helpers/lti_helper.rb
@@ -15,7 +15,7 @@ module LtiHelper
       end
     elsif series_id.present?
       series = Series.find(series_id)
-      url = lti_series_url(course_id, series)
+      url = lti_series_url(series)
       [LTI::Messages::Types::DeepLinkingResponse::LtiResourceLink.new(series.name, url)]
     else
       course = Course.find(course_id)
@@ -36,11 +36,11 @@ module LtiHelper
     end
   end
 
-  def lti_series_url(course_id, series)
+  def lti_series_url(series)
     if series.hidden?
       series_url(series, token: series.access_token)
     else
-      course_url(course_id, anchor: series.anchor)
+      series_url(series)
     end
   end
 end

--- a/test/helpers/lti_helper_test.rb
+++ b/test/helpers/lti_helper_test.rb
@@ -50,7 +50,7 @@ class LtiHelperTest < ActionDispatch::IntegrationTest
     assert_equal(1, result.length)
     item = result[0]
     assert_equal(@series.name, item.title)
-    assert_equal(lti_series_url(@course.id, @series), item.url)
+    assert_equal(lti_series_url(@series), item.url)
   end
 
   test 'resource link is for hidden series if series is selected' do
@@ -67,7 +67,7 @@ class LtiHelperTest < ActionDispatch::IntegrationTest
     assert_equal(1, result.length)
     item = result[0]
     assert_equal(@series.name, item.title)
-    assert_equal(lti_series_url(@course.id, @series), item.url)
+    assert_equal(lti_series_url(@series), item.url)
   end
 
   test 'resource link is for activity if activity is selected' do


### PR DESCRIPTION
- Ufora just appends query params to whatever URL we give it, so we can't give anchors. Just link to the series URL instead.
- The second commit is to prevent issues when the form sends `activities: [""]`, which happens if you select an activity and then select nothing again.
