### PR TITLE
Don't bundle foreman

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -180,9 +180,6 @@ group :development do
   gem 'spring', '~> 2.1.1'
   gem 'spring-watcher-listen', '~> 2.0.1'
 
-  # Manage processes (webpack, rails, delayed_job, ...)
-  gem 'foreman', github: 'andrewmcodes/foreman'
-
   # for opening letters
   gem 'letter_opener', '~> 1.7.0'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,3 @@
-GIT
-  remote: https://github.com/andrewmcodes/foreman.git
-  revision: efe04a65e9eb0114700fecab8c0b8c45a20fe333
-  specs:
-    foreman (0.85.0)
-      thor (>= 0.19, < 0.21)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -497,7 +490,6 @@ DEPENDENCIES
   factory_bot_rails (~> 6.1.0)
   faker (~> 2.15.1)
   flamegraph (~> 0.9.5)
-  foreman!
   has_scope (~> 0.7.2)
   httparty (~> 0.18.1)
   i18n-js (~> 3.8.0)

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ The simplest way to start the server is with the `rails s` command. But this wil
 - With `bin/webpack-dev-server` your javascript is reloaded live and you can see development output.
 
 To run all these processes at the same time, the foreman gem is used. To start the rails server, delayed job and the webpack dev server, simply run `bin/server`.
+The foreman gem is [not bundled with Dodona](https://github.com/ddollar/foreman/wiki/Don%27t-Bundle-Foreman). Install it globally with `gem install foreman`.
 
 This has one letdown: debugging with `byebug` is broken. You can run `bin/server norails` to only start webpack and delayed_job in foreman and then run `rails s` in a different terminal to be able to use `byebug` again.
 

--- a/bin/server
+++ b/bin/server
@@ -5,4 +5,4 @@ if [ "$1" = "norails" ]
 then
     formation="$formation,web=0"
 fi
-bundle exec foreman start -f Procfile.dev "$formation"
+foreman start -f Procfile.dev "$formation"


### PR DESCRIPTION
Removes `foreman` from our gemfile.

The readme has been updated with instruction to install the gem globally. The run script has been modified to use the global foreman instead of running it via bundler. `bin/server` still seems to work.

In the words of foreman's author:
> [...] the primary reason that the README suggests you take care not to install foreman in your project's Gemfile. Ruby's dependency versioning is strict and has a global namespace and it will be impossible to satisfy everyone's needs. Foreman is not a library, it's a utility, and should just be installed at the system level with gem install foreman.

See also https://github.com/ddollar/foreman/wiki/Don%27t-Bundle-Foreman

Fixes #2487.
