### PR TITLE
Fix nil when converting exercises to reading activities

### DIFF
--- a/app/assets/javascripts/exercise.js
+++ b/app/assets/javascripts/exercise.js
@@ -221,7 +221,7 @@ function initExerciseShow(exerciseId, programmingLanguage, loggedIn, editorShown
         return $.post("/submissions.json", {
             submission: {
                 code: code,
-                exercise_id: exerciseId,
+                activity_id: exerciseId,
                 course_id: courseId,
             },
         });

--- a/app/controllers/annotations_controller.rb
+++ b/app/controllers/annotations_controller.rb
@@ -7,7 +7,7 @@ class AnnotationsController < ApplicationController
   has_scope :by_course, as: :course_id
 
   has_scope :by_filter, as: 'filter' do |controller, scope, value|
-    scope.by_filter(value, skip_user: controller.params[:user_id].present?, skip_exercise: controller.params[:exercise_id].present?)
+    scope.by_filter(value, skip_user: controller.params[:user_id].present?, skip_activity: controller.params[:exercise_id].present?)
   end
 
   def index
@@ -34,7 +34,7 @@ class AnnotationsController < ApplicationController
     end
 
     # Preload dependencies for efficiency
-    @questions = @questions.includes(:user, :last_updated_by, submission: %i[exercise course])
+    @questions = @questions.includes(:user, :last_updated_by, submission: %i[activity course])
 
     @questions = @questions.order(created_at: :desc).paginate(page: parse_pagination_param(params[:page]))
     @activities = policy_scope(Activity.all)

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -201,15 +201,15 @@ class CoursesController < ApplicationController
     @refresh = ActiveRecord::Type::Boolean.new.deserialize(params.fetch(:refresh, @course.enabled_questions?.to_s))
     @unanswered = @course.unanswered_questions
                          .reorder(created_at: :asc)
-                         .includes(:user, :last_updated_by, submission: [:exercise])
+                         .includes(:user, :last_updated_by, submission: [:activity])
                          .paginate(page: parse_pagination_param(params[:unanswered_page]), per_page: 10)
     @in_progress = @course.in_progress_questions
                           .reorder(updated_at: :desc)
-                          .includes(:user, :last_updated_by, submission: [:exercise])
+                          .includes(:user, :last_updated_by, submission: [:activity])
                           .paginate(page: parse_pagination_param(params[:in_progress_page]), per_page: 10)
     @answered = @course.answered_questions
                        .reorder(updated_at: :desc)
-                       .includes(:user, :last_updated_by, submission: [:exercise])
+                       .includes(:user, :last_updated_by, submission: [:activity])
                        .paginate(page: parse_pagination_param(params[:answered_page]), per_page: 10)
     count = @course.unanswered_questions.count
     @title = if count == 0

--- a/app/helpers/export_helper.rb
+++ b/app/helpers/export_helper.rb
@@ -186,10 +186,10 @@ module ExportHelper
                    headers
                  end
           submissions.each do |submission|
-            exercises_per_user[submission.user.id].add(submission.exercise.id)
-            filename = get_filename submission.user, submission.exercise, submission
+            exercises_per_user[submission.user.id].add(submission.activity.id)
+            filename = get_filename submission.user, submission.activity, submission
             write_submission(zio, submission, filename)
-            csv_submission(csv, submission.user, submission.exercise, submission, filename)
+            csv_submission(csv, submission.user, submission.activity, submission, filename)
           end
           if all_students? # Loop over all user/exercise-combinations to write an empty file to include them in the zip
             users.each do |user|
@@ -240,17 +240,17 @@ module ExportHelper
         exercises = @list.map(&:exercises).flatten
       else # is User
         submissions = get_submissions_for_user(@list)
-        exercises = submissions.map(&:exercise).uniq
+        exercises = submissions.map(&:activity).uniq
       end
 
       { data: generate_zip_data(@users, exercises, submissions), filename: zip_filename }
     end
 
     def get_submissions_for_series(selected_exercises, users)
-      submissions = Submission.all.where(user_id: users.map(&:id), exercise_id: selected_exercises.map(&:id)).includes(:user, :exercise)
+      submissions = Submission.all.where(user_id: users.map(&:id), activity_id: selected_exercises.map(&:id)).includes(:user, :activity)
       submissions = submissions.before_deadline(@options[:deadline]) if deadline?
-      submissions = submissions.group(:user_id, :exercise_id).most_recent if only_last_submission?
-      submissions.sort_by { |s| [selected_exercises.map(&:id).index(s.exercise_id), users.map(&:id).index(s.user_id), s.id] }
+      submissions = submissions.group(:user_id, :activity_id).most_recent if only_last_submission?
+      submissions.sort_by { |s| [selected_exercises.map(&:id).index(s.activity_id), users.map(&:id).index(s.user_id), s.id] }
     end
 
     def get_submissions_for_course(selected_series, users)
@@ -261,7 +261,7 @@ module ExportHelper
     end
 
     def get_submissions_for_user(selected_courses)
-      return Submission.of_user(@item).includes(:user, :exercise) if all? # allow submissions without a course
+      return Submission.of_user(@item).includes(:user, :activity) if all? # allow submissions without a course
 
       selected_courses.map { |course| get_submissions_for_course(course.series, @users) }.flatten
     end

--- a/app/helpers/renderers/feedback_table_renderer.rb
+++ b/app/helpers/renderers/feedback_table_renderer.rb
@@ -23,13 +23,13 @@ class FeedbackTableRenderer
     @builder = Builder::XmlMarkup.new
     @code = submission.code
     @user = user
-    @exercise = submission.exercise
-    @programming_language = @exercise.programming_language&.editor_name
+    @activity = submission.activity
+    @programming_language = submission.exercise&.programming_language&.editor_name
   end
 
   def parse
     if @result.present?
-      @builder.div(class: 'feedback-table', "data-exercise_id": @exercise.id) do
+      @builder.div(class: 'feedback-table', "data-exercise_id": @activity.id) do
         if @result[:messages].present?
           @builder.div(class: 'row feedback-table-messages') do
             messages(@result[:messages])
@@ -39,7 +39,7 @@ class FeedbackTableRenderer
         init_js
       end.html_safe
     else
-      @builder.div(class: 'feedback-table', "data-exercise_id": @exercise.id) do
+      @builder.div(class: 'feedback-table', "data-exercise_id": @activity.id) do
         @builder.div(class: 'row feedback-table-messages') do
           messages([{ description: I18n.t('submissions.show.reading_failed'), format: 'plain' }])
         end
@@ -293,8 +293,8 @@ class FeedbackTableRenderer
 
   def init_js
     @builder.script do
-      token = @exercise.access_private? ? "'#{@exercise.access_token}'" : 'undefined'
-      @builder << "dodona.initSubmissionShow('feedback-table', '#{activity_path(nil, @exercise)}', #{token});"
+      token = @activity.access_private? ? "'#{@activity.access_token}'" : 'undefined'
+      @builder << "dodona.initSubmissionShow('feedback-table', '#{activity_path(nil, @activity)}', #{token});"
     end
   end
 
@@ -352,7 +352,7 @@ class FeedbackTableRenderer
   end
 
   def safe(html)
-    if @exercise.allow_unsafe?
+    if @activity.allow_unsafe?
       html
     else
       sanitize html

--- a/app/helpers/renderers/pythia_renderer.rb
+++ b/app/helpers/renderers/pythia_renderer.rb
@@ -86,8 +86,8 @@ class PythiaRenderer < FeedbackTableRenderer
     return super(tc) unless tc[:data] && tc[:data][:files]
 
     jsonfiles = tc[:data][:files].to_a.map do |key, value|
-      value[:content] = "#{value[:content]}?token=#{@exercise.access_token}" \
-        if @exercise.access_private? && value&.dig(:location) == 'href'
+      value[:content] = "#{value[:content]}?token=#{@activity.access_token}" \
+        if @activity.access_private? && value&.dig(:location) == 'href'
       [key, value]
     end.to_h.to_json
     @builder.div(class: "testcase #{tc[:accepted] ? 'correct' : 'wrong'} contains-file", "data-files": jsonfiles) do

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -53,6 +53,9 @@ class Activity < ApplicationRecord
   has_many :courses, -> { distinct }, through: :series
   has_many :activity_labels, dependent: :destroy
   has_many :labels, through: :activity_labels
+  # Content pages can also have submissions, since they can be converted
+  # from normal exercises
+  has_many :submissions, dependent: :restrict_with_error
 
   validates :path, uniqueness: { scope: :repository_id, case_sensitive: false }, allow_nil: true
 

--- a/app/models/annotation.rb
+++ b/app/models/annotation.rb
@@ -33,16 +33,16 @@ class Annotation < ApplicationRecord
   scope :released, -> { where(evaluation_id: nil).or(where(evaluations: { released: true })) }
   scope :by_course, ->(course_id) { where(submission: Submission.in_course(Course.find(course_id))) }
   scope :by_username, ->(name) { where(user: User.by_filter(name)) }
-  scope :by_exercise_name, ->(name) { where(submission: Submission.by_exercise_name(name)) }
+  scope :by_activity_name, ->(name) { where(submission: Submission.by_activity_name(name)) }
 
   before_validation :set_last_updated_by, on: :create
   after_destroy :destroy_notification
   after_save :create_notification
 
-  scope :by_filter, lambda { |filter, skip_user:, skip_exercise:|
+  scope :by_filter, lambda { |filter, skip_user:, skip_activity:|
     filter.split(' ').map(&:strip).select(&:present?).map do |part|
       scopes = []
-      scopes << by_exercise_name(part) unless skip_exercise
+      scopes << by_activity_name(part) unless skip_activity
       scopes << by_username(part) unless skip_user
       scopes.any? ? merge(scopes.reduce(&:or)) : self
     end.reduce(includes(submission: [:exercise], user: []), &:merge)

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -244,7 +244,7 @@ class Course < ApplicationRecord
 
   def correct_solutions(_options = {})
     Submission.where(status: 'correct', course: self)
-              .select(:exercise_id, :user_id)
+              .select(:activity_id, :user_id)
               .distinct
               .count
   end

--- a/app/models/exercise.rb
+++ b/app/models/exercise.rb
@@ -33,7 +33,6 @@ class Exercise < Activity
 
   belongs_to :judge
   belongs_to :programming_language, optional: true
-  has_many :submissions, dependent: :restrict_with_error
 
   before_save :check_memory_limit
 
@@ -150,7 +149,7 @@ class Exercise < Activity
   end
 
   def self.move_relations(from, to)
-    from.submissions.each { |s| s.update(exercise: to) }
+    from.submissions.each { |s| s.update(activity: to) }
     super
   end
 

--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -36,15 +36,15 @@ class Feedback < ApplicationRecord
   scope :undecided, -> { where(submission: nil) }
 
   def previous_attempts
-    user.submissions.of_exercise(exercise).in_course(evaluation.series.course).before_deadline(submission.created_at).count
+    user.submissions.of_activity(exercise).in_course(evaluation.series.course).before_deadline(submission.created_at).count
   end
 
   def later_attempts
-    user.submissions.of_exercise(exercise).in_course(evaluation.series.course).where('created_at > ?', submission.created_at).count
+    user.submissions.of_activity(exercise).in_course(evaluation.series.course).where('created_at > ?', submission.created_at).count
   end
 
   def total_attempts
-    user.submissions.of_exercise(exercise).in_course(evaluation.series.course).count
+    user.submissions.of_activity(exercise).in_course(evaluation.series.course).count
   end
 
   def time_to_deadline
@@ -68,7 +68,7 @@ class Feedback < ApplicationRecord
 
   def determine_submission
     # First because the default order is id: :desc
-    self.submission = user.submissions.of_exercise(exercise).before_deadline(evaluation.deadline).first
+    self.submission = user.submissions.of_activity(exercise).before_deadline(evaluation.deadline).first
     self.completed = true if submission.nil?
   end
 
@@ -91,6 +91,6 @@ class Feedback < ApplicationRecord
 
   def submission_user_exercise_correct
     errors.add(:submission, 'user should be the same as in the evaluation') if submission.present? && submission.user_id != user.id
-    errors.add(:submission, 'exercise should be the same as in the evaluation') if submission.present? && submission.exercise_id != exercise.id
+    errors.add(:submission, 'exercise should be the same as in the evaluation') if submission.present? && submission.activity_id != exercise.id
   end
 end

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -148,7 +148,7 @@ class Series < ApplicationRecord
 
     submission_hash = Submission.in_series(self).where(user: users)
     submission_hash = submission_hash.before_deadline(deadline) if deadline.present?
-    submission_hash = submission_hash.group(%i[user_id exercise_id]).most_recent.index_by { |s| [s.user_id, s.exercise_id] }
+    submission_hash = submission_hash.group(%i[user_id activity_id]).most_recent.index_by { |s| [s.user_id, s.activity_id] }
 
     read_state_hash = ActivityReadState.in_series(self).where(user: users)
     read_state_hash = read_state_hash.before_deadline(deadline) if deadline.present?

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -260,7 +260,10 @@ class Submission < ApplicationRecord
   end
 
   def self.rejudge(submissions, priority = :low)
-    submissions.each { |s| s.evaluate_delayed(priority) }
+    submissions
+      .includes(:activity)
+      .filter { |s| s.activity.exercise? }
+      .each { |s| s.evaluate_delayed(priority) }
   end
 
   def self.normalize_status(status)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -201,7 +201,7 @@ class User < ApplicationRecord
   def attempted_exercises(options)
     s = submissions.judged
     s = s.in_course(options[:course]) if options[:course].present?
-    s.select('distinct exercise_id').count
+    s.select('distinct activity_id').count
   end
 
   invalidateable_instance_cacheable(:attempted_exercises,
@@ -210,7 +210,7 @@ class User < ApplicationRecord
   def correct_exercises(options)
     s = submissions.where(status: :correct)
     s = s.in_course(options[:course]) if options[:course].present?
-    s.select('distinct exercise_id').count
+    s.select('distinct activity_id').count
   end
 
   invalidateable_instance_cacheable(:correct_exercises,
@@ -221,8 +221,7 @@ class User < ApplicationRecord
   end
 
   def recent_exercises(limit = 3)
-    # If a user has submitted to a content page this will include `nil` values. So we compact to throw those away.
-    submissions.select('distinct exercise_id').limit(limit).includes(:exercise).map(&:exercise).compact
+    submissions.select('distinct activity_id').limit(limit).includes(:activity).map(&:activity).select(&:exercise?)
   end
 
   def pending_series

--- a/app/policies/submission_policy.rb
+++ b/app/policies/submission_policy.rb
@@ -44,7 +44,8 @@ class SubmissionPolicy < ApplicationPolicy
   end
 
   def permitted_attributes
-    %i[code exercise_id course_id]
+    # Exercise id is kept for API compatibility
+    %i[code exercise_id activity_id course_id]
   end
 
   private

--- a/app/runners/submission_runner.rb
+++ b/app/runners/submission_runner.rb
@@ -17,8 +17,10 @@ class SubmissionRunner
     # definition of submission
     @submission = submission
 
-    # derive exercise and judge definitions from submission
+    # derive exercise definitions from submission
     @exercise = submission.exercise
+    raise 'cannot judge submission linked to content page' if @exercise.nil?
+
     @judge = @exercise.judge
 
     # create name for hidden directory in docker container

--- a/app/views/annotations/_questions_table.html.erb
+++ b/app/views/annotations/_questions_table.html.erb
@@ -33,10 +33,10 @@
         <td>
           <i class="mdi mdi-filter-outline mdi-18 filter-icon"
              title="<%= t('questions.question.filter-by-exercise') %>"
-             data-filter="<%= question.submission.exercise.name %>"
+             data-filter="<%= question.submission.activity.name %>"
              data-toggle="tooltip"
              data-placement="top"></i>
-            <%= link_to question.submission.exercise.name, course_exercise_path(question.submission.course, question.submission.exercise) %>
+            <%= link_to question.submission.activity.name, course_activity_path(question.submission.course, question.submission.activity) %>
           <div class="ellipsis-overflow text-muted icon-indent">
             <%= question.question_text %>
           </div>

--- a/app/views/courses/_question_table.html.erb
+++ b/app/views/courses/_question_table.html.erb
@@ -13,7 +13,7 @@
           <%= question.user.full_name %>
         </td>
         <td>
-          <%= question.submission.exercise.name %>
+          <%= question.submission.activity.name %>
           <div class="ellipsis-overflow text-muted">
             <%= question.question_text %>
           </div>

--- a/app/views/submissions/_description.html.erb
+++ b/app/views/submissions/_description.html.erb
@@ -4,7 +4,7 @@
     window.dodona.initMathJax();
   </script>
   <script id="MathJax-script" src='https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js'></script>
-  <%= javascript_pack_tag 'pythia_submission' if submission.judge.renderer == PythiaRenderer %>
+  <%= javascript_pack_tag 'pythia_submission' if submission.judge&.renderer == PythiaRenderer %>
 <% end %>
 
 
@@ -12,9 +12,9 @@
   <span class="description">
     <%= t "submissions.show.submission_for" %>
     <% if submission.course.nil? %>
-      <%= link_to submission.exercise.name, activity_path(submission.exercise) %>
+      <%= link_to submission.activity.name, activity_path(submission.activity) %>
     <% else %>
-      <%= link_to submission.exercise.name, course_activity_path(submission.course, submission.exercise) %>
+      <%= link_to submission.activity.name, course_activity_path(submission.course, submission.activity) %>
     <% end %>
     <% if current_user.course_admin?(submission.course) %>
       <%= t "submissions.show.by" %>
@@ -41,5 +41,6 @@
 </div>
 
 <% unless submission.queued? or submission.running? %>
-  <%= submission.judge.renderer.new(submission, current_user).parse %>
+  <% renderer = submission.judge&.renderer || FeedbackTableRenderer %>
+  <%= renderer.new(submission, current_user).parse %>
 <% end %>

--- a/app/views/submissions/_submission.html.erb
+++ b/app/views/submissions/_submission.html.erb
@@ -27,15 +27,15 @@
     <td>
       <i class="mdi mdi-filter-outline mdi-18 filter-icon"
         title="<%= t('.filter-submissions-by-exercise') %>"
-        data-filter="<%= submission.exercise.name %>"
+        data-filter="<%= submission.activity.name %>"
         data-toggle="tooltip"
         data-placement="top"
       >
       </i>
       <% if submission.course.nil? %>
-        <%= link_to submission.exercise.name, activity_path(submission.exercise) %>
+        <%= link_to submission.activity.name, activity_path(submission.activity) %>
       <% else %>
-        <%= link_to submission.exercise.name, course_activity_path(submission.course, submission.exercise) %>
+        <%= link_to submission.activity.name, course_activity_path(submission.course, submission.activity) %>
       <% end %>
     </td>
   <% end %>

--- a/app/views/submissions/_submission_basic.json.jbuilder
+++ b/app/views/submissions/_submission_basic.json.jbuilder
@@ -2,5 +2,5 @@ json.extract! submission, :created_at, :status, :summary, :accepted, :id
 json.url submission_url(submission, format: :json)
 json.user user_url(submission.user, format: :json)
 json.has_annotations submission.annotated?
-json.exercise activity_url(submission.exercise, format: :json)
+json.exercise activity_url(submission.activity, format: :json)
 json.course course_url(submission.course, format: :json) if submission.course

--- a/config/initializers/delayed_job_config.rb
+++ b/config/initializers/delayed_job_config.rb
@@ -26,7 +26,7 @@ class SubmissionDjPlugin < Delayed::Plugin
     lifecycle.after(:failure) do |_worker, job, *_args|
       if job.payload_object.object.is_a?(Submission)
         sub = job.payload_object.object
-        Delayed::Worker.logger.debug("Failed submission #{sub.id} by user #{sub.user_id} for exercise #{sub.exercise_id} after #{job.attempts} attempts (worker #{job.locked_by})")
+        Delayed::Worker.logger.debug("Failed submission #{sub.id} by user #{sub.user_id} for exercise #{sub.activity_id} after #{job.attempts} attempts (worker #{job.locked_by})")
         Delayed::Worker.logger.debug(job.last_error[0..10_000])
         begin
           sub.save_result(

--- a/db/migrate/20201109102745_rename_submission_exercise_to_activity.rb
+++ b/db/migrate/20201109102745_rename_submission_exercise_to_activity.rb
@@ -1,0 +1,5 @@
+class RenameSubmissionExerciseToActivity < ActiveRecord::Migration[6.0]
+  def change
+    rename_column :submissions, :exercise_id, :activity_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_24_072242) do
+ActiveRecord::Schema.define(version: 2020_11_09_102745) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
@@ -387,7 +387,7 @@ ActiveRecord::Schema.define(version: 2020_09_24_072242) do
   end
 
   create_table "submissions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
-    t.integer "exercise_id"
+    t.integer "activity_id"
     t.integer "user_id"
     t.string "summary"
     t.datetime "created_at", null: false
@@ -397,10 +397,10 @@ ActiveRecord::Schema.define(version: 2020_09_24_072242) do
     t.integer "course_id"
     t.string "fs_key", limit: 24
     t.index ["accepted"], name: "index_submissions_on_accepted"
+    t.index ["activity_id", "user_id", "accepted", "created_at"], name: "ex_us_ac_cr_index"
+    t.index ["activity_id", "user_id", "status", "created_at"], name: "ex_us_st_cr_index"
+    t.index ["activity_id"], name: "index_submissions_on_activity_id"
     t.index ["course_id"], name: "index_submissions_on_course_id"
-    t.index ["exercise_id", "user_id", "accepted", "created_at"], name: "ex_us_ac_cr_index"
-    t.index ["exercise_id", "user_id", "status", "created_at"], name: "ex_us_st_cr_index"
-    t.index ["exercise_id"], name: "index_submissions_on_exercise_id"
     t.index ["fs_key"], name: "index_submissions_on_fs_key", unique: true
     t.index ["status"], name: "index_submissions_on_status"
     t.index ["user_id"], name: "index_submissions_on_user_id"
@@ -471,7 +471,7 @@ ActiveRecord::Schema.define(version: 2020_09_24_072242) do
   add_foreign_key "series", "courses"
   add_foreign_key "series_memberships", "activities"
   add_foreign_key "series_memberships", "series"
-  add_foreign_key "submissions", "activities", column: "exercise_id"
+  add_foreign_key "submissions", "activities"
   add_foreign_key "submissions", "courses"
   add_foreign_key "submissions", "users"
   add_foreign_key "users", "institutions"

--- a/test/controllers/activities_controller_test.rb
+++ b/test/controllers/activities_controller_test.rb
@@ -316,7 +316,7 @@ class ActivitiesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should get edit submission with show' do
-    submission = create :submission, exercise: @instance
+    submission = create :submission, activity: @instance
 
     Submission.expects(:find).with(submission.id.to_s).returns(submission)
 
@@ -403,7 +403,7 @@ class ActivitiesPermissionControllerTest < ActionDispatch::IntegrationTest
 
   test 'user should be able to see invalid activity when he has submissions, but not when closed' do
     @instance = create :exercise, :nameless
-    create :submission, exercise: @instance, user: @user
+    create :submission, activity: @instance, user: @user
     show_activity
     assert_response :success
   end
@@ -480,7 +480,7 @@ class ActivitiesPermissionControllerTest < ActionDispatch::IntegrationTest
   test 'should get activity media because user has submissions' do
     @instance = create(:exercise, :description_html)
     Exercise.any_instance.stubs(:ok?).returns(false)
-    create :submission, exercise: @instance, user: @user
+    create :submission, activity: @instance, user: @user
     Exercise.any_instance.stubs(:media_path).returns(Pathname.new('public'))
 
     get("#{activity_url(@instance)}/media/icon.png")

--- a/test/controllers/annotations_controller_test.rb
+++ b/test/controllers/annotations_controller_test.rb
@@ -31,13 +31,13 @@ class AnnotationControllerTest < ActionDispatch::IntegrationTest
     assert_response :created
   end
 
-  test 'should be able to search by exercise name' do
+  test 'should be able to search by activity name' do
     u = create :user
     sign_in u
     e1 = create :exercise, name_en: 'abcd'
     e2 = create :exercise, name_en: 'efgh'
-    s1 = create :submission, exercise: e1, user: u
-    s2 = create :submission, exercise: e2, user: u
+    s1 = create :submission, :for_content_page, activity: e1, user: u
+    s2 = create :submission, activity: e2, user: u
     create :question, submission: s1
     create :question, submission: s2
 

--- a/test/controllers/courses_controller_test.rb
+++ b/test/controllers/courses_controller_test.rb
@@ -584,4 +584,16 @@ class CoursesPermissionControllerTest < ActionDispatch::IntegrationTest
     get questions_course_path(@course)
     assert_select 'title', /\(1\)/
   end
+
+  test 'can view questions without exercises' do
+    s = create :submission, :for_content_page, course: @course
+    create :question, submission: s
+
+    # Check that the test is useful.
+    assert_nil s.exercise
+
+    sign_in @admins.first
+    get questions_course_path(@course)
+    assert_response :success
+  end
 end

--- a/test/controllers/evaluations_controller_test.rb
+++ b/test/controllers/evaluations_controller_test.rb
@@ -8,7 +8,7 @@ class EvaluationsControllerTest < ActionDispatch::IntegrationTest
     @submitted_users.each do |user|
       user.enrolled_courses << @series.course
       @exercises.each do |ex|
-        create :submission, exercise: ex, user: user, course: @series.course, status: :correct, created_at: Time.current - 1.hour
+        create :submission, activity: ex, user: user, course: @series.course, status: :correct, created_at: Time.current - 1.hour
       end
     end
     @no_submission_user = create :user

--- a/test/controllers/pages_controller_test.rb
+++ b/test/controllers/pages_controller_test.rb
@@ -24,7 +24,7 @@ class PagesControllerTest < ActionDispatch::IntegrationTest
     activity = create :exercise
     create :submission,
            user: user,
-           exercise: activity
+           activity: activity
     activity.update(type: ContentPage.name)
 
     sign_in(user)

--- a/test/factories/evaluations.rb
+++ b/test/factories/evaluations.rb
@@ -15,7 +15,7 @@ FactoryBot.define do
     deadline { series.deadline }
     released { false }
     exercises { series.exercises }
-    users { series.course.submissions.where(exercise: exercises).map(&:user).uniq }
+    users { series.course.submissions.where(activity: exercises).map(&:user).uniq }
   end
 
   trait :released do

--- a/test/factories/exercises.rb
+++ b/test/factories/exercises.rb
@@ -56,7 +56,7 @@ FactoryBot.define do
     after :create do |exercise, e|
       e.submission_count.times do
         create :submission,
-               exercise: exercise,
+               activity: exercise,
                course: e.series&.first&.course,
                user: e.submission_users.sample
       end

--- a/test/factories/submissions.rb
+++ b/test/factories/submissions.rb
@@ -74,5 +74,15 @@ FactoryBot.define do
     trait :rate_limited do
       skip_rate_limit_check { false }
     end
+
+    trait :for_content_page do
+      after(:create) do |submission|
+        # Convert the exercise to a reading activity
+        # The exercise is now nil
+        submission.exercise.type = 'ContentPage'
+        submission.exercise.save
+        submission.reload
+      end
+    end
   end
 end

--- a/test/factories/submissions.rb
+++ b/test/factories/submissions.rb
@@ -38,7 +38,8 @@ FactoryBot.define do
     end
 
     user
-    exercise
+    association :activity, factory: :exercise
+    exercise { activity }
 
     initialize_with { new(attributes) }
 

--- a/test/models/activity_status_test.rb
+++ b/test/models/activity_status_test.rb
@@ -32,7 +32,7 @@ class ActivityStatusTest < ActiveSupport::TestCase
     assert_not as1.started
     assert_not as2.started
 
-    create :submission, exercise: activity, course: course, status: :correct, user: user
+    create :submission, activity: activity, course: course, status: :correct, user: user
 
     as1.reload
     as2.reload

--- a/test/models/course_test.rb
+++ b/test/models/course_test.rb
@@ -105,14 +105,14 @@ class CourseTest < ActiveSupport::TestCase
 
     create :wrong_submission,
            course: course,
-           exercise: series.exercises[0],
+           activity: series.exercises[0],
            user: user
 
     assert_equal 0, course.correct_solutions
 
     create :correct_submission,
            course: course,
-           exercise: series.exercises[0],
+           activity: series.exercises[0],
            user: user
 
     assert_equal 1, course.correct_solutions
@@ -126,13 +126,13 @@ class CourseTest < ActiveSupport::TestCase
     assert_equal 0, course.correct_solutions
 
     create :wrong_submission,
-           exercise: series.exercises[0],
+           activity: series.exercises[0],
            user: user
 
     assert_equal 0, course.correct_solutions
 
     create :correct_submission,
-           exercise: series.exercises[0],
+           activity: series.exercises[0],
            user: user
 
     assert_equal 0, course.correct_solutions
@@ -159,19 +159,19 @@ class CourseTest < ActiveSupport::TestCase
           case i
           when 0 # Wrong submission before deadline
             create :wrong_submission,
-                   exercise: exercise,
+                   activity: exercise,
                    user: u,
                    created_at: (deadline - 2.minutes),
                    course: course
             expected_started[[u.id, series.id]] += 1
           when 1 # Wrong, then correct submission before deadline
             create :correct_submission,
-                   exercise: exercise,
+                   activity: exercise,
                    user: u,
                    created_at: (deadline - 2.minutes),
                    course: course
             create :correct_submission,
-                   exercise: exercise,
+                   activity: exercise,
                    user: u,
                    created_at: (deadline - 1.minute),
                    course: course
@@ -179,24 +179,24 @@ class CourseTest < ActiveSupport::TestCase
             expected_accepted[[u.id, series.id]] += 1
           when 2 # Wrong submission after deadline
             create :wrong_submission,
-                   exercise: exercise,
+                   activity: exercise,
                    user: u,
                    created_at: (deadline + 2.minutes),
                    course: course
           when 3 # Correct submission after deadline
             create :correct_submission,
-                   exercise: exercise,
+                   activity: exercise,
                    user: u,
                    created_at: (deadline + 2.minutes),
                    course: course
           when 4 # Correct submission before deadline not in course
             create :correct_submission,
-                   exercise: exercise,
+                   activity: exercise,
                    user: u,
                    created_at: (deadline - 2.minutes)
           when 5 # Correct submission after deadline not in course
             create :correct_submission,
-                   exercise: exercise,
+                   activity: exercise,
                    user: u,
                    created_at: (deadline + 2.minutes)
           end

--- a/test/models/exercise_test.rb
+++ b/test/models/exercise_test.rb
@@ -173,7 +173,7 @@ class ExerciseTest < ActiveSupport::TestCase
 
   test 'move_relations should move submissions from one exercise to the other' do
     exercise1 = create :exercise
-    create :submission, exercise: exercise1
+    create :submission, activity: exercise1
     exercise2 = create :exercise
     assert_equal 1, exercise1.submissions.count
     assert_equal 0, exercise2.submissions.count
@@ -197,45 +197,45 @@ class ExerciseTest < ActiveSupport::TestCase
     assert_equal 0, e.users_tried(course: course1)
     assert_equal 0, e.users_tried(course: course2)
 
-    create :submission, user: users_c1[0], course: course1, exercise: e, status: :wrong
+    create :submission, user: users_c1[0], course: course1, activity: e, status: :wrong
 
     assert_equal 1, e.users_tried
     assert_equal 1, e.users_tried(course: course1)
     assert_equal 0, e.users_tried(course: course2)
 
-    create :submission, user: users_c2[0], course: course2, exercise: e, status: :wrong
+    create :submission, user: users_c2[0], course: course2, activity: e, status: :wrong
 
     assert_equal 2, e.users_tried
     assert_equal 1, e.users_tried(course: course1)
     assert_equal 1, e.users_tried(course: course2)
 
-    create :submission, user: users_all[0], exercise: e, status: :wrong
+    create :submission, user: users_all[0], activity: e, status: :wrong
 
     assert_equal 3, e.users_tried
     assert_equal 1, e.users_tried(course: course1)
     assert_equal 1, e.users_tried(course: course2)
 
     users_c1.each do |user|
-      create :submission, user: user, course: course1, exercise: e, status: :wrong
+      create :submission, user: user, course: course1, activity: e, status: :wrong
     end
     assert_equal 7, e.users_tried
     assert_equal 5, e.users_tried(course: course1)
     assert_equal 1, e.users_tried(course: course2)
 
     users_c2.each do |user|
-      create :submission, user: user, course: course2, exercise: e, status: :wrong
+      create :submission, user: user, course: course2, activity: e, status: :wrong
     end
     assert_equal 11, e.users_tried
     assert_equal 5, e.users_tried(course: course1)
     assert_equal 5, e.users_tried(course: course2)
     users_all.each do |user|
-      create :submission, user: user, exercise: e, status: :wrong
+      create :submission, user: user, activity: e, status: :wrong
     end
     assert_equal 15, e.users_tried
     assert_equal 5, e.users_tried(course: course1)
     assert_equal 5, e.users_tried(course: course2)
     users_all.each do |user|
-      create :submission, user: user, exercise: e, status: :running
+      create :submission, user: user, activity: e, status: :running
     end
     assert_equal 15, e.users_tried
     assert_equal 5, e.users_tried(course: course1)
@@ -257,32 +257,32 @@ class ExerciseTest < ActiveSupport::TestCase
     assert_equal 0, e.users_correct(course: course1)
     assert_equal 0, e.users_correct(course: course2)
 
-    create :wrong_submission, user: user_c1, course: course1, exercise: e
+    create :wrong_submission, user: user_c1, course: course1, activity: e
     assert_equal 0, e.users_correct
     assert_equal 0, e.users_correct(course: course1)
     assert_equal 0, e.users_correct(course: course2)
 
-    create :correct_submission, user: user_c1, course: course1, exercise: e
+    create :correct_submission, user: user_c1, course: course1, activity: e
     assert_equal 1, e.users_correct
     assert_equal 1, e.users_correct(course: course1)
     assert_equal 0, e.users_correct(course: course2)
 
-    create :wrong_submission, user: user_c2, course: course2, exercise: e
+    create :wrong_submission, user: user_c2, course: course2, activity: e
     assert_equal 1, e.users_correct
     assert_equal 1, e.users_correct(course: course1)
     assert_equal 0, e.users_correct(course: course2)
 
-    create :correct_submission, user: user_c2, course: course2, exercise: e
+    create :correct_submission, user: user_c2, course: course2, activity: e
     assert_equal 2, e.users_correct
     assert_equal 1, e.users_correct(course: course1)
     assert_equal 1, e.users_correct(course: course2)
 
-    create :wrong_submission, user: user_all, exercise: e
+    create :wrong_submission, user: user_all, activity: e
     assert_equal 2, e.users_correct
     assert_equal 1, e.users_correct(course: course1)
     assert_equal 1, e.users_correct(course: course2)
 
-    create :correct_submission, user: user_all, exercise: e
+    create :correct_submission, user: user_all, activity: e
     assert_equal 3, e.users_correct
     assert_equal 1, e.users_correct(course: course1)
     assert_equal 1, e.users_correct(course: course2)
@@ -290,13 +290,13 @@ class ExerciseTest < ActiveSupport::TestCase
 
   test 'solved_for' do
     create :wrong_submission,
-           exercise: @exercise,
+           activity: @exercise,
            user: @user
 
     assert_equal false, @exercise.solved_for?(@user)
 
     create :correct_submission,
-           exercise: @exercise,
+           activity: @exercise,
            user: @user
 
     assert_equal true, @exercise.solved_for?(@user)
@@ -304,7 +304,7 @@ class ExerciseTest < ActiveSupport::TestCase
 
   test 'solved_for should retry finding ActivityStatus when it fails once' do
     create :wrong_submission,
-           exercise: @exercise,
+           activity: @exercise,
            user: @user
 
     ActivityStatus.stubs(:find_or_create_by)
@@ -315,7 +315,7 @@ class ExerciseTest < ActiveSupport::TestCase
 
   test 'solved_for should not retry finding ActivityStatus when it fails twice' do
     create :wrong_submission,
-           exercise: @exercise,
+           activity: @exercise,
            user: @user
 
     ActivityStatus.stubs(:find_or_create_by)
@@ -331,7 +331,7 @@ class ExerciseTest < ActiveSupport::TestCase
 
     first = create :wrong_submission,
                    user: @user,
-                   exercise: @exercise,
+                   activity: @exercise,
                    created_at: @date
 
     assert_equal first, @exercise.last_submission!(@user)
@@ -340,7 +340,7 @@ class ExerciseTest < ActiveSupport::TestCase
 
     second = create :correct_submission,
                     user: @user,
-                    exercise: @exercise,
+                    activity: @exercise,
                     created_at: @date + 1.minute
 
     assert_equal second, @exercise.last_submission!(@user)
@@ -352,14 +352,14 @@ class ExerciseTest < ActiveSupport::TestCase
 
     create :wrong_submission,
            user: @user,
-           exercise: @exercise,
+           activity: @exercise,
            created_at: @date
 
     assert_nil @exercise.last_correct_submission!(@user)
 
     correct = create :correct_submission,
                      user: @user,
-                     exercise: @exercise,
+                     activity: @exercise,
                      created_at: @date + 1.second
 
     assert_equal correct, @exercise.last_correct_submission!(@user)
@@ -367,7 +367,7 @@ class ExerciseTest < ActiveSupport::TestCase
 
     create :wrong_submission,
            user: @user,
-           exercise: @exercise,
+           activity: @exercise,
            created_at: @date + 2.seconds
 
     assert_equal correct, @exercise.last_correct_submission!(@user)
@@ -378,14 +378,14 @@ class ExerciseTest < ActiveSupport::TestCase
 
     wrong = create :wrong_submission,
                    user: @user,
-                   exercise: @exercise,
+                   activity: @exercise,
                    created_at: @date
 
     assert_equal wrong, @exercise.best_submission!(@user)
 
     correct = create :correct_submission,
                      user: @user,
-                     exercise: @exercise,
+                     activity: @exercise,
                      created_at: @date + 10.seconds
 
     assert_equal correct, @exercise.best_submission!(@user)
@@ -393,7 +393,7 @@ class ExerciseTest < ActiveSupport::TestCase
 
     create :wrong_submission,
            user: @user,
-           exercise: @exercise,
+           activity: @exercise,
            created_at: @date + 1.minute
 
     assert_equal correct, @exercise.best_submission!(@user)
@@ -404,14 +404,14 @@ class ExerciseTest < ActiveSupport::TestCase
 
     create :correct_submission,
            user: @user,
-           exercise: @exercise,
+           activity: @exercise,
            created_at: @date
 
     assert @exercise.best_is_last_submission?(@user)
 
     create :wrong_submission,
            user: @user,
-           exercise: @exercise,
+           activity: @exercise,
            created_at: @date + 10.seconds
 
     assert_not @exercise.best_is_last_submission?(@user)
@@ -422,21 +422,21 @@ class ExerciseTest < ActiveSupport::TestCase
 
     create :wrong_submission,
            user: @user,
-           exercise: @exercise,
+           activity: @exercise,
            created_at: @date
 
     assert_not @exercise.accepted_for?(@user)
 
     create :correct_submission,
            user: @user,
-           exercise: @exercise,
+           activity: @exercise,
            created_at: @date + 10.seconds
 
     assert @exercise.accepted_for?(@user)
 
     create :wrong_submission,
            user: @user,
-           exercise: @exercise,
+           activity: @exercise,
            created_at: @date + 1.minute
 
     assert_not @exercise.accepted_for?(@user)
@@ -452,7 +452,7 @@ class ExerciseTest < ActiveSupport::TestCase
 
     create :correct_submission,
            course: course,
-           exercise: @exercise,
+           activity: @exercise,
            user: @user
 
     series.each do |series_it|
@@ -466,7 +466,7 @@ class ExerciseTest < ActiveSupport::TestCase
 
     create :correct_submission,
            user: @user,
-           exercise: @exercise
+           activity: @exercise
 
     series.each do |series_it|
       assert_not @exercise.accepted_for?(@user, series_it)
@@ -474,7 +474,7 @@ class ExerciseTest < ActiveSupport::TestCase
 
     create :wrong_submission,
            user: @user,
-           exercise: @exercise
+           activity: @exercise
 
     series.each do |series_it|
       assert_not @exercise.accepted_for?(@user, series_it)
@@ -482,7 +482,7 @@ class ExerciseTest < ActiveSupport::TestCase
 
     create :correct_submission,
            user: @user,
-           exercise: @exercise,
+           activity: @exercise,
            course: courses[0]
 
     assert @exercise.accepted_for?(@user, series[0])
@@ -490,7 +490,7 @@ class ExerciseTest < ActiveSupport::TestCase
 
     create :correct_submission,
            user: @user,
-           exercise: @exercise,
+           activity: @exercise,
            course: courses[1]
 
     series.each do |series_it|
@@ -630,7 +630,7 @@ class ExerciseRemoteTest < ActiveSupport::TestCase
   test 'safe_delete should not destroy exercise if it has submissions' do
     @exercise.status = 2 # set status to removed
     user = create :user
-    submission = create :submission, exercise: @exercise, user: user
+    submission = create :submission, activity: @exercise, user: user
     @exercise.submissions.concat(submission) # Add a submission
     @exercise.safe_destroy
     assert_equal @repository.exercises.first, @exercise

--- a/test/models/feedback_test.rb
+++ b/test/models/feedback_test.rb
@@ -21,7 +21,7 @@ class FeedbackTest < ActiveSupport::TestCase
     @users.each do |u|
       series.course.enrolled_members << u
       @exercises.each do |e|
-        create :submission, user: u, exercise: e, course: series.course, created_at: Time.current - 1.hour
+        create :submission, user: u, activity: e, course: series.course, created_at: Time.current - 1.hour
       end
     end
     @evaluation = create :evaluation, series: series, users: @users, exercises: @exercises, deadline: Time.current
@@ -59,7 +59,7 @@ class FeedbackTest < ActiveSupport::TestCase
     feedback = @evaluation.feedbacks.where.not(submission_id: nil).first
     user = feedback.user
     exercise = feedback.exercise
-    submission = create :submission, user: user, exercise: exercise, course: @evaluation.series.course
+    submission = create :submission, user: user, activity: exercise, course: @evaluation.series.course
 
     feedback.submission.annotations.create(evaluation_id: @evaluation.id, annotation_text: 'blah', line_nr: 0, user: @zeus)
 

--- a/test/models/series_test.rb
+++ b/test/models/series_test.rb
@@ -76,7 +76,7 @@ class SeriesTest < ActiveSupport::TestCase
     create :correct_submission,
            created_at: Time.zone.now,
            course: course,
-           exercise: series.exercises[0],
+           activity: series.exercises[0],
            user: user
 
     assert_equal true, series.completed_before_deadline?(user)
@@ -132,7 +132,7 @@ class SeriesTest < ActiveSupport::TestCase
       exercise = create :exercise
       series.exercises << exercise
 
-      create :wrong_submission, created_at: now - 3.days, user: user, course: course, exercise: exercise
+      create :wrong_submission, created_at: now - 3.days, user: user, course: course, activity: exercise
 
       assert_equal false, series.completed_before_deadline?(user)
 
@@ -143,7 +143,7 @@ class SeriesTest < ActiveSupport::TestCase
 
       assert_equal false, series.completed_before_deadline?(user)
 
-      create :correct_submission, created_at: now + 2.days, user: user, course: course, exercise: exercise
+      create :correct_submission, created_at: now + 2.days, user: user, course: course, activity: exercise
 
       # Restore the original deadline
       series.update(deadline: original_deadline)
@@ -162,7 +162,7 @@ class SeriesTest < ActiveSupport::TestCase
       exercise = create :exercise
       series.exercises << exercise
 
-      create :correct_submission, user: user, course: course, exercise: exercise
+      create :correct_submission, user: user, course: course, activity: exercise
       assert_equal true, series.completed_before_deadline?(user)
 
       # Simulate we have a new request
@@ -194,7 +194,7 @@ class SeriesTest < ActiveSupport::TestCase
                                course: course,
                                user: user
 
-      create :correct_submission, user: user, course: course, exercise: exercise, created_at: now + 2.days
+      create :correct_submission, user: user, course: course, activity: exercise, created_at: now + 2.days
       ActivityStatus.clear_status_store
       assert_equal true, series.completed_before_deadline?(user)
 
@@ -294,43 +294,43 @@ class SeriesTest < ActiveSupport::TestCase
         case i
         when 0 # Wrong submission before deadline
           s = create :wrong_submission,
-                     exercise: exercise,
+                     activity: exercise,
                      user: u,
                      created_at: (deadline - 2.minutes),
                      course: course
           expected_submissions << s.id
         when 1 # Wrong, then correct submission before deadline
           create :correct_submission,
-                 exercise: exercise,
+                 activity: exercise,
                  user: u,
                  created_at: (deadline - 2.minutes),
                  course: course
           s = create :correct_submission,
-                     exercise: exercise,
+                     activity: exercise,
                      user: u,
                      created_at: (deadline - 1.minute),
                      course: course
           expected_submissions << s.id
         when 2 # Wrong submission after deadline
           create :wrong_submission,
-                 exercise: exercise,
+                 activity: exercise,
                  user: u,
                  created_at: (deadline + 2.minutes),
                  course: course
         when 3 # Correct submission after deadline
           create :correct_submission,
-                 exercise: exercise,
+                 activity: exercise,
                  user: u,
                  created_at: (deadline + 2.minutes),
                  course: course
         when 4 # Correct submission before deadline not in course
           create :correct_submission,
-                 exercise: exercise,
+                 activity: exercise,
                  user: u,
                  created_at: (deadline - 2.minutes)
         when 5 # Correct submission after deadline not in course
           create :correct_submission,
-                 exercise: exercise,
+                 activity: exercise,
                  user: u,
                  created_at: (deadline + 2.minutes)
         end
@@ -362,7 +362,7 @@ class SeriesTest < ActiveSupport::TestCase
     assert_equal expected_read_states.to_set, scoresheet[:read_states].values.map(&:id).to_set
     # Hash mapping is correct.
     scoresheet[:submissions].each do |key, submission|
-      assert_equal [submission.user_id, submission.exercise.id], key
+      assert_equal [submission.user_id, submission.activity.id], key
     end
   end
 
@@ -373,7 +373,7 @@ class SeriesTest < ActiveSupport::TestCase
     deadline = series.deadline
     # Wrong submission before deadline
     create :wrong_submission,
-           exercise: series.exercises.first,
+           activity: series.exercises.first,
            user: user,
            created_at: (deadline - 2.minutes)
 
@@ -389,7 +389,7 @@ class SeriesTest < ActiveSupport::TestCase
     # Correct submission before deadline
     create :correct_submission,
            course: series.course,
-           exercise: series.exercises.first,
+           activity: series.exercises.first,
            user: user,
            created_at: (deadline - 2.minutes)
 
@@ -404,7 +404,7 @@ class SeriesTest < ActiveSupport::TestCase
     deadline = series.deadline
     # Correct submission before deadline
     create :correct_submission,
-           exercise: series.exercises.first,
+           activity: series.exercises.first,
            user: user,
            created_at: (deadline - 2.minutes)
 
@@ -419,7 +419,7 @@ class SeriesTest < ActiveSupport::TestCase
     deadline = series.deadline
     # Wrong submission after deadline
     create :wrong_submission,
-           exercise: series.exercises.first,
+           activity: series.exercises.first,
            user: user,
            created_at: (deadline + 2.minutes)
 
@@ -435,7 +435,7 @@ class SeriesTest < ActiveSupport::TestCase
     # Correct submission after deadline
     create :correct_submission,
            course: series.course,
-           exercise: series.exercises.first,
+           activity: series.exercises.first,
            user: user,
            created_at: (deadline + 2.minutes)
 
@@ -450,7 +450,7 @@ class SeriesTest < ActiveSupport::TestCase
     deadline = series.deadline
     # Correct submission after deadline
     create :correct_submission,
-           exercise: series.exercises.first,
+           activity: series.exercises.first,
            user: user,
            created_at: (deadline + 2.minutes)
 
@@ -465,7 +465,7 @@ class SeriesTest < ActiveSupport::TestCase
     deadline = series.deadline
     # Correct submission before deadline
     create :correct_submission,
-           exercise: series.exercises.first,
+           activity: series.exercises.first,
            user: user,
            course: series.course,
            created_at: (deadline - 2.minutes)
@@ -482,7 +482,7 @@ class SeriesTest < ActiveSupport::TestCase
 
     # Wrong submission before deadline
     create :wrong_submission,
-           exercise: series.exercises.first,
+           activity: series.exercises.first,
            user: user,
            course: series.course,
            created_at: (deadline - 2.minutes)
@@ -508,7 +508,7 @@ class SeriesTest < ActiveSupport::TestCase
 
     # Correct submission before deadline
     create :correct_submission,
-           exercise: series.exercises.first,
+           activity: series.exercises.first,
            user: user,
            course: series.course,
            created_at: (deadline - 2.minutes)

--- a/test/models/submission_test.rb
+++ b/test/models/submission_test.rb
@@ -31,7 +31,7 @@ class SubmissionTest < ActiveSupport::TestCase
       submission.exercise = content_page
     end
 
-    assert_not submission.update(exercise_id: content_page.id)
+    assert_not submission.update(activity_id: content_page.id)
   end
 
   test 'submissions should be rate limited for a user' do

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -147,22 +147,22 @@ class UserTest < ActiveSupport::TestCase
 
     assert_user_exercises user, 0, 0, 0
 
-    create :wrong_submission, user: user, exercise: exercise1
-    create :wrong_submission, user: user, exercise: exercise1
-    create :wrong_submission, user: user, exercise: exercise1
+    create :wrong_submission, user: user, activity: exercise1
+    create :wrong_submission, user: user, activity: exercise1
+    create :wrong_submission, user: user, activity: exercise1
     assert_user_exercises user, 1, 0, 1
 
-    create :correct_submission, user: user, exercise: exercise1
-    create :correct_submission, user: user, exercise: exercise1
+    create :correct_submission, user: user, activity: exercise1
+    create :correct_submission, user: user, activity: exercise1
     assert_user_exercises user, 1, 1, 0
 
-    create :correct_submission, user: user, exercise: exercise2
+    create :correct_submission, user: user, activity: exercise2
     assert_user_exercises user, 2, 2, 0
 
-    create :wrong_submission, user: user, exercise: exercise3
+    create :wrong_submission, user: user, activity: exercise3
     assert_user_exercises user, 3, 2, 1
 
-    create :submission, user: user, exercise: exercise3
+    create :submission, user: user, activity: exercise3
     assert_user_exercises user, 3, 2, 1
   end
 
@@ -276,7 +276,7 @@ class UserTest < ActiveSupport::TestCase
     exercise1 = create :exercise
     exercise2 = create :exercise
     create :series, exercises: [exercise1, exercise2]
-    create :submission, user: user, exercise: exercise1
+    create :submission, user: user, activity: exercise1
     assert_equal [exercise1], user.recent_exercises
   end
 

--- a/test/renderers/renderers_test.rb
+++ b/test/renderers/renderers_test.rb
@@ -32,7 +32,7 @@ class RenderersTest < ActiveSupport::TestCase
     json = FILES_LOCATION.join('output.json').read
     exercise = create :exercise
     exercise.update(allow_unsafe: true)
-    submission = create :submission, result: json, user: create(:zeus), exercise: exercise, status: :correct
+    submission = create :submission, result: json, user: create(:zeus), activity: exercise, status: :correct
 
     assert_match %r{<script>alert.*</script>}, FeedbackTableRenderer.new(submission, submission.user).parse
   end
@@ -41,7 +41,7 @@ class RenderersTest < ActiveSupport::TestCase
     json = FILES_LOCATION.join('pythia_output.json').read
     exercise = create :exercise
     exercise.update(allow_unsafe: true)
-    submission = create :submission, result: json, user: create(:zeus), exercise: exercise, status: :correct
+    submission = create :submission, result: json, user: create(:zeus), activity: exercise, status: :correct
 
     assert_match %r{<script>alert.*</script>}, PythiaRenderer.new(submission, submission.user).parse
   end
@@ -50,7 +50,7 @@ class RenderersTest < ActiveSupport::TestCase
     json = FILES_LOCATION.join('output.json').read
     exercise = create :exercise
     exercise.update(access: :private)
-    submission = create :submission, result: json, user: create(:zeus), exercise: exercise, status: :correct
+    submission = create :submission, result: json, user: create(:zeus), activity: exercise, status: :correct
 
     assert_match exercise.access_token, FeedbackTableRenderer.new(submission, submission.user).parse
   end

--- a/test/runners/submission_runner_test.rb
+++ b/test/runners/submission_runner_test.rb
@@ -109,6 +109,12 @@ class SubmissionRunnerTest < ActiveSupport::TestCase
     @submission.evaluate
   end
 
+  test 'evaluating submission without exercise should error' do
+    s = create :submission, :for_content_page
+    exception = assert_raise(Exception) { s.evaluate }
+    assert_equal 'cannot judge submission linked to content page', exception.message
+  end
+
   test 'correct submission should be accepted and correct' do
     summary = 'Wow. Such code. Many variables.'
     evaluate_with_stubbed_docker output: {

--- a/test/runners/submission_runner_test.rb
+++ b/test/runners/submission_runner_test.rb
@@ -16,7 +16,7 @@ class SubmissionRunnerTest < ActiveSupport::TestCase
     @submission = create :submission,
                          user: @user,
                          course: @course,
-                         exercise: @exercise
+                         activity: @exercise
   end
 
   STRIKE_ERROR = 'DE HAVENVAKBOND STAAKT!!1!'.freeze
@@ -204,7 +204,7 @@ class SubmissionRunnerTest < ActiveSupport::TestCase
   test 'errors outside of docker startup should be sent to slack' do
     Delayed::Backend::ActiveRecord::Job.delete_all
     Rails.env.stubs(:"production?").returns(true)
-    Submission.any_instance.stubs(:judge).raises(STRIKE_ERROR)
+    Exercise.any_instance.stubs(:judge).raises(STRIKE_ERROR)
     ExceptionNotifier.stubs(:notify_exception).twice
     Docker::Container.stubs(:create).returns(docker_mock)
     @submission.evaluate_delayed


### PR DESCRIPTION
Fixes issues with nil in the submission and question related pages when an exercise with existing submissions is converted to a reading activity. This PR renames the existing column `submissions.excerise_id` to `submissions.activity_id`, and changes to the code to the the linked entity as an activity wherever possible, and making the code that requires an exercise nil-proof:

- `exercise` and `exercise_id` have been renamed everywhere it was possible to use the linked entity as an activity instead of an exercise.
- `exercise` is kept as a nillable attribute:
   - When submissions lose their programming language, they become `text`.
   - When submissions lose their judge/renderer, the default one is used.
   - When attempting to evaluate a submission without exercise, an error is thrown. This allows us to catch those cases, since they shouldn't happen.
    - Submissions without exercise are excluded from mass rejudges and exercise-dependent cache invalidation stuff.
- `exercise_id` continues to be accepted and returned via the API, next to `activity_id`. This to prevent breaking clients.

- [x] Tests were added.
- [ ] Documentation was updated.

Closes #2364.