### PR TITLE
Show link to contact page on login error

### DIFF
--- a/app/controllers/auth/omniauth_callbacks_controller.rb
+++ b/app/controllers/auth/omniauth_callbacks_controller.rb
@@ -279,4 +279,12 @@ class Auth::OmniauthCallbacksController < Devise::OmniauthCallbacksController
     flash_failure I18n.t('auth.sign_in.errors.missing-provider')
     redirect_to sign_in_path
   end
+
+  def find_message(kind, options = {})
+    if kind == :failure
+      # Include the contact us prompt on failure.
+      flash[:contact] = true
+    end
+    super(kind, options)
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -183,6 +183,15 @@ module ApplicationHelper
     end
   end
 
+  def flash_to_bootstrap(klass)
+    {
+      'notice' => 'info',
+      'danger' => 'error',
+      'alert' => 'warning',
+      'success' => 'success'
+    }[klass]
+  end
+
   class BootstrapLinkRenderer < ::WillPaginate::ActionView::LinkRenderer
     protected
 

--- a/app/views/layouts/_main_container.html.erb
+++ b/app/views/layouts/_main_container.html.erb
@@ -1,11 +1,13 @@
 <div id="main-container" class="<%= content_for?(:container_class) ? yield(:container_class) : "container" %> main">
   <div class="page-messages hidden-print">
     <% flash.each do |key, value| %>
-      <% unless value.nil? %>
-        <%= content_tag(:div, raw("<strong>#{t("layout.messages.info")}:</strong> ") + value, :class => "alert alert-info") if key == "notice" %>
-        <%= content_tag(:div, raw("<strong>#{t("layout.messages.danger")}!</strong> ") + value, :class => "alert alert-danger") if key == "error" %>
-        <%= content_tag(:div, raw("<strong>#{t("layout.messages.warning")}!</strong> ") + value, :class => "alert alert-warning") if key == "alert" %>
-        <%= content_tag(:div, raw("<strong>#{t("layout.messages.success")}!</strong> ") + value, :class => "alert alert-success") if key == "success" %>
+      <% type = flash_to_bootstrap(key) %>
+      <% if value.present? && type.present? %>
+        <div class="alert alert-<%= type %>">
+          <strong><%= t("layout.messages.#{type}") %></strong>
+          <%= value %>
+          <%= link_to(t('pages.contact.prompt'), contact_path) if flash[:contact] %>
+        </div>
       <% end %>
     <% end %>
     <% if user_signed_in? %>

--- a/config/locales/views/defaults/en.yml
+++ b/config/locales/views/defaults/en.yml
@@ -20,10 +20,10 @@ en:
       info:  while in demo mode, Dodona conceals all users names.
       switch_back: Disable demo mode.
     messages:
-      warning: Warning
-      danger: Oh snap
-      info: Heads up
-      success: Great
+      warning: Warning!
+      danger: Oh snap!
+      info: "Heads up:"
+      success: Great!
       time_zone_html: Your time zone is currently set to <strong>%{time_zone}</strong>, but this doesn't seem to match with your local time. You can switch time zones on your <a href='%{profile_edit}'>profile page</a>.
       iframe: It seems that you are using Dodona within another webpage, so not everything may work properly. Let your teacher know so that he can solve the problem by adjusting a setting in the learning environment. In the meantime, you can click <a href='%{url}' target='_blank'>this link</a> to open Dodona in a new window.
       kid: There was an error when communicating with Ufora. You should re-open this page.

--- a/config/locales/views/defaults/nl.yml
+++ b/config/locales/views/defaults/nl.yml
@@ -20,10 +20,10 @@ nl:
       info: in demo modus verbergt Dodona de echte namen van alle gebruikers.
       switch_back: Demo modus uitschakelen.
     messages:
-      warning: Opgepast
-      danger: Oh nee
-      info: Ter info
-      success: Geweldig
+      warning: Opgepast!
+      danger: Oh nee!
+      info: "Ter info:"
+      success: Geweldig!
       time_zone_html: Je tijdzone staat momenteel ingesteld op <strong>%{time_zone}</strong>, maar dit lijkt niet overeen te komen met je lokale tijd. Je kan van tijdzone wisselen op je <a href='%{profile_edit}'>profielpagina</a>.
       iframe: Het lijkt erop dat je Dodona gebruikt binnen een andere webpagina waardoor mogelijk niet alles goed werkt. Laat dit weten aan je lesgever zodat hij het probleem kan oplossen door een instelling in de leeromgeving aan te passen. Ondertussen kan je <a href='%{url}' target='_blank'>op deze link klikken</a> om Dodona te openen in een nieuw venster.
       kid: Er ging iets verkeerd tijdens het communiceren met Ufora. Je opent deze pagina best opnieuw.

--- a/config/locales/views/pages/en.yml
+++ b/config/locales/views/pages/en.yml
@@ -52,6 +52,7 @@ en:
       email: Email
       subject: Subject
       message: Message
+      prompt: Contact us if the problem persists.
     create_contact:
       mail_sent: "Your message has been sent. Thanks for getting in touch."
       captcha_failed: reCAPTCHA could not be verified; please try again.

--- a/config/locales/views/pages/nl.yml
+++ b/config/locales/views/pages/nl.yml
@@ -52,6 +52,7 @@ nl:
       email: Email
       subject: Onderwerp
       message: Bericht
+      prompt: Contacteer ons als het probleem zich blijft voordoen.
     create_contact:
       captcha_failed: reCAPTCHA kon niet geverifieerd worden, probeer opnieuw.
       mail_sent: "Je bericht werd verstuurd. Bedankt om contact op te nemen."


### PR DESCRIPTION
This pull request adds a link to the contact page on login failures.

![image](https://user-images.githubusercontent.com/1756811/96430664-bde3f580-1202-11eb-8c0b-22115fbf74b5.png)

Closes #2237.
