### PR TITLE
Highlight whole lines in code listing

### DIFF
--- a/app/assets/stylesheets/components/code_listing.css.less
+++ b/app/assets/stylesheets/components/code_listing.css.less
@@ -39,7 +39,15 @@
         line-height: 20px;
       }
 
+      // Highlight for the line numbers.
       .lineno.marked {
+        background-color: @warning-500;
+        // Only do the line number, don't extend to the full height
+        background-clip: content-box;
+      }
+
+      // Highlight for the code itself.
+      .lineno.marked .rouge-code pre {
         background-color: @warning-500;
       }
 


### PR DESCRIPTION
This pull request changes highlighting of lines to also include the code and to not include the annotation.

![image](https://user-images.githubusercontent.com/1756811/95442483-ba778100-095b-11eb-9c7c-d6c5c87e6faf.png)


Closes #2222.
