### PR TITLE
Fix feedback table backgrounds in dark mode

### DIFF
--- a/app/assets/stylesheets/theme/rouge-dark.css.less
+++ b/app/assets/stylesheets/theme/rouge-dark.css.less
@@ -17,7 +17,6 @@
 }
 
 .highlighter-rouge {
-  background: #282a36;
   color: #f8f8f2
 }
 


### PR DESCRIPTION
Remove the Rouge-specific background colour: in most places it was overridden anyway, and it fixes the issue.

![image](https://user-images.githubusercontent.com/1756811/95960282-db305280-0e03-11eb-9f42-fdd02401976b.png)

Fixes #2337.
