### PR TITLE
Handle Unicode URLs in Smartschool name extraction

### DIFF
--- a/test/factories/institutions.rb
+++ b/test/factories/institutions.rb
@@ -13,7 +13,7 @@
 
 FactoryBot.define do
   factory :institution, class: 'Institution' do
-    name { Faker::University.unique.name }
+    name { Faker::University.unique.name.gsub(/[^[:ascii:]]/, '') }
     short_name { name.gsub(/\s+/, '') }
     logo { 'logo.png' }
   end


### PR DESCRIPTION
This pull request adds code to handle unicode in Smartschool URLs. I don't think there are Smartschool URLs with Unicode, but we never know. For now we just use the default name for Unicode URLs.

<!-- If there are visual changes, add a screenshot -->

- [ ] Tests were added
- [ ] Documentation update can be found at dodona-edu/dodona-edu.github.io#

Closes #2585.
