### PR TITLE
Disable spring in github actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,7 @@ jobs:
   ruby:
     name: Ruby
     env:
+      DISABLE_SPRING: "true"
       RAILS_ENV: "test"
       TEST_DATABASE_URL: "mysql2://root:dodona@127.0.0.1:3306/dodona_test"
     runs-on: ubuntu-latest
@@ -84,6 +85,7 @@ jobs:
   system:
     name: System
     env:
+      DISABLE_SPRING: "true"
       RAILS_ENV: "test"
       TEST_DATABASE_URL: "mysql2://root:dodona@127.0.0.1:3306/dodona_test"
     runs-on: ubuntu-latest


### PR DESCRIPTION
It doesn't really do anything in CI anyway, and it messes with our coverage reports: https://github.com/simplecov-ruby/simplecov/issues/671.
