### PR TITLE
Fix n+1 loading evaluations for series on course show

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -36,7 +36,7 @@ class CoursesController < ApplicationController
       return if performed?
     end
     @title = @course.name
-    @series = policy_scope(@course.series)
+    @series = policy_scope(@course.series).includes(:evaluation)
     @series_loaded = params[:secret].present? ? @course.series.count : 2
   end
 


### PR DESCRIPTION
This pull request makes sure evaluations are loaded eagerly on course show.

Closes #2528.
