### PR TITLE
Invalidate series status cache on deadline change

### DIFF
--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -171,6 +171,10 @@ class Series < ApplicationRecord
 
   def invalidate_activity_statuses_and_caches
     ActivityStatus.delete_by(series: self)
+    delay.invalidate_status_cache
+  end
+
+  def invalidate_status_cache
     # Remove the caches for each user.
     exercises.includes(submissions: :user)
              .flat_map { |exercise| exercise.submissions.map(&:user) }

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -273,10 +273,7 @@ class Submission < ApplicationRecord
     # the current course that contains this exercise, for the current user.
     # Afterwards, invalidate the completion status of the series itself as well.
     exercise.series.where(course_id: course_id).find_each do |ex_series|
-      ex_series.invalidate_completed?(user: user)
-      ex_series.invalidate_completed?(deadline: ex_series.deadline, user: user)
-      ex_series.invalidate_started?(user: user)
-      ex_series.invalidate_wrong?(user: user)
+      ex_series.invalidate_caches(user)
     end
 
     # Invalidate other statistics.

--- a/test/models/series_test.rb
+++ b/test/models/series_test.rb
@@ -21,6 +21,8 @@
 require 'test_helper'
 
 class SeriesTest < ActiveSupport::TestCase
+  include CacheHelper
+
   setup do
     stub_all_activities!
     @series = create :series
@@ -116,6 +118,39 @@ class SeriesTest < ActiveSupport::TestCase
     ActivityStatus.clear_status_store
 
     assert_equal true, series.completed_before_deadline?(user)
+  end
+
+  test 'changing deadline clears exercise cache' do
+    with_cache do
+      now = Time.zone.now
+      original_deadline = now + 3.days
+
+      course = create :course
+      series = create :series, course: course, deadline: original_deadline
+      user = create :user
+
+      exercise = create :exercise
+      series.exercises << exercise
+
+      create :wrong_submission, created_at: now - 3.days, user: user, course: course, exercise: exercise
+
+      assert_equal false, series.completed_before_deadline?(user)
+
+      # Move the deadline up
+      series.update(deadline: now + 5.days)
+      # Simulate we have a new request
+      ActivityStatus.clear_status_store
+
+      assert_equal false, series.completed_before_deadline?(user)
+
+      create :correct_submission, created_at: now + 2.days, user: user, course: course, exercise: exercise
+
+      # Restore the original deadline
+      series.update(deadline: original_deadline)
+      ActivityStatus.clear_status_store
+
+      assert_equal true, series.completed_before_deadline?(user)
+    end
   end
 
   test 'enabling indianio_support should generate a new token if there was none' do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -19,6 +19,7 @@ require 'testhelpers/git_helper'
 require 'testhelpers/remote_helper'
 require 'testhelpers/export_zip_helper'
 require 'testhelpers/lti_test_helper'
+require 'testhelpers/cache_helper'
 
 # automatically set locale for all routes
 require 'minitest/utils/rails/locale'

--- a/test/testhelpers/cache_helper.rb
+++ b/test/testhelpers/cache_helper.rb
@@ -1,0 +1,15 @@
+module CacheHelper
+  def with_cache
+    original_store = Rails.application.config.cache_store
+    original_cache = Rails.cache
+    Rails.application.config.cache_store = [:memory_store, { size: 64.megabytes }]
+    Rails.cache = ActiveSupport::Cache::MemoryStore.new(
+      expires_in: 1.minute
+    )
+    yield
+  ensure
+    Rails.cache.clear
+    Rails.cache = original_cache
+    Rails.application.config.cache_store = original_store
+  end
+end


### PR DESCRIPTION
This pull request modifies the series status cache to:

- No longer include the deadline in the cache key
- Invalidate all caches on deadline change

The problem this solves is e.g. this scenario:

1. The user submits something in a series with a deadline
2. Someone changes the deadline. Old series status is not removed, but another cache key is used => no problem
3. The user does a submission. Series status cache is removed, but for current deadline => no problem
4. Someone changes deadline back. Now the old cache is used again, since the key is the same. The new submission from step 3 is thus ignored.

Suggestions welcome if there is a better way of doing this.

- [x] Tests were added. I've introduced a helper that enables an in-memory cache for the specified tests.

(Should hopefully) close #2218.
