### PR TITLE
Update question notification dot in navbar

### DIFF
--- a/app/assets/javascripts/question_table.ts
+++ b/app/assets/javascripts/question_table.ts
@@ -122,3 +122,9 @@ export class QuestionTable {
         });
     }
 }
+
+export function toggleQuestionNavDot(show: boolean): void {
+    const element = document.getElementById("question-navbar-link");
+    element.classList.toggle("notification", show);
+    element.classList.toggle("notification-left", show);
+}

--- a/app/javascript/packs/course.js
+++ b/app/javascript/packs/course.js
@@ -8,7 +8,8 @@ import {
 } from "course.js";
 
 import {
-    QuestionTable
+    QuestionTable,
+    toggleQuestionNavDot
 } from "question_table.ts";
 import { setDocumentTitle } from "util.js";
 
@@ -21,3 +22,4 @@ window.dodona.loadUsers = loadUsers;
 
 window.dodona.questionTable = QuestionTable;
 window.dodona.setDocumentTitle = setDocumentTitle;
+window.dodona.toggleQuestionNavDot = toggleQuestionNavDot;

--- a/app/views/courses/_navbar_links.html.erb
+++ b/app/views/courses/_navbar_links.html.erb
@@ -23,6 +23,7 @@
   <%= navbar_link url: questions_course_path(@course),
                   title: t('.questions'),
                   icon: 'account-question',
+                  id: 'question-navbar-link',
                   class: (@course.unanswered_questions.any? ? 'notification notification-left' : ''),
                   if: policy(@course).questions? %>
 <% end %>

--- a/app/views/courses/questions.js.erb
+++ b/app/views/courses/questions.js.erb
@@ -12,3 +12,4 @@ dodona.setDocumentTitle("<%= @title %> - Dodona");
 <% else %>
   dodona.dotManager.releaseDot("questions");
 <% end %>
+dodona.toggleQuestionNavDot(<%= @unanswered.any? %>);


### PR DESCRIPTION
This pull request toggles the notification dot on the question link in the navbar when the questions are updated.

(This will only update automatically on the question dashboard, since there is no automatic question refresh on the other course-related pages.)

Closes #2326 .
