### PR TITLE
Fix question ordering

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -200,15 +200,15 @@ class CoursesController < ApplicationController
 
     @refresh = ActiveRecord::Type::Boolean.new.deserialize(params.fetch(:refresh, @course.enabled_questions?.to_s))
     @unanswered = @course.unanswered_questions
-                         .order(created_at: :asc)
+                         .reorder(created_at: :asc)
                          .includes(:user, :last_updated_by, submission: [:exercise])
                          .paginate(page: parse_pagination_param(params[:unanswered_page]), per_page: 10)
     @in_progress = @course.in_progress_questions
-                          .order(updated_at: :desc)
+                          .reorder(updated_at: :desc)
                           .includes(:user, :last_updated_by, submission: [:exercise])
                           .paginate(page: parse_pagination_param(params[:in_progress_page]), per_page: 10)
     @answered = @course.answered_questions
-                       .order(updated_at: :desc)
+                       .reorder(updated_at: :desc)
                        .includes(:user, :last_updated_by, submission: [:exercise])
                        .paginate(page: parse_pagination_param(params[:answered_page]), per_page: 10)
     count = @course.unanswered_questions.count


### PR DESCRIPTION
The questions are accessed through the `submissions` relation on the course, which has a default ordering on the submission id. In the question controller I used `order`, so the new ordering by question date was appended, meaning the questions are order like so: `ORDER BY submissions.id DESC, annotations.created_at ASC`. Fixed by using `reorder` instead, which overwrites any previously defined ordering.
