### PR TITLE
Don't destroy status cache for deleted series

### DIFF
--- a/app/models/series_membership.rb
+++ b/app/models/series_membership.rb
@@ -26,7 +26,7 @@ class SeriesMembership < ApplicationRecord
 
   def invalidate_caches
     course.invalidate_activities_count_cache
-    series.delay.invalidate_status_cache
+    series.delay.invalidate_status_cache unless series.destroyed?
   end
 
   def invalidate_status


### PR DESCRIPTION
Because the series will already be gone when the status cache is deleted in a delayed job.