### PR TITLE
Don't deploy on review requested

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,6 @@ name: Deploy
 on:
   pull_request:
     types:
-      - review_requested
       - labeled
 
 jobs:


### PR DESCRIPTION
This pull request tweaks the auto-deploy behaviour. It no longer deploys automatically on "review request" because this fails when multiple users are selected. Adding the "deploy" label remains the preferred way of deploying.
