### PR TITLE
include judge in internal error notification

### DIFF
--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -381,6 +381,7 @@ class Submission < ApplicationRecord
       Exception.new("Submission(#{id}) status was changed to internal error"),
       data: {
         host: `hostname`,
+        judge: judge.name,
         submission: inspect,
         url: Rails.application.routes.url_helpers.submission_url('en', self, host: Rails.application.config.default_host)
       }

--- a/test/models/submission_test.rb
+++ b/test/models/submission_test.rb
@@ -289,7 +289,7 @@ class SubmissionTest < ActiveSupport::TestCase
 
   test 'update to internal error should send exception notification' do
     submission = create :submission
-    ExceptionNotifier.expects(:notify_exception).with { |_e, data| data[:data][:url].present? }
+    ExceptionNotifier.expects(:notify_exception).with { |_e, data| data[:data][:url].present? && data[:data][:judge].present? }
     submission.update(status: :"internal error")
   end
 

--- a/test/runners/submission_runner_test.rb
+++ b/test/runners/submission_runner_test.rb
@@ -204,7 +204,7 @@ class SubmissionRunnerTest < ActiveSupport::TestCase
   test 'errors outside of docker startup should be sent to slack' do
     Delayed::Backend::ActiveRecord::Job.delete_all
     Rails.env.stubs(:"production?").returns(true)
-    Submission.any_instance.stubs(:judge).raises(STRIKE_ERROR)
+    Submission.any_instance.stubs(:judge).returns(Object.new.stubs(:name).returns(''))
     ExceptionNotifier.stubs(:notify_exception).twice
     Docker::Container.stubs(:create).returns(docker_mock)
     @submission.evaluate_delayed

--- a/test/runners/submission_runner_test.rb
+++ b/test/runners/submission_runner_test.rb
@@ -204,7 +204,12 @@ class SubmissionRunnerTest < ActiveSupport::TestCase
   test 'errors outside of docker startup should be sent to slack' do
     Delayed::Backend::ActiveRecord::Job.delete_all
     Rails.env.stubs(:"production?").returns(true)
-    Submission.any_instance.stubs(:judge).returns(Object.new.stubs(:name).returns(''))
+    # create a stubbed judge with fails when used to evaluate a submission,
+    # but which still has a name (for the ExceptionNotifier)
+    studge = Object.new
+    studge.stubs(:name).returns('Studge')
+    studge.stubs(:config).raises(STRIKE_ERROR)
+    Submission.any_instance.stubs(:judge).returns(studge)
     ExceptionNotifier.stubs(:notify_exception).twice
     Docker::Container.stubs(:create).returns(docker_mock)
     @submission.evaluate_delayed


### PR DESCRIPTION
Can be used to filter internal error mails about judges you're not
involved with.

- [x] Tests were added
- [ ] Documentation update can be found at dodona-edu/dodona-edu.github.io# (not relevant)
