### PR TITLE
Prevent crash if creating annotation while logged out

### DIFF
--- a/app/controllers/annotations_controller.rb
+++ b/app/controllers/annotations_controller.rb
@@ -13,7 +13,7 @@ class AnnotationsController < ApplicationController
   def show; end
 
   def create
-    clazz = if current_user.course_admin?(@submission.course)
+    clazz = if current_user&.course_admin?(@submission.course)
               Annotation
             else
               Question

--- a/test/controllers/annotations_controller_test.rb
+++ b/test/controllers/annotations_controller_test.rb
@@ -158,6 +158,18 @@ class QuestionAnnotationControllerTest < ActionDispatch::IntegrationTest
     sign_in @submission.user
   end
 
+  test 'not logged in is rejected' do
+    sign_out @submission.user
+    post submission_annotations_url(@submission), params: {
+      question: {
+        line_nr: 1,
+        annotation_text: 'Ik heb een vraag over mijn code - Lijn'
+      },
+      format: :json
+    }
+    assert_response :unauthorized
+  end
+
   test 'student can create a question' do
     post submission_annotations_url(@submission), params: {
       question: {


### PR DESCRIPTION
When creating an annotation when logged out, it crashes instead of returning `401 Unauthorized`. This PR fixes that.

- [x] Tests were added
