### PR TITLE
Fix question pagination when refreshing

### DIFF
--- a/app/assets/javascripts/question_table.ts
+++ b/app/assets/javascripts/question_table.ts
@@ -70,8 +70,12 @@ export class QuestionTable {
     }
 
     refresh(): void {
-        const url = setParam(this.refreshUrl, "refresh", this.timeout.isStarted().toString());
-        fetch(url, {
+        // Include existing params, e.g. pagination.
+        const url = new URL(this.refreshUrl, window.location.origin);
+        url.search = window.location.search;
+        // Update the refresh param.
+        const updatedUrl = setParam(url.toString(), "refresh", this.timeout.isStarted().toString());
+        fetch(updatedUrl, {
             headers: {
                 "accept": "text/javascript",
                 "x-csrf-token": $("meta[name=\"csrf-token\"]").attr("content"),


### PR DESCRIPTION
Other query params, such as pagination, where not included when making the refresh call, meaning they were effectively ignored. Fixed by including all existing query params when making a request.

Fixes #2338.