### PR TITLE
Create read state within course if content page is opened in course without series

### DIFF
--- a/app/views/activities/show.html.erb
+++ b/app/views/activities/show.html.erb
@@ -139,7 +139,7 @@ end %>
           <i class="mdi mdi-chevron-left icon"></i><span class="text"><%= previous_tooltip %></span>
         <% end %>
       <% end %>
-      <%= render partial: 'content_page_read_button', locals: {activity: @activity, course: @series&.course, user: current_user, read_state: @read_state} %>
+      <%= render partial: 'content_page_read_button', locals: {activity: @activity, course: @course, user: current_user, read_state: @read_state} %>
       <% if @series.present? %>
         <%= link_to next_link, class: 'content-page-action btn-fab-extended right next' do %>
           <span class="text"><%= next_tooltip %></span>


### PR DESCRIPTION
This pull request fixes read states being created outside of the course when the content page is opened without a series id in the URL. (This is used in evaluations right now to allow access to and 'reading of' content pages without giving access to the full series yet.)
