### PR TITLE
Flip page & site name in page title

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,7 +20,7 @@
   <link rel="shortcut icon" sizes="192x192" href="<%= @unread_notifications&.any? ? "/icon-not.png" : "/icon.png" %>">
   <link rel="shortcut icon" href="<%= @unread_notifications&.any? ? "/favicon-not.ico" : "/favicon.ico" %>">
   <link rel="manifest" href="/manifest.json">
-  <title>Dodona<%= " - #{@title}" if @title %></title>
+  <title><%= "#{@title} - " if @title %>Dodona</title>
   <link href="https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,300;0,400;0,500;0,700;1,400&display=swap" rel="stylesheet">
   <link href="https://cdn.materialdesignicons.com/5.2.45/css/materialdesignicons.min.css" rel="stylesheet" type='text/css'>
   <% if session[:dark].nil? && current_user.present? %>


### PR DESCRIPTION
This pull request switchtes the page & site name in the page title to the more common "Page - Site" structure.

![image](https://user-images.githubusercontent.com/1756811/94436901-5277ac80-019d-11eb-81cc-37aecbf34c1b.png)
