### PR TITLE
Reset to origin HEAD instead of hard-coded master branch

### DIFF
--- a/app/models/concerns/gitable.rb
+++ b/app/models/concerns/gitable.rb
@@ -13,7 +13,7 @@ module Gitable
   end
 
   def reset
-    _out, error, status = Open3.capture3('git fetch --all && git reset --hard origin/master', chdir: full_path.to_path)
+    _out, error, status = Open3.capture3('git fetch --all && git reset --hard origin/HEAD', chdir: full_path.to_path)
     [status.success?, error]
   end
 


### PR DESCRIPTION
This pull request fixes errors in the webhook when the remote repository does not have a master branch (which happened recently because GitHub changed the default name of the default branch).