### PR TITLE
Make question policy nil aware

### DIFF
--- a/app/policies/question_policy.rb
+++ b/app/policies/question_policy.rb
@@ -20,7 +20,7 @@ class QuestionPolicy < AnnotationPolicy
     # Only the course admins can transition, except for the answered state.
     return true if to.to_s == 'answered' && record.user == user
 
-    user.course_admin?(record.submission.course)
+    user&.course_admin?(record.submission.course)
   end
 
   def update?

--- a/test/controllers/annotations_controller_test.rb
+++ b/test/controllers/annotations_controller_test.rb
@@ -473,6 +473,19 @@ class QuestionAnnotationControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test 'questions cannot transition if logged out' do
+    sign_out @submission.user
+    question = create :question, submission: @submission, question_state: :unanswered
+    patch annotation_path(question), params: {
+      from: question.question_state,
+      question: {
+        question_state: :answered
+      },
+      format: :json
+    }
+    assert_response :unauthorized
+  end
+
   test 'question cannot transition if already changed' do
     sign_in create :zeus
 


### PR DESCRIPTION
This pull request fixes a bug in the `transition?` method when no-one is logged in.

<!-- If there are visual changes, add a screenshot -->

- [x] Tests were added
- [ ] Documentation update can be found at dodona-edu/dodona-edu.github.io#

Closes #2505.
