### PR TITLE
Fix MathJax in image captions

### DIFF
--- a/app/assets/javascripts/exercise.js
+++ b/app/assets/javascripts/exercise.js
@@ -56,7 +56,15 @@ function initLabelsEdit(labels, undeletableLabels) {
 }
 
 function showLightbox(content) {
-    Strip.show(content.images, { side: "top" }, content.index);
+    Strip.show(content.images, {
+        side: "top",
+        onShow: function () {
+            // There might have been math in the image captions, so ask
+            // MathJax to search for new math (but only in the captions).
+            window.MathJax.typeset([".strp-caption"]);
+        }
+    }, content.index);
+
     // Transfer focus back to the document body to allow the lightbox to be closed.
     // https://github.com/dodona-edu/dodona/issues/1759.
     document.body.focus();

--- a/vendor/assets/javascripts/strip/strip.pkgd.min.js
+++ b/vendor/assets/javascripts/strip/strip.pkgd.min.js
@@ -765,8 +765,6 @@ function initStrip() {
                                 d = this.view && this.view.options.onShow;
                             "function" == $.type(d) && d.call(Strip);
 
-                            /* BEGIN MathJax in caption */
-
                             function _resize(element) {
                                 var e = Window.resize(element[c], function() {
                                     --b < 1 && a()
@@ -774,42 +772,7 @@ function initStrip() {
                                 return e;
                             }
 
-                            var numberMathJax = 0;
-                            if (typeof MathJax !== 'undefined') {
-
-                                $('div.strp-caption').each(function() {
-                                    //There is math in this caption -> Typeset it
-                                    if ($(this).html().indexOf('$$') > -1) {
-                                        numberMathJax += 1;
-                                        MathJax.Hub.Queue(["Typeset", MathJax.Hub, $(this)[0]]);
-                                    }
-                                });
-                                
-                                parent = this;
-
-                                /* Put Mathjax inline, but only when necessary */
-                                if (numberMathJax > 0) {
-
-                                    MathJax.Hub.Queue(function() {
-                                        $("div.strp-caption div.MathJax_Display").each(function() {
-                                            $(this).contents().unwrap();
-                                        });
-                                        e = _resize(this);
-                                        //force explicit resize after mathjax is done
-                                        var a;
-                                        (a = Pages.page) && (a.animated || a.animatingWindow ? (a.fitToWindow(), a.show()) : (a.fitToWindow(), Window.resize(a.z, null, 0), Window.adjustPrevNext(null, !0)))
-                                    })
-
-                                } else {
-                                    var e = _resize(this);
-                                }
-
-
-                            } else {
-                                var e = _resize(this);
-                            }
-
-                            /* END MathJax in caption */
+                            var e = _resize(this);
 
                             this._show(function() {
                                 --b < 1 && a()


### PR DESCRIPTION
This pull request migrates the MathJax typesetting in image captions to MathJax 3.

Since I didn't want to do further changes in the minified code from the lightbox, I've moved the typesetting to the caller. I tried it with some bigger maths as well, and it seems to work (without explicit calls to resize).

<!-- If there are visual changes, add a screenshot -->
![image](https://user-images.githubusercontent.com/1756811/101355286-a508cf80-3896-11eb-8c43-2616edd29df3.png)


- [ ] Tests were added
- [ ] Documentation update can be found at dodona-edu/dodona-edu.github.io#

Closes #2403.
