### PR TITLE
Improvements to institution management

### DIFF
--- a/app/assets/stylesheets/models.css.less
+++ b/app/assets/stylesheets/models.css.less
@@ -7,3 +7,4 @@
 @import "models/users.css.less";
 @import "models/questions.css.less";
 @import "models/programming_languages.css.less";
+@import "models/institutions.css.less";

--- a/app/assets/stylesheets/models/institutions.css.less
+++ b/app/assets/stylesheets/models/institutions.css.less
@@ -1,0 +1,3 @@
+.generated-name-icon {
+  color: @text-secondary;
+}

--- a/app/controllers/auth/authentication_controller.rb
+++ b/app/controllers/auth/authentication_controller.rb
@@ -24,7 +24,7 @@ class Auth::AuthenticationController < Devise::SessionsController
       .includes(:institution)
       .where(type: @generic_providers.keys)
       .where(mode: :prefer)
-      .where.not(institutions: { name: Institution::NEW_INSTITUTION_NAME }))
+      .where(institutions: { generated_name: false }))
     render 'auth/sign_in'
   end
 end

--- a/app/controllers/auth/omniauth_callbacks_controller.rb
+++ b/app/controllers/auth/omniauth_callbacks_controller.rb
@@ -131,8 +131,9 @@ class Auth::OmniauthCallbacksController < Devise::OmniauthCallbacksController
 
     # Provider was not found. Currently, a new institution will be created for
     # every new provider as well.
-    institution = Institution.new name: Institution::NEW_INSTITUTION_NAME,
-                                  short_name: Institution::NEW_INSTITUTION_NAME,
+    name, short_name = provider_type.extract_institution_name(auth_hash)
+    institution = Institution.new name: name,
+                                  short_name: short_name,
                                   logo: "#{auth_provider_type}.png"
     provider = institution.providers.build identifier: oauth_provider_id,
                                            type: provider_type.name

--- a/app/controllers/institutions_controller.rb
+++ b/app/controllers/institutions_controller.rb
@@ -1,11 +1,17 @@
 class InstitutionsController < ApplicationController
   before_action :set_institution, only: %i[show edit update]
 
+  has_scope :by_filter, as: 'filter' do |_controller, scope, value|
+    scope.by_name(value)
+  end
+
   def index
     authorize Institution
-    @institutions = Institution.all.order(name: :asc).includes(:courses, :users, :providers).to_a
-    empty_institutions = @institutions.select { |i| i.name == Institution::NEW_INSTITUTION_NAME }
-    @institutions = empty_institutions + (@institutions - empty_institutions)
+    # This should be safe, since NEW_INSTITUTION_NAME is a constant defined in code, not user input.
+    order_sql = Arel.sql("CASE name WHEN '#{Institution::NEW_INSTITUTION_NAME}' THEN 1 ELSE 2 END, name")
+    @institutions = apply_scopes(Institution).all.order(order_sql)
+                                             .includes(:courses, :users, :providers)
+                                             .paginate(page: parse_pagination_param(params[:page]))
     @title = I18n.t('institutions.index.title')
   end
 

--- a/app/controllers/institutions_controller.rb
+++ b/app/controllers/institutions_controller.rb
@@ -7,9 +7,7 @@ class InstitutionsController < ApplicationController
 
   def index
     authorize Institution
-    # This should be safe, since NEW_INSTITUTION_NAME is a constant defined in code, not user input.
-    order_sql = Arel.sql("CASE name WHEN '#{Institution::NEW_INSTITUTION_NAME}' THEN 1 ELSE 2 END, name")
-    @institutions = apply_scopes(Institution).all.order(order_sql)
+    @institutions = apply_scopes(Institution).all.order(generated_name: :desc, name: :asc)
                                              .includes(:courses, :users, :providers)
                                              .paginate(page: parse_pagination_param(params[:page]))
     @title = I18n.t('institutions.index.title')

--- a/app/models/institution.rb
+++ b/app/models/institution.rb
@@ -2,12 +2,13 @@
 #
 # Table name: institutions
 #
-#  id         :bigint           not null, primary key
-#  name       :string(255)
-#  short_name :string(255)
-#  logo       :string(255)
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
+#  id             :bigint           not null, primary key
+#  name           :string(255)
+#  short_name     :string(255)
+#  logo           :string(255)
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  generated_name :boolean          default(TRUE), not null
 #
 
 class Institution < ApplicationRecord
