### PR TITLE
Make calculating recent exercises deterministic

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -222,7 +222,7 @@ class User < ApplicationRecord
 
   def recent_exercises(limit = 3)
     # If a user has submitted to a content page this will include `nil` values. So we compact to throw those away.
-    submissions.select('distinct exercise_id').limit(limit).includes(:exercise).map(&:exercise).compact
+    submissions.group(:exercise_id).reorder('MAX(id) DESC').select('exercise_id').limit(limit).includes(:exercise).map(&:exercise).compact
   end
 
   def pending_series

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -273,11 +273,11 @@ class UserTest < ActiveSupport::TestCase
 
   test 'recent_exercises should return the 3 most recent exercises submissions have been submitted' do
     user = create :user
-    exercise1 = create :exercise
-    exercise2 = create :exercise
-    create :series, exercises: [exercise1, exercise2]
-    create :submission, user: user, exercise: exercise1
-    assert_equal [exercise1], user.recent_exercises
+    exercises = (0..5).map { create :exercise }
+    create :series, exercises: exercises
+    exercises.each { |e| create :submission, user: user, exercise: e }
+    exercises.take(3).each { |e| create :submission, user: user, exercise: e }
+    assert_equal exercises.take(3).reverse, user.recent_exercises
   end
 
   test 'pending_series should return all series of the users courses that have a deadline' do


### PR DESCRIPTION
This pull request makes sure the same recent exercises are always returned, independent of database version. The generated SQL is as follows: 
```
SELECT `submissions`.`exercise_id` FROM `submissions` WHERE `submissions`.`user_id` = 1 GROUP BY `submissions`.`exercise_id` ORDER BY MAX(id) DESC LIMIT 5
```

I expanded the test case to try to catch regressions, but note that mariadb and and at least some versions of mysql actually pass the expanded test as well.

- [x] Tests were added

Closes #2279.
