### PR TITLE
Fix missing <li> in view feedback link on series

### DIFF
--- a/app/views/series/_series.html.erb
+++ b/app/views/series/_series.html.erb
@@ -107,9 +107,11 @@
             </li>
           <% end %>
           <% if series.evaluation.present? && policy(series.evaluation).overview? %>
+            <li>
               <%= link_to overview_evaluation_path(series.evaluation) do %>
                 <i class='mdi mdi-message-draw mdi-18'></i> <%= t("series.show.evaluation_overview") %>
               <% end %>
+            </li>
           <% end %>
         </ul>
       </div>


### PR DESCRIPTION
This pull request fixes a missing `<li>`  in the view feedback link on series.

Before:
![image](https://user-images.githubusercontent.com/1756811/112987398-f8af6980-9162-11eb-8aed-345c08016013.png)

After:
![image](https://user-images.githubusercontent.com/1756811/112987417-fea54a80-9162-11eb-9a41-aef8c3ec0a20.png)
