### PR TITLE
Fix activity completion fields not being scoped to series (when available)

### DIFF
--- a/app/views/activities/_activity.json.jbuilder
+++ b/app/views/activities/_activity.json.jbuilder
@@ -8,11 +8,11 @@ if activity.exercise?
   json.programming_language activity.programming_language
   if current_user
     json.last_solution_is_best activity.best_is_last_submission?(current_user, series)
-    json.has_solution activity.started_for?(current_user)
-    json.has_correct_solution activity.solved_for?(current_user)
+    json.has_solution activity.started_for?(current_user, series)
+    json.has_correct_solution activity.solved_for?(current_user, series)
   end
 elsif activity.content_page?
-  json.has_read activity.solved_for?(current_user) if current_user
+  json.has_read activity.solved_for?(current_user, series) if current_user
 end
 json.description_url description_activity_url(activity, token: activity.access_token)
 json.url activity_scoped_url(activity: activity, series: series, course: course, options: { format: :json })


### PR DESCRIPTION
This pull request changes the activity json jbuilder to take into account the series the activity is scoped in (when available). Activities will only take into account submissions or activity read states that were done in the course the series is linked to. This bug was introduced in https://github.com/dodona-edu/dodona/commit/cfb76694282738d27a55cf1148ac93a6402b6597, so has been in Dodona for as long as the API exists.

- [x] Tests were added

Closes #2523.
