### PR TITLE
Clear ActivityStatus cache when adding/removing exercises to series

### DIFF
--- a/app/models/series_membership.rb
+++ b/app/models/series_membership.rb
@@ -21,11 +21,16 @@ class SeriesMembership < ApplicationRecord
   validates :series_id, uniqueness: { scope: :activity_id }
   after_create :invalidate_caches
   after_destroy :invalidate_caches
+  after_destroy :invalidate_status
   after_destroy :regenerate_activity_token
 
   def invalidate_caches
     course.invalidate_activities_count_cache
     series.delay.invalidate_status_cache
+  end
+
+  def invalidate_status
+    ActivityStatus.delete_by(series: series, activity: activity)
   end
 
   def regenerate_activity_token

--- a/app/models/series_membership.rb
+++ b/app/models/series_membership.rb
@@ -25,6 +25,7 @@ class SeriesMembership < ApplicationRecord
 
   def invalidate_caches
     course.invalidate_activities_count_cache
+    series.delay.invalidate_status_cache
   end
 
   def regenerate_activity_token

--- a/test/models/series_test.rb
+++ b/test/models/series_test.rb
@@ -176,6 +176,47 @@ class SeriesTest < ActiveSupport::TestCase
     end
   end
 
+  test 'removing solved exercise and re-adding with changed deadline results in correct status' do
+    with_cache do
+      now = Time.zone.now
+      original_deadline = now + 3.days
+
+      course = create :course
+      series = create :series, course: course, deadline: original_deadline
+      user = create :user
+
+      exercise = create :exercise
+      series.exercises << exercise
+      content_page = create :content_page
+      series.content_pages << content_page
+
+      ActivityReadState.create activity: content_page,
+                               course: course,
+                               user: user
+
+      create :correct_submission, user: user, course: course, exercise: exercise, created_at: now + 2.days
+      ActivityStatus.clear_status_store
+      assert_equal true, series.completed_before_deadline?(user)
+
+      series.exercises.delete(exercise)
+      series.reload
+      ActivityStatus.clear_status_store
+
+      assert_equal true, series.completed_before_deadline?(user)
+
+      series.update(deadline: now + 1.day)
+
+      ActivityStatus.clear_status_store
+      assert_equal true, series.completed_before_deadline?(user)
+
+      series.exercises << exercise
+      ActivityStatus.clear_status_store
+      series.reload
+
+      assert_equal false, series.completed_before_deadline?(user)
+    end
+  end
+
   test 'enabling indianio_support should generate a new token if there was none' do
     @series.indianio_support = true
     assert_not_nil @series.indianio_token


### PR DESCRIPTION
This pull request invalidates the status of the series when adding/removing exercises to the series.

I don't think it is necessary to clear the actual activity statuses themselves (as happens when the deadline of the series changes), since they are still valid.

- [x] Tests were added

Closes #2079.
