### PR TITLE
Uncomplete feedback if submission is changed

### DIFF
--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -22,6 +22,7 @@ class Feedback < ApplicationRecord
   delegate :user, to: :evaluation_user
   delegate :exercise, to: :evaluation_exercise
 
+  before_save :uncomplete, if: :submission_id_changed?
   before_save :manage_annotations_after_submission_update
   before_create :generate_id
   before_create :determine_submission
@@ -77,6 +78,10 @@ class Feedback < ApplicationRecord
       new = SecureRandom.random_number(2_147_483_646)
     end until Feedback.find_by(id: new).nil?
     self.id = new
+  end
+
+  def uncomplete
+    self.completed = false
   end
 
   def manage_annotations_after_submission_update

--- a/test/models/feedback_test.rb
+++ b/test/models/feedback_test.rb
@@ -66,4 +66,15 @@ class FeedbackTest < ActiveSupport::TestCase
     feedback.update(submission_id: submission.id)
     assert_equal 0, submission.annotations.count
   end
+
+  test 'feedback is uncompleted on submission change' do
+    feedback = @evaluation.feedbacks.where.not(submission_id: nil).first
+    user = feedback.user
+    exercise = feedback.exercise
+    submission = create :submission, user: user, exercise: exercise, course: @evaluation.series.course
+
+    feedback.update(completed: true)
+    feedback.update(submission_id: submission.id)
+    assert_not feedback.completed
+  end
 end


### PR DESCRIPTION
This pull request makes sure the feedback object is not completed if the submission was changed.

- [x] Tests were added

Closes #2502.
