### PR TITLE
Use "bug" instead of "bug fix" in release drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -2,7 +2,7 @@ categories:
   - title: "🚀 New Features"
     label: "feature"
   - title: "🐛 Bug Fixes"
-    label: "bug fix"
+    label: "bug"
   - title: "🧰 Maintenance"
     label: "chore"
 exclude-labels:


### PR DESCRIPTION
"Bug fix" as a label no longer exists.