### PR TITLE
Don't assume question if not logged in

### DIFF
--- a/app/controllers/annotations_controller.rb
+++ b/app/controllers/annotations_controller.rb
@@ -47,7 +47,10 @@ class AnnotationsController < ApplicationController
   def show; end
 
   def create
-    clazz = if current_user&.course_admin?(@submission.course)
+    # Fail fast if not logged in; otherwise we would always assume a question.
+    raise Pundit::NotAuthorizedError, 'Unauthorized' if current_user.blank?
+
+    clazz = if current_user.course_admin?(@submission.course)
               Annotation
             else
               Question

--- a/test/controllers/annotations_controller_test.rb
+++ b/test/controllers/annotations_controller_test.rb
@@ -31,6 +31,19 @@ class AnnotationControllerTest < ActionDispatch::IntegrationTest
     assert_response :created
   end
 
+  test "creating annotation when logged out doesn't result in question creating" do
+    sign_out @zeus
+    post submission_annotations_url(@submission), params: {
+      annotation: {
+        line_nr: 1,
+        annotation_text: 'Not available'
+      },
+      format: :json
+    }
+
+    assert_response :unauthorized
+  end
+
   test 'pagination is generated correctly' do
     submission = create :submission, :within_course
     create_list :question, 31, submission: submission


### PR DESCRIPTION
This pull request fixes another bug in questions/annotations when a user is nog logged in. When the user is not logged in, the code assumed the user wanted to create a question, which results in `ActionController::ParameterMissing` instead of the appropriate `unauthorized` when they actually wanted to create an annotation.

- [x] Tests were added
- [ ] Documentation update can be found at dodona-edu/dodona-edu.github.io#

Not specifically #2505, but related.