@@ -21,6 +22,8 @@ class Institution < ApplicationRecord
 
   scope :of_course_by_members, ->(course) { joins(users: :courses).where(courses: { id: course.id }).distinct }
   scope :by_name, ->(name) { where('name LIKE ?', "%#{name}%").or(where('short_name LIKE ?', "%#{name}%")) }
+
+  before_update :unmark_generated, if: :will_save_change_to_name?
 
   def name
     return self[:name] unless Current.demo_mode
@@ -39,5 +42,9 @@ class Institution < ApplicationRecord
 
   def uses_smartschool?
     providers.any? { |provider| provider.type == Provider::Smartschool.name }
+  end
+
+  def unmark_generated
+    self.generated_name = false
   end
 end

--- a/app/models/institution.rb
+++ b/app/models/institution.rb
@@ -20,6 +20,7 @@ class Institution < ApplicationRecord
   validates :logo, :short_name, presence: true
 
   scope :of_course_by_members, ->(course) { joins(users: :courses).where(courses: { id: course.id }).distinct }
+  scope :by_name, ->(name) { where('name LIKE ?', "%#{name}%").or(where('short_name LIKE ?', "%#{name}%")) }
 
   def name
     return self[:name] unless Current.demo_mode

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -51,6 +51,10 @@ class Provider < ApplicationRecord
     raise 'Unknown provider type.'
   end
 
+  def self.extract_institution_name(_auth_hash)
+    [Institution::NEW_INSTITUTION_NAME, Institution::NEW_INSTITUTION_NAME]
+  end
+
   private
 
   def at_least_one_preferred

--- a/app/models/provider/g_suite.rb
+++ b/app/models/provider/g_suite.rb
@@ -27,4 +27,15 @@ class Provider::GSuite < Provider
   def self.sym
     :google_oauth2
   end
+
+  def self.extract_institution_name(auth_hash)
+    # The institution is the domain
+    institution = auth_hash&.info&.institution
+
+    if institution.present?
+      [institution, institution]
+    else
+      Provider.extract_institution_name(auth_hash)
+    end
+  end
 end

--- a/app/models/provider/lti.rb
+++ b/app/models/provider/lti.rb
@@ -27,4 +27,8 @@ class Provider::Lti < Provider
   def self.sym
     :lti
   end
+
+  def self.extract_institution_name(auth_hash)
+    Provider.extract_institution_name(auth_hash)
+  end
 end

--- a/app/models/provider/office365.rb
+++ b/app/models/provider/office365.rb
@@ -27,4 +27,14 @@ class Provider::Office365 < Provider
   def self.sym
     :office365
   end
+
+  def self.extract_institution_name(auth_hash)
+    # Office 365 has no useful information, so take the domain name of the email.
+    mail = auth_hash&.info&.email
+
+    return Provider.extract_institution_name(auth_hash) unless mail =~ URI::MailTo::EMAIL_REGEXP
+
+    domain = Mail::Address.new(mail).domain
+    [domain, domain]
+  end
 end

--- a/app/models/provider/saml.rb
+++ b/app/models/provider/saml.rb
@@ -33,4 +33,8 @@ class Provider::Saml < Provider
   def self.sym
     :saml
   end
+
+  def self.extract_institution_name(auth_hash)
+    Provider.extract_institution_name(auth_hash)
+  end
 end

--- a/app/models/provider/smartschool.rb
+++ b/app/models/provider/smartschool.rb
@@ -27,4 +27,20 @@ class Provider::Smartschool < Provider
   def self.sym
     :smartschool
   end
+
+  SMARTSCHOOL_SUFFIX = '.smartschool.be'.freeze
+
+  def self.extract_institution_name(auth_hash)
+    institution = auth_hash&.info&.institution
+
+    # Sanity check
+    return Provider.extract_institution_name(auth_hash) unless institution =~ URI::DEFAULT_PARSER.make_regexp
+
+    uri = URI.parse(institution)
+    host = uri.host
+    return Provider.extract_institution_name(auth_hash) unless host.end_with?(SMARTSCHOOL_SUFFIX)
+
+    school_name = host.delete_suffix SMARTSCHOOL_SUFFIX
+    [school_name, school_name]
+  end
 end

--- a/app/views/institutions/_institution_table.html.erb
+++ b/app/views/institutions/_institution_table.html.erb
@@ -13,7 +13,12 @@
     <tbody>
     <% institutions.each do |institution| %>
       <tr>
