### PR TITLE
Use Rails logger for Omniauth

### DIFF
--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,0 +1,2 @@
+# Use Rails logger with Omniauth
+OmniAuth.config.logger = Rails.logger


### PR DESCRIPTION
This pull request integrates omniauth logging with the rails logger, getting rid of this:

![image](https://user-images.githubusercontent.com/1756811/99272103-ab6fd280-2827-11eb-8f12-d20414d4badd.png)

Main rational is that I'm tired of having these logs when I run tests locally.

Since we also use the rails logger for the rest, I don't think it's necessary to make this a conditional change (e.g. only in test or dev environment), but not sure.
