### PR TITLE
(Some) login page improvements

### DIFF
--- a/app/assets/javascripts/sign_in.js
+++ b/app/assets/javascripts/sign_in.js
@@ -1,57 +1,72 @@
 /* globals Bloodhound */
 
 function initInstitutionAutoSelect(institutions, links) {
-    const institution = new Bloodhound({
+    // Textual, user-facing representation of the institution.
+    function institutionRepresentation(institution) {
+        return institution.name + " – " + links[institution.type].name;
+    }
+
+    const institutionSuggestions = new Bloodhound({
         datumTokenizer: Bloodhound.tokenizers.obj.whitespace("name"),
         queryTokenizer: Bloodhound.tokenizers.whitespace,
         local: institutions,
     });
 
-    const typeaheadRef = $("#scrollable-dropdown-menu .typeahead").typeahead({
+    const typeAhead = $("#scrollable-dropdown-menu .typeahead");
+    const loginButton = $("#sign-in");
+
+    typeAhead.typeahead({
         minLength: 0,
         highlight: true
     }, {
         name: "institution",
         display: institutionRepresentation,
-        limit: institutions.length,
-        source: institutionsWithDefaults
-    });
-
-    function institutionRepresentation(institution) {
-        return institution.name + " – " + institution.type.replace("Provider::", "");
-    }
-
-    function institutionsWithDefaults(q, sync) {
-        if (q === "") {
-            sync(institution.all()); // This is the only change needed to get 'ALL' items as the defaults
-        } else {
-            institution.search(q, sync);
+        source: (query, sync) => {
+            if (query === "") {
+                // Needed to get 'ALL' items as the default suggestions.
+                sync(institutionSuggestions.all());
+            } else {
+                institutionSuggestions.search(query, sync);
+            }
         }
-    }
-
-    const institutionRepresentations = institutions.map(i => institutionRepresentation(i));
-
-    $("input").bind("input", e => {
-        const val = e.target.value;
-
-        $(".login-button").attr("disabled", !institutionRepresentations.includes(val));
     });
 
-    $(".typeahead").bind("typeahead:select", function (ev, suggestion) {
-        $("#sign-in").attr("href", links[suggestion.type]);
-        $(".login-button").attr("disabled", false);
-        localStorage.setItem("institution", JSON.stringify(suggestion));
+    // Select an institution.
+    function selectInstitution(institution) {
+        loginButton.attr("href", links[institution.type].link);
+        loginButton.attr("disabled", false);
+        localStorage.setItem("institution", JSON.stringify(institution));
+    }
+
+    // Clear the selection.
+    function clearInstitutionSelection() {
+        loginButton.attr("href", "");
+        loginButton.attr("disabled", true);
+        localStorage.removeItem("institution");
+    }
+
+    // When users select something in the dropdown.
+    typeAhead.on("typeahead:select", (e, i) => selectInstitution(i));
+    // When the field is autocompleted, e.g. with the tab key.
+    typeAhead.on("typeahead:autocomplete", (e, i) => selectInstitution(i));
+    // When the user types the full name on their own.
+    typeAhead.on("input", e => {
+        const val = e.target.value;
+        const institution = institutions.find(i => val === institutionRepresentation(i));
+        if (institution) {
+            selectInstitution(institution);
+        } else {
+            clearInstitutionSelection();
+        }
     });
 
     // Check if there is an institution in localStorage if so set it as default selection.
     const localStorageInstitution = localStorage.getItem("institution");
     if (localStorageInstitution !== null) {
         const institution = JSON.parse(localStorageInstitution);
-        $(".typeahead").typeahead("val", institutionRepresentation(institution));
-        $("#sign-in").attr("href", links[institution.type]);
-        $(".login-button").attr("disabled", false);
+        typeAhead.typeahead("val", institutionRepresentation(institution));
+        selectInstitution(institution);
     }
-    typeaheadRef.focus();
 }
 
 export { initInstitutionAutoSelect };

--- a/app/controllers/auth/authentication_controller.rb
+++ b/app/controllers/auth/authentication_controller.rb
@@ -6,11 +6,23 @@ class Auth::AuthenticationController < Devise::SessionsController
   skip_before_action :verify_authenticity_token, raise: false
 
   def sign_in
+    # Providers that are not necessarily specific to one institution.
+    @generic_providers = {
+      Provider::Smartschool => { image: 'smartschool.png', name: 'Smartschool' },
+      Provider::Office365 => { image: 'office365.png', name: 'Office 365' },
+      Provider::GSuite => { image: 'google_oauth2.png', name: 'G Suite' }
+    }
+
+    # Calculate some information for these providers.
+    @generic_providers.each do |key, value|
+      value[:link] = omniauth_authorize_path(:user, key.sym)
+    end
+
     @providers = Provider.all
     @title = I18n.t('auth.sign_in.sign_in')
     @oauth_providers = apply_scopes(@providers
       .includes(:institution)
-      .where(type: [Provider::Smartschool, Provider::Office365, Provider::GSuite])
+      .where(type: @generic_providers.keys)
       .where(mode: :prefer)
       .where.not(institutions: { name: Institution::NEW_INSTITUTION_NAME }))
     render 'auth/sign_in'

--- a/app/views/auth/sign_in.html.erb
+++ b/app/views/auth/sign_in.html.erb
@@ -62,12 +62,8 @@
         </div>
     </div>
     <div class="sign-in-dialog-institutions row">
-      <% [
-        { symbol: Provider::Smartschool.sym, image: 'smartschool.png',   name: 'Smartschool'},
-        { symbol: Provider::Office365.sym,   image: 'office365.png',     name: 'Office 365'},
-        { symbol: Provider::GSuite.sym,      image: 'google_oauth2.png', name: 'G Suite'}
-      ].each do |provider| %>
-        <%= link_to omniauth_authorize_path(:user, provider[:symbol]), class: 'institution-sign-in' do %>
+      <% @generic_providers.values.each do |provider| %>
+        <%= link_to provider[:link], class: 'institution-sign-in' do %>
           <div class="col-sm-6 col-lg-4">
             <div class="option-btn">
               <div class="option-btn-img">
@@ -101,10 +97,6 @@
 </div>
 <script>
   const institutions = <%= raw @oauth_providers.map{|i| {id: i.id, name: i.institution.name, type: i.type}}.to_json %>;
-  const links = {
-    "Provider::GSuite": "<%= omniauth_authorize_path(:user, Provider::GSuite.sym) %>",
-    "Provider::Office365": "<%= omniauth_authorize_path(:user, Provider::Office365.sym) %>",
-    "Provider::Smartschool": "<%= omniauth_authorize_path(:user, Provider::Smartschool.sym) %>",
-  };
+  const links = <%= raw @generic_providers.to_json %>;
   window.dodona.initInstitutionAutoSelect(institutions, links);
 </script>


### PR DESCRIPTION
- Don't focus on typeahead (fixes #2281)
- Fixes to selection:
   - When using tab completion, the button was not always updated with the correct link and stayed disabled (if you use tab completion without selecting something in the dropdown, the "selected" event is not fired, only the "autocomplete" one).
   - When typing the name manually, the button is enabled, but the link is not updated.
- Small clean-up in the javascript, especially on the jquery selectors, which used a bunch of different selectors to select the same element
- Small general clean-up: move the "generic" providers to the controller, so we only have to hard code them once.

No visual changes, except that the typeahead is no longer focussed, so the dropdown is only shown when clicking the input field (although always showing the dropdown didn't seem to work reliable in Chrome anyway).
