### PR TITLE
Include course_labels in export

### DIFF
--- a/app/controllers/exports_controller.rb
+++ b/app/controllers/exports_controller.rb
@@ -78,9 +78,10 @@ class ExportsController < ApplicationController
 
     if @user.blank? && (item.class == Series || item.class == Course)
       authorize item, :course_admin?
-      params[:include_labels] = true
+      params[:with_labels] = true
     else
-      params.remove(:include_labels)
+      # only course admins should be able to export labels
+      params.delete(:with_labels)
     end
 
     Export.create(user: current_user).delay(queue: 'exports').start(item, list, ([@user] if @user), params)

--- a/app/controllers/exports_controller.rb
+++ b/app/controllers/exports_controller.rb
@@ -75,7 +75,13 @@ class ExportsController < ApplicationController
   def create(item, list)
     authorize item, :export?
     authorize @user, :export? if @user
-    authorize item, :course_admin? if @user.blank? && (item.class == Series || item.class == Course)
+
+    if @user.blank? && (item.class == Series || item.class == Course)
+      authorize item, :course_admin?
+      params[:include_labels] = true
+    else
+      params.remove(:include_labels)
+    end
 
     Export.create(user: current_user).delay(queue: 'exports').start(item, list, ([@user] if @user), params)
     respond_to do |format|

--- a/app/helpers/export_helper.rb
+++ b/app/helpers/export_helper.rb
@@ -224,7 +224,7 @@ module ExportHelper
                [filename, submission&.status, submission&.id, exercise.name_en, exercise.name_nl, exercise.id]
              else
                row = [filename, user.full_name, user.id, submission&.status, submission&.id, exercise.name_en, exercise.name_nl, exercise.id, submission&.created_at]
-               labels? && row << @users_labels[user].map(&:name).join(';')
+               row << @users_labels[user].map(&:name).join(';') if labels?
                row
              end
     end


### PR DESCRIPTION
This pull request adds course labels to series or course exports for course admins.

<!-- If there are visual changes, add a screenshot -->

I confirmed manually that labels are included as expected. Adding a test to check if the correct course labels are present would complicate and slow down the already complex code in `test/testhelpers/export_zip_helper.rb`.

Closes #2341.