-        <td><%= link_to institution.name, institution %></td>
+        <td>
+          <%= link_to institution.name, institution %>
+          <% if institution.generated_name? %>
+            <span class="generated-name-icon" title="<%= t 'institutions.index.generated_name' %>"><i class="mdi mdi-18 mdi-cogs icon"></i></span>
+          <% end %>
+        </td>
         <td><%= institution.short_name %></td>
         <td><%= link_to institution.users.length, users_url(institution_id: institution.id) %></td>
         <td><%= link_to institution.courses.length, courses_url(institution_id: institution.id) %></td>

--- a/app/views/institutions/_institution_table.html.erb
+++ b/app/views/institutions/_institution_table.html.erb
@@ -1,0 +1,36 @@
+<div class="table-scroll-wrapper">
+  <table class="table table-index table-resource">
+    <thead>
+    <tr>
+      <th><%= Institution.human_attribute_name(:name) %></th>
+      <th><%= Institution.human_attribute_name(:short_name) %></th>
+      <th><%= t('institutions.index.number_of_users') %></th>
+      <th><%= t('institutions.index.number_of_courses') %></th>
+      <th><%= Institution.human_attribute_name(:providers) %></th>
+      <th class="actions"></th>
+    </tr>
+    </thead>
+    <tbody>
+    <% institutions.each do |institution| %>
+      <tr>
+        <td><%= link_to institution.name, institution %></td>
+        <td><%= institution.short_name %></td>
+        <td><%= link_to institution.users.length, users_url(institution_id: institution.id) %></td>
+        <td><%= link_to institution.courses.length, courses_url(institution_id: institution.id) %></td>
+        <td><%= institution.providers.map { |p| t("activerecord.attributes.provider.#{p.class.sym}") }.join(',') %></td>
+        <td class="actions">
+          <% if policy(institution).edit? %>
+            <%= link_to edit_institution_path(institution), title: t("institutions.index.edit"), class: "btn btn-sm btn-default" do %>
+              <i class="mdi mdi-pencil mdi-18"></i>
+            <% end %>
+          <% end %>
+        </td>
+      </tr>
+    <% end %>
+    </tbody>
+  </table>
+</div>
+<% if institutions.empty? %>
+  <p class="text-center text-muted lead table-placeholder"><%= t 'institutions.index.no_institutions' %></p>
+<% end %>
+<center><%= page_navigation_links institutions, true, 'institutions', {} %></center>

--- a/app/views/institutions/index.html.erb
+++ b/app/views/institutions/index.html.erb
@@ -5,37 +5,9 @@
         <h2 class="card-title-text"><%= t('.title') %></h2>
       </div>
       <div class="card-supporting-text">
-        <div class="table-scroll-wrapper">
-          <table class="table table-index table-resource">
-            <thead>
-            <tr>
-              <th><%= Institution.human_attribute_name(:name) %></th>
-              <th><%= Institution.human_attribute_name(:short_name) %></th>
-              <th><%= t('.number_of_users') %></th>
-              <th><%= t('.number_of_courses') %></th>
-              <th><%= Institution.human_attribute_name(:providers) %></th>
-              <th class="actions"></th>
-            </tr>
-            </thead>
-            <tbody>
-            <% @institutions.each do |institution| %>
-              <tr>
-                <td><%= link_to institution.name, institution %></td>
-                <td><%= institution.short_name %></td>
-                <td><%= link_to institution.users.length, users_url(institution_id: institution.id) %></td>
-                <td><%= link_to institution.courses.length, courses_url(institution_id: institution.id) %></td>
-                <td><%= institution.providers.map { |p| t("activerecord.attributes.provider.#{p.class.sym}") }.join(',') %></td>
-                <td class="actions">
-                  <% if policy(institution).edit? %>
-                    <%= link_to edit_institution_path(institution), title: t("institutions.index.edit"), class: "btn btn-sm btn-default" do %>
-                      <i class="mdi mdi-pencil mdi-18"></i>
-                    <% end %>
-                  <% end %>
-                </td>
-              </tr>
-            <% end %>
-            </tbody>
-          </table>
+        <%= render partial: 'layouts/searchbar' %>
+        <div id="institution-table-wrapper">
+          <%= render partial: 'institution_table', locals: {institutions: @institutions, pagination_opts: @pagination_opts} %>
         </div>
       </div>
     </div>

--- a/app/views/institutions/index.js.erb
+++ b/app/views/institutions/index.js.erb
@@ -1,0 +1,1 @@
+$("#institution-table-wrapper").html("<%= escape_javascript(render partial: 'institutions/institution_table', locals: {institutions: @institutions, pagination_opts: @pagination_opts }) %>");

--- a/app/views/institutions/show.html.erb
+++ b/app/views/institutions/show.html.erb
@@ -5,6 +5,9 @@
         <div>
           <span class="profile-line">
             <span class="name"><%= @institution.name %></span> (<%= @institution.short_name %>)
+            <% if @institution.generated_name? %>
+              <span class="generated-name-icon" title="<%= t 'institutions.index.generated_name' %>"><i class="mdi mdi-18 mdi-cogs icon"></i></span>
+            <% end %>
           </span>
         </div>
         <div class="row">

--- a/config/locales/views/institutions/en.yml
+++ b/config/locales/views/institutions/en.yml
@@ -6,6 +6,7 @@ en:
       number_of_courses: "Courses"
       edit: "Edit institution"
       no_institutions: "No institutions found"
+      generated_name: "Generated from available data."
     show:
       staff: "Staff"
       edit: "Edit institution"

--- a/config/locales/views/institutions/en.yml
+++ b/config/locales/views/institutions/en.yml
@@ -5,6 +5,7 @@ en:
       number_of_users: "Users"
       number_of_courses: "Courses"
       edit: "Edit institution"
+      no_institutions: "No institutions found"
     show:
       staff: "Staff"
       edit: "Edit institution"

--- a/config/locales/views/institutions/nl.yml
+++ b/config/locales/views/institutions/nl.yml
@@ -6,6 +6,7 @@ nl:
       number_of_courses: "Cursussen"
       edit: "Onderwijsinstelling aanpassen"
       no_institutions: "Geen onderwijsinstellingen gevonden"
+      generated_name: "Gegenereerd uit de beschikbare data."
     show:
       staff: "Lesgevers"
       edit: "Onderwijsinstelling aanpassen"

--- a/config/locales/views/institutions/nl.yml
+++ b/config/locales/views/institutions/nl.yml
@@ -5,6 +5,7 @@ nl:
       number_of_users: "Gebruikers"
       number_of_courses: "Cursussen"
       edit: "Onderwijsinstelling aanpassen"
+      no_institutions: "Geen onderwijsinstellingen gevonden"
     show:
       staff: "Lesgevers"
       edit: "Onderwijsinstelling aanpassen"

--- a/db/migrate/20210223200809_add_generated_name_to_institutions.rb
+++ b/db/migrate/20210223200809_add_generated_name_to_institutions.rb
@@ -1,6 +1,33 @@
+require "ostruct"
+
 class AddGeneratedNameToInstitutions < ActiveRecord::Migration[6.0]
   def change
     add_column :institutions, :generated_name, :boolean, default: true, null: false
-    Institution.where.not(name: 'n/a').update_all(generated_name: false)
+
+    reversible do |dir|
+      dir.up do
+        Institution.where.not(name: 'n/a').update_all(generated_name: false)
+        # Update existing institutions if there is a preferred provider.
+        # Only for GSuite & Smartschool, since the rest is a lot of work]
+        Institution.joins(:providers)
+                   .where(generated_name: true)
+                   .where(providers: { type: %w[Provider::GSuite Provider::Smartschool] })
+                   .each do |institution|
+          provider = institution.preferred_provider
+          auth_hash = OpenStruct.new(info: OpenStruct.new(institution: provider.identifier))
+          long, short = provider.class.extract_institution_name(auth_hash)
+          institution.update_columns(name: long, short_name: short)
+        end
+      end
+      dir.down do
+        Institution.joins(:providers)
+                   .where(generated_name: true)
+                   .where(providers: { type: %w[Provider::GSuite Provider::Smartschool] })
+                   .update_all(
+                     name: Institution::NEW_INSTITUTION_NAME,
+                     short_name: Institution::NEW_INSTITUTION_NAME
+                   )
+      end
+    end
   end
 end

--- a/db/migrate/20210223200809_add_generated_name_to_institutions.rb
+++ b/db/migrate/20210223200809_add_generated_name_to_institutions.rb
@@ -1,0 +1,6 @@
+class AddGeneratedNameToInstitutions < ActiveRecord::Migration[6.0]
+  def change
+    add_column :institutions, :generated_name, :boolean, default: true, null: false
+    Institution.where.not(name: 'n/a').update_all(generated_name: false)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -283,6 +283,7 @@ ActiveRecord::Schema.define(version: 2021_03_08_102217) do
     t.string "logo"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "generated_name", default: true, null: false
   end
 
   create_table "judges", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|

--- a/test/controllers/institution_controller_test.rb
+++ b/test/controllers/institution_controller_test.rb
@@ -10,5 +10,15 @@ class InstitutionControllerTest < ActionDispatch::IntegrationTest
     sign_in create(:zeus)
   end
 
-  test_crud_actions only: %i[index show]
+  test_crud_actions only: %i[index show edit update], except: %i[update_redirect]
+
+  test 'should be able to search by institution name' do
+    i1 = create :institution, name: 'abcd'
+    i2 = create :institution, name: 'efgh'
+
+    get institutions_path, params: { filter: 'abcd' }
+
+    assert_select 'a[href=?]', institution_path(i1), 1
+    assert_select 'a[href=?]', institution_path(i2), 0
+  end
 end

--- a/test/factories/institutions.rb
+++ b/test/factories/institutions.rb
@@ -2,12 +2,13 @@
 #
 # Table name: institutions
 #
-#  id         :bigint           not null, primary key
-#  name       :string(255)
-#  short_name :string(255)
-#  logo       :string(255)
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
+#  id             :bigint           not null, primary key
+#  name           :string(255)
+#  short_name     :string(255)
+#  logo           :string(255)
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  generated_name :boolean          default(TRUE), not null
 #
 
 FactoryBot.define do

--- a/test/factories/institutions.rb
+++ b/test/factories/institutions.rb
@@ -12,7 +12,7 @@
 #
 
 FactoryBot.define do
-  factory :institution, class: Institution do
+  factory :institution, class: 'Institution' do
     name { Faker::University.unique.name }
     short_name { name.gsub(/\s+/, '') }
     logo { 'logo.png' }

--- a/test/factories/providers.rb
+++ b/test/factories/providers.rb
@@ -20,12 +20,12 @@
 #  jwks_uri          :string(255)
 #
 FactoryBot.define do
-  factory :gsuite_provider, class: Provider::GSuite do
+  factory :gsuite_provider, class: 'Provider::GSuite' do
     institution
     identifier { SecureRandom.uuid }
   end
 
-  factory :lti_provider, class: Provider::Lti do
+  factory :lti_provider, class: 'Provider::Lti' do
     institution
 
     authorization_uri { Faker::Internet.url }
@@ -34,12 +34,12 @@ FactoryBot.define do
     jwks_uri { Faker::Internet.url }
   end
 
-  factory :office365_provider, class: Provider::Office365 do
+  factory :office365_provider, class: 'Provider::Office365' do
     institution
     identifier { SecureRandom.uuid }
   end
 
-  factory :provider, aliases: [:saml_provider], class: Provider::Saml do
+  factory :provider, aliases: [:saml_provider], class: 'Provider::Saml' do
     institution
 
     entity_id { Faker::Internet.url }
@@ -48,7 +48,7 @@ FactoryBot.define do
     certificate { Faker::Crypto.sha256 }
   end
 
-  factory :smartschool_provider, class: Provider::Smartschool do
+  factory :smartschool_provider, class: 'Provider::Smartschool' do
     institution
     identifier { "https://#{institution.short_name}.smartschool.be" }
   end

--- a/test/models/institution_test.rb
+++ b/test/models/institution_test.rb
@@ -18,12 +18,12 @@ class InstitutionTest < ActiveSupport::TestCase
     create :institution
   end
 
-  test 'get prefered provider' do
+  test 'get preferred provider' do
     institution = create :institution
-    prefered = create :provider, institution: institution
+    preferred = create :provider, institution: institution
     create_list :provider, 4, institution: institution, mode: :redirect
 
-    assert prefered, institution.preferred_provider
+    assert preferred, institution.preferred_provider
   end
 
   test 'generated name is unmarked if name is updated' do

--- a/test/models/institution_test.rb
+++ b/test/models/institution_test.rb
@@ -2,12 +2,13 @@
 #
 # Table name: institutions
 #
-#  id         :bigint           not null, primary key
-#  name       :string(255)
-#  short_name :string(255)
-#  logo       :string(255)
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
+#  id             :bigint           not null, primary key
+#  name           :string(255)
+#  short_name     :string(255)
+#  logo           :string(255)
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  generated_name :boolean          default(TRUE), not null
 #
 
 require 'test_helper'
@@ -23,5 +24,16 @@ class InstitutionTest < ActiveSupport::TestCase
     create_list :provider, 4, institution: institution, mode: :redirect
 
     assert prefered, institution.preferred_provider
+  end
+
+  test 'generated name is unmarked if name is updated' do
+    institution = create :institution
+    assert institution.generated_name?
+
+    institution.update(logo: 'blabla')
+    assert institution.generated_name?
+
+    institution.update(name: 'Hallo')
+    assert_not institution.generated_name?
   end
 end

--- a/test/models/provider_test.rb
+++ b/test/models/provider_test.rb
@@ -22,6 +22,8 @@
 require 'test_helper'
 
 class ProviderTest < ActiveSupport::TestCase
+  DEFAULT_NAMES = [Institution::NEW_INSTITUTION_NAME, Institution::NEW_INSTITUTION_NAME].freeze
+
   test 'provider factories' do
     AUTH_PROVIDERS.each do |provider|
       create provider
@@ -43,5 +45,84 @@ class ProviderTest < ActiveSupport::TestCase
 
     second = build :provider, institution: institution
     assert_not second.valid?
+  end
+
+  test 'gsuite extracts name of institution' do
+    # This hash is extracted from the one we receive when logging in.
+    provider = Provider::GSuite
+    hash = {
+      provider: 'google_oauth2',
+      uid: 'something',
+      info: {
+        name: 'Jan Janssens',
+        email: 'janssens@example.com',
+        first_name: 'Jan',
+        last_name: 'Janssens',
+        institution: 'example.com'
+      }
+    }
+    hash = OmniAuth::AuthHash.new(hash)
+    assert_equal %w[example.com example.com], provider.extract_institution_name(hash)
+
+    assert_equal DEFAULT_NAMES, provider.extract_institution_name(OmniAuth::AuthHash.new({}))
+    assert_equal DEFAULT_NAMES, provider.extract_institution_name(OmniAuth::AuthHash.new({ info: {} }))
+  end
+
+  test 'smartschool extracts name of institution' do
+    provider = Provider::Smartschool
+    # This hash is extracted from the one we receive when logging in.
+    hash = {
+      provider: 'smartschool',
+      uid: 'something',
+      info: {
+        username: 'janj',
+        first_name: 'Jan',
+        last_name: 'Janssens',
+        email: 'example@example.com',
+        institution: 'https://test.smartschool.be'
+      }
+    }
+    hash = OmniAuth::AuthHash.new(hash)
+    assert_equal %w[test test], provider.extract_institution_name(hash)
+
+    # Do tests to ensure it works for "invalid" input
+    hash.info.institution = 'not-url'
+    assert_equal DEFAULT_NAMES, provider.extract_institution_name(hash)
+
+    hash.info.institution = 'http://www.example.com'
+    assert_equal DEFAULT_NAMES, provider.extract_institution_name(hash)
+
+    assert_equal DEFAULT_NAMES, provider.extract_institution_name(OmniAuth::AuthHash.new({}))
+    assert_equal DEFAULT_NAMES, provider.extract_institution_name(OmniAuth::AuthHash.new({ info: {} }))
+  end
+
+  test 'office365 extracts name of institution' do
+    provider = Provider::Office365
+    # This hash is extracted from the one we receive when logging in.
+    hash = {
+      provider: 'office365',
+      uid: 'something',
+      info: {
+        username: 'janj',
+        first_name: 'Jan',
+        last_name: 'Janssens',
+        email: 'example@example.com',
+        institution: 'useless-for-human-identifier'
+      }
+    }
+    hash = OmniAuth::AuthHash.new(hash)
+    assert_equal %w[example.com example.com], provider.extract_institution_name(hash)
+
+    hash.info.email = 'not an email anymore'
+    assert_equal DEFAULT_NAMES, provider.extract_institution_name(hash)
+
+    assert_equal DEFAULT_NAMES, provider.extract_institution_name(OmniAuth::AuthHash.new({}))
+    assert_equal DEFAULT_NAMES, provider.extract_institution_name(OmniAuth::AuthHash.new({ info: {} }))
+  end
+
+  test 'other providers use default' do
+    [Provider::Lti, Provider::Saml].each do |provider|
+      assert_equal DEFAULT_NAMES, provider.extract_institution_name(OmniAuth::AuthHash.new({}))
+    end
   end
 end


### PR DESCRIPTION
Part of #2452, implements two of the suggestions:

- Adds pagination & search to institution page
- Better default names for institutions
   - Smartschool: subdomain (e.g. `name` in `[name].smartschool.be`)
   - GSuite: the domain itself (e.g. `example.com`)
   - Office365: the domain of the email of the user
   - Others (LTI, Saml): no change
   
- [x] Tests were added