### PR TITLE
Handle kid error more gracefully

### DIFF
--- a/app/controllers/concerns/set_lti_message.rb
+++ b/app/controllers/concerns/set_lti_message.rb
@@ -11,6 +11,8 @@ module SetLtiMessage
     @lti_message = parse_message(params[:id_token], params[:provider_id])
     @lti_launch = @lti_message.is_a?(LTI::Messages::Types::ResourceLaunchRequest)
     helpers.locale = @lti_message&.launch_presentation_locale if @lti_message&.launch_presentation_locale.present?
+  rescue JSON::JWK::Set::KidNotFound => _e
+    flash.now[:error] = t('layout.messages.kid')
   end
 
   def set_lti_provider

--- a/config/locales/views/defaults/en.yml
+++ b/config/locales/views/defaults/en.yml
@@ -26,6 +26,7 @@ en:
       success: Great
       time_zone_html: Your time zone is currently set to <strong>%{time_zone}</strong>, but this doesn't seem to match with your local time. You can switch time zones on your <a href='%{profile_edit}'>profile page</a>.
       iframe: It seems that you are using Dodona within another webpage, so not everything may work properly. Let your teacher know so that he can solve the problem by adjusting a setting in the learning environment. In the meantime, you can click <a href='%{url}' target='_blank'>this link</a> to open Dodona in a new window.
+      kid: There was an error when communicating with Ufora. You should re-open this page.
     menu:
       manual: User manual
       activities: Activities

--- a/config/locales/views/defaults/nl.yml
+++ b/config/locales/views/defaults/nl.yml
@@ -26,6 +26,7 @@ nl:
       success: Geweldig
       time_zone_html: Je tijdzone staat momenteel ingesteld op <strong>%{time_zone}</strong>, maar dit lijkt niet overeen te komen met je lokale tijd. Je kan van tijdzone wisselen op je <a href='%{profile_edit}'>profielpagina</a>.
       iframe: Het lijkt erop dat je Dodona gebruikt binnen een andere webpagina waardoor mogelijk niet alles goed werkt. Laat dit weten aan je lesgever zodat hij het probleem kan oplossen door een instelling in de leeromgeving aan te passen. Ondertussen kan je <a href='%{url}' target='_blank'>op deze link klikken</a> om Dodona te openen in een nieuw venster.
+      kid: Er ging iets verkeerd tijdens het communiceren met Ufora. Je opent deze pagina best opnieuw.
     menu:
       manual: Gebruikershandleiding
       activities: Leeractiviteiten

--- a/test/testhelpers/lti_test_helper.rb
+++ b/test/testhelpers/lti_test_helper.rb
@@ -51,8 +51,10 @@ module LtiTestHelper
     JWT.decode(payload, key.keypair, false, algorithm: 'RS256').first
   end
 
-  def self.jwks_content
+  def self.jwks_content(kid = nil)
     pk = OpenSSL::PKey::RSA.new(File.read(FILES_LOCATION.join('public_key.pem')))
-    { keys: [JWT::JWK.create_from(pk).export.merge({ use: 'sig' })] }.to_json
+    options = { use: 'sig' }
+    options[:kid] = kid if kid
+    { keys: [JWT::JWK.create_from(pk).export.merge(options)] }.to_json
   end
 end


### PR DESCRIPTION
This pull request shows an error flash if the kid is no longer found instead of erroring:

![image](https://user-images.githubusercontent.com/1756811/95306838-2f798680-0888-11eb-9122-274129dd24f8.png)

- [x] Tests were added