### PR TITLE
Use denormalized course_id in annotations in question index

### DIFF
--- a/app/controllers/annotations_controller.rb
+++ b/app/controllers/annotations_controller.rb
@@ -27,9 +27,9 @@ class AnnotationsController < ApplicationController
     # By default, filter only for the courses a user is an admin of, unless we are in filtering by course or user, or
     # the user has explicitly asked to view all questions.
     if @unfiltered && current_user&.a_course_admin? && !ActiveRecord::Type::Boolean.new.deserialize(params[:everything])
-      @questions = @questions
-                   .joins(:submission)
-                   .where(submissions: { course_id: current_user.administrating_courses.map(&:id) })
+      @questions = @questions.where(
+        course_id: current_user.administrating_courses.map(&:id)
+      )
     end
 
     # Preload dependencies for efficiency

--- a/test/controllers/annotations_controller_test.rb
+++ b/test/controllers/annotations_controller_test.rb
@@ -51,6 +51,25 @@ class AnnotationControllerTest < ActionDispatch::IntegrationTest
     assert_select 'a[href=?]', questions_path(page: 2, everything: true)
   end
 
+  test 'questions should from courses should be shown to course admins' do
+    u = create :user
+    sign_in u
+    s1 = create :course_submission, user: u
+    s2 = create :course_submission, user: u
+    s3 = create :course_submission, user: u
+    create :question, submission: s1
+    create :question, submission: s2
+    create :question, submission: s3
+    admin = create :user
+    admin.administrating_courses << s1.course
+    admin.administrating_courses << s2.course
+
+    sign_in admin
+    get questions_url(format: :json)
+
+    assert_equal 2, JSON.parse(response.body).count
+  end
+
   test 'should be able to search by exercise name' do
     u = create :user
     sign_in u


### PR DESCRIPTION
This pull request make sure the new `question_index` page uses the new denormalized `course_id` in annotations.
