### PR TITLE
Use activity path for media in submission view

### DIFF
--- a/app/assets/javascripts/pythia_submission.js
+++ b/app/assets/javascripts/pythia_submission.js
@@ -2,10 +2,10 @@
 import { showInfoModal } from "./modal.js";
 import { logToGoogle } from "./util.js";
 
-function initPythiaSubmissionShow(submissionCode) {
+function initPythiaSubmissionShow(submissionCode, activityPath) {
     function init() {
         initTutorLinks();
-        initFileViewers();
+        initFileViewers(activityPath);
         if ($(".tutormodal").length == 1) {
             initFullScreen();
         } else {
@@ -50,7 +50,7 @@ function initPythiaSubmissionShow(submissionCode) {
         });
     }
 
-    function initFileViewers() {
+    function initFileViewers(activityPath) {
         $("a.file-link").click(function () {
             const fileName = $(this).text();
             const $tc = $(this).parents(".testcase.contains-file");
@@ -59,7 +59,7 @@ function initPythiaSubmissionShow(submissionCode) {
             if (file.location === "inline") {
                 showInlineFile(fileName, file.content);
             } else if (file.location === "href") {
-                showRealFile(fileName, file.content);
+                showRealFile(fileName, activityPath, file.content);
             }
             return false;
         });
@@ -69,7 +69,8 @@ function initPythiaSubmissionShow(submissionCode) {
         showInfoModal(name, "<div class='code'>" + content + "</div>");
     }
 
-    function showRealFile(name, path) {
+    function showRealFile(name, activityPath, filePath) {
+        const path = activityPath + "/" + filePath;
         const random = Math.floor(Math.random() * 10000 + 1);
         showInfoModal(
             name +

--- a/app/helpers/renderers/pythia_renderer.rb
+++ b/app/helpers/renderers/pythia_renderer.rb
@@ -104,7 +104,7 @@ class PythiaRenderer < FeedbackTableRenderer
       @builder << '$(function() {'
       @builder << "$('#tutor').appendTo('body');"
       @builder << "var code = \"#{escaped}\";"
-      @builder << 'dodona.initPythiaSubmissionShow(code);});'
+      @builder << "dodona.initPythiaSubmissionShow(code, '#{activity_path(nil, @exercise)}');});"
     end
 
     # Tutor HTML


### PR DESCRIPTION
This should allow the files to work everywhere, including in the feedback view.

Closes #2220.