### PR TITLE
fewer labels for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,8 @@ updates:
     time: "13:00"
     timezone: Europe/Brussels
   open-pull-requests-limit: 99
+  default_labels:
+    - "dependencies"
   ignore:
   - dependency-name: sprockets
     versions:
@@ -19,6 +21,8 @@ updates:
     time: "13:00"
     timezone: Europe/Brussels
   open-pull-requests-limit: 99
+  default_labels:
+    - "dependencies"
   ignore:
   - dependency-name: webpack-cli
     versions:
@@ -31,3 +35,5 @@ updates:
     time: "13:00"
     timezone: Europe/Brussels
   open-pull-requests-limit: 99
+  default_labels:
+    - "dependencies"


### PR DESCRIPTION
This pull request removes the programming language label for dependabot PRs.
