### PR TITLE
Enable dependabot for Github Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,3 +24,10 @@ updates:
     versions:
     - ">= 4.a"
     - "< 5"
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: weekly
+    time: "13:00"
+    timezone: Europe/Brussels
+  open-pull-requests-limit: 99


### PR DESCRIPTION
This pull request enables dependabot for Github Actions. It follows the same schedule as the existing checks.
