### PR TITLE
Configure base href on medusa

### DIFF
--- a/app/views/layouts/frame.html.erb
+++ b/app/views/layouts/frame.html.erb
@@ -31,7 +31,7 @@
 </head>
 <body>
 <%# Open links in the parent window %>
-<base target="_parent">
+<base target="_parent" href="<%= request.original_url %>">
   <%= yield %>
 </body>
 </html>


### PR DESCRIPTION
This pull request sets the correct `base href` in activity descriptions, to fix loading relative images in Visual Studio Code.

Branch is currently live on naos.