### PR TITLE
Split programming language renderer and editor name

### DIFF
--- a/app/helpers/renderers/feedback_table_renderer.rb
+++ b/app/helpers/renderers/feedback_table_renderer.rb
@@ -24,7 +24,7 @@ class FeedbackTableRenderer
     @code = submission.code
     @user = user
     @exercise = submission.exercise
-    @programming_language = @exercise.programming_language&.editor_name
+    @programming_language = @exercise.programming_language&.renderer_name
   end
 
   def parse

--- a/app/models/programming_language.rb
+++ b/app/models/programming_language.rb
@@ -20,6 +20,7 @@ class ProgrammingLanguage < ApplicationRecord
 
   def fill_fields
     self.editor_name ||= name
+    self.renderer_name ||= name
     self.extension ||= 'txt'
   end
 

--- a/app/policies/programming_language_policy.rb
+++ b/app/policies/programming_language_policy.rb
@@ -27,7 +27,7 @@ class ProgrammingLanguagePolicy < ApplicationPolicy
 
   def permitted_attributes
     if user&.zeus?
-      %i[name extension editor_name icon]
+      %i[name extension editor_name renderer_name icon]
     else
       []
     end

--- a/app/views/activities/info.html.erb
+++ b/app/views/activities/info.html.erb
@@ -187,7 +187,7 @@
                       <%= link_to t('.sample_solution_submit'), activity_scoped_url(activity: @activity, series: @series, course: @course, options: {from_solution: fname}), class: "btn-text" %>
                     </div>
                     <div class="code-table">
-                      <%= raw FeedbackCodeRenderer.new(code, @activity.programming_language&.editor_name).add_code.html %>
+                      <%= raw FeedbackCodeRenderer.new(code, @activity.programming_language&.renderer_name).add_code.html %>
                     </div>
                   </div>
                 <% end %>

--- a/app/views/programming_languages/_form.html.erb
+++ b/app/views/programming_languages/_form.html.erb
@@ -20,6 +20,11 @@
   </div>
 
   <div class="field form-group">
+    <%= f.label :renderer_name, :class => "col-sm-3 control-label" %>
+    <div class="col-sm-4"><%= f.text_field :renderer_name, class: "form-control" %></div>
+  </div>
+
+  <div class="field form-group">
     <%= f.label :extension, :class => "col-sm-3 control-label" %>
     <div class="col-sm-4"><%= f.text_field :extension, class: "form-control" %></div>
   </div>

--- a/app/views/programming_languages/_programming_language.json.jbuilder
+++ b/app/views/programming_languages/_programming_language.json.jbuilder
@@ -1,2 +1,2 @@
-json.extract! programming_language, :id, :name, :editor_name, :extension, :created_at, :updated_at
+json.extract! programming_language, :id, :name, :editor_name, :renderer_name, :extension, :created_at, :updated_at
 json.url programming_language_url(programming_language, format: :json)

--- a/app/views/programming_languages/index.html.erb
+++ b/app/views/programming_languages/index.html.erb
@@ -24,6 +24,9 @@
                 <%= ProgrammingLanguage.human_attribute_name("editor_name") %>
               </th>
               <th>
+                <%= ProgrammingLanguage.human_attribute_name("renderer_name") %>
+              </th>
+              <th>
                 <%= ProgrammingLanguage.human_attribute_name("extension") %>
               </th>
               <th>
@@ -45,6 +48,9 @@
                 </td>
                 <td>
                   <%= programming_language.editor_name %>
+                </td>
+                <td>
+                  <%= programming_language.renderer_name %>
                 </td>
                 <td>
                   <%= programming_language.extension %>

--- a/app/views/programming_languages/show.html.erb
+++ b/app/views/programming_languages/show.html.erb
@@ -17,6 +17,10 @@
           <%= @programming_language.editor_name %>
         </p>
         <p>
+          <strong><%= ProgrammingLanguage.human_attribute_name("renderer_name") %></strong>
+          <%= @programming_language.renderer_name %>
+        </p>
+        <p>
           <strong><%= ProgrammingLanguage.human_attribute_name("extension") %></strong>
           <%= @programming_language.extension %>
         </p>

--- a/config/locales/models/en.yml
+++ b/config/locales/models/en.yml
@@ -137,6 +137,7 @@ en:
       programming_language:
         name: Name
         editor_name: Editor mode
+        renderer_name: Renderer name
         extension: Extension
       institution:
         name: Name

--- a/config/locales/models/nl.yml
+++ b/config/locales/models/nl.yml
@@ -138,6 +138,7 @@ nl:
       programming_language:
         name: Naam
         editor_name: Editor modus
+        renderer_name: Renderer naam
         extension: Extensie
       institution:
         name: Naam

--- a/db/migrate/20210222143708_split_programming_language_ace_and_rouge.rb
+++ b/db/migrate/20210222143708_split_programming_language_ace_and_rouge.rb
@@ -1,0 +1,9 @@
+class SplitProgrammingLanguageAceAndRouge < ActiveRecord::Migration[6.0]
+  def change
+    add_column :programming_languages, :renderer_name, :string
+    ProgrammingLanguage.all.each do |pl|
+      pl.update(renderer_name: pl.editor_name)
+    end
+    change_column_null :programming_languages, :renderer_name, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_24_072242) do
+ActiveRecord::Schema.define(version: 2021_02_22_143708) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
@@ -312,6 +312,7 @@ ActiveRecord::Schema.define(version: 2020_09_24_072242) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "icon"
+    t.string "renderer_name", null: false
     t.index ["name"], name: "index_programming_languages_on_name", unique: true
   end
 

--- a/test/controllers/programming_languages_controller_test.rb
+++ b/test/controllers/programming_languages_controller_test.rb
@@ -1,7 +1,7 @@
 class ProgrammingLanguagesControllerTest < ActionDispatch::IntegrationTest
   extend CRUDTest
 
-  crud_helpers ProgrammingLanguage, attrs: %i[name editor_name extension]
+  crud_helpers ProgrammingLanguage, attrs: %i[name editor_name renderer_name extension]
 
   def setup
     @instance = create :programming_language

--- a/test/factories/programming_languages.rb
+++ b/test/factories/programming_languages.rb
@@ -14,6 +14,7 @@ FactoryBot.define do
   factory :programming_language do
     name { "#{Faker::ProgrammingLanguage.name}#{Faker::Number.unique.positive}" }
     editor_name { name }
+    renderer_name { name }
     extension { name }
   end
 end


### PR DESCRIPTION
This pull request splits out the name of the programming language used for rouge from the name used for ACE. These names aren't the same for C.

Closes #2486. (Or better, this allows us to fix #2486.)
