### PR TITLE
Never allow annotations on submissions outside a course

### DIFF
--- a/app/policies/annotation_policy.rb
+++ b/app/policies/annotation_policy.rb
@@ -17,7 +17,7 @@ class AnnotationPolicy < ApplicationPolicy
   end
 
   def create?
-    user.course_admin?(record.submission.course)
+    record.submission.course.present? && user.course_admin?(record.submission.course)
   end
 
   def show?

--- a/test/controllers/annotations_controller_test.rb
+++ b/test/controllers/annotations_controller_test.rb
@@ -373,6 +373,18 @@ class QuestionAnnotationControllerTest < ActionDispatch::IntegrationTest
     assert_not @submission.questions.any?
   end
 
+  test 'even zeus cannot create an annotation on a submission outside of a course' do
+    sign_in create(:zeus)
+    post submission_annotations_url(create(:submission, course: nil)), params: {
+      annotation: {
+        line_nr: 1,
+        annotation_text: 'Ik heb een vraag over mijn code - Lijn'
+      },
+      format: :json
+    }
+    assert_response :forbidden
+  end
+
   test 'questions can transition from unanswered' do
     zeus = create :zeus
     staff = create :staff


### PR DESCRIPTION
This pull request makes sure even Zeus cannot (try) to create an annotation outside a course. (The button is also not shown on the code tab, it uses the policy to determine whether it should be shown.)

- [x] Tests were added

Closes #2600.
