### PR TITLE
Fix MathJax not being loaded on activity page

### DIFF
--- a/app/assets/javascripts/exercise.js
+++ b/app/assets/javascripts/exercise.js
@@ -104,7 +104,6 @@ function centerImagesAndTables() {
 
 function initMathJax() {
     // configure MathJax
-    window.dodona.afterInitialMathJaxTypeset = [];
     window.MathJax = {
         tex: {
             inlineMath: [
@@ -126,14 +125,6 @@ function initMathJax() {
         },
         loader: {
             load: ["[tex]/noerrors"]
-        },
-        startup: {
-            ready: () => {
-                window.MathJax.startup.defaultReady();
-                window.MathJax.startup.promise.then(() => {
-                    window.dodona.afterInitialMathJaxTypeset.forEach(f => f());
-                });
-            }
         }
     };
 }

--- a/app/helpers/renderers/feedback_code_renderer.rb
+++ b/app/helpers/renderers/feedback_code_renderer.rb
@@ -91,7 +91,7 @@ class FeedbackCodeRenderer
 
     @builder.script(type: 'application/javascript') do
       @builder << <<~HEREDOC
-        window.dodona.afterInitialMathJaxTypeset.push(() => {
+        window.MathJax.startup.promise.then(() => {
           window.dodona.codeListing = new window.dodona.codeListingClass(#{submission.id}, #{@code.to_json}, #{@code.lines.length}, #{user_is_student});
           window.dodona.codeListing.addMachineAnnotations(#{messages.map { |o| Hash[o.each_pair.to_a] }.to_json});
           #{'window.dodona.codeListing.initAnnotateButtons();' if user_perm}

--- a/app/views/activities/show.html.erb
+++ b/app/views/activities/show.html.erb
@@ -2,6 +2,10 @@
   <%= javascript_pack_tag 'exercise' %>
   <% if @activity.exercise? %>
     <%= javascript_pack_tag 'submission' %>
+    <script>
+      window.dodona.initMathJax();
+    </script>
+    <script id="MathJax-script" src='https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js'></script>
     <%= javascript_pack_tag 'pythia_submission' if @activity.judge.renderer == PythiaRenderer %>
   <% end %>
 <% end %>

--- a/app/views/feedbacks/show.html.erb
+++ b/app/views/feedbacks/show.html.erb
@@ -77,7 +77,7 @@
 </div>
 <% if @feedback.submission.present? %>
   <script>
-    window.dodona.afterInitialMathJaxTypeset.push(() => {
+    window.MathJax.startup.promise.then(() => {
       window.dodona.codeListing.setEvaluation(<%= @feedback.evaluation.id %>)
       $(".nav.nav-tabs li:last-child a").tab("show");
     });


### PR DESCRIPTION
Also simplifies the MathJax setup some more. I didn't realise earlier that the MathJax object is replaced by MathJax on script load, so we don't actually need to have a roundabout way of making sure we only initialise the annotations in the code listing after MathJax is initialised.

Closes #2296.
