### PR TITLE
Fix question pagination

### DIFF
--- a/app/controllers/annotations_controller.rb
+++ b/app/controllers/annotations_controller.rb
@@ -29,7 +29,6 @@ class AnnotationsController < ApplicationController
     if @unfiltered && current_user&.a_course_admin? && !ActiveRecord::Type::Boolean.new.deserialize(params[:everything])
       @questions = @questions
                    .joins(:submission)
-                   .left_joins(:evaluation)
                    .where(submissions: { course_id: current_user.administrating_courses.map(&:id) })
     end
 

--- a/app/views/annotations/_questions_table.html.erb
+++ b/app/views/annotations/_questions_table.html.erb
@@ -78,7 +78,7 @@
   </table>
 </div>
 <% if questions.try(:total_pages) %>
-  <center><%= page_navigation_links questions, true, "questions" %></center>
+  <center><%= page_navigation_links questions, true, "annotations", {}, 'question_index' %></center>
 <% end %>
 <script type="text/javascript">
     $(function () {

--- a/test/controllers/annotations_controller_test.rb
+++ b/test/controllers/annotations_controller_test.rb
@@ -31,6 +31,13 @@ class AnnotationControllerTest < ActionDispatch::IntegrationTest
     assert_response :created
   end
 
+  test 'pagination is generated correctly' do
+    submission = create :submission, :within_course
+    create_list :question, 31, submission: submission
+    get questions_url, params: { everything: true }
+    assert_select 'a[href=?]', questions_path(page: 2, everything: true)
+  end
+
   test 'should be able to search by exercise name' do
     u = create :user
     sign_in u


### PR DESCRIPTION
PR #2354 contains a bug: the pagination doesn't work, because the wrong controller/action was used. Besides a fix, there is also a small commit to not join evaluations when getting the questions.

While this is a bug fix, there is no need for hot fix, since the feature isn't live yet.

- [x] Tests were added
