### PR TITLE
Make activities in hidden series inaccessible to non-members

### DIFF
--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -255,6 +255,8 @@ class Activity < ApplicationRecord
     if course.present?
       if user&.course_admin? course
         return false unless course.activities.pluck(:id).include? id
+      elsif user&.member_of? course
+        return false unless course.accessible_activities.pluck(:id).include? id
       else
         return false unless course.visible_activities.pluck(:id).include? id
       end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -71,20 +71,19 @@ class Course < ApplicationRecord
            through: :series_memberships,
            source: :activity
 
-  has_many :visible_activities,
+  has_many :accessible_activities,
            lambda {
              where(series: { visibility: %i[open hidden] }).distinct
            },
            through: :series,
            source: :activities
 
-  # TODO: Remove and use activities?
-  has_many :visible_exercises,
+  has_many :visible_activities,
            lambda {
-             where(series: { visibility: %i[open hidden] }).distinct
+             where(series: { visibility: %i[open] }).distinct
            },
            through: :series,
-           source: :exercises
+           source: :activities
 
   has_many :subscribed_members,
            lambda {

--- a/test/controllers/submissions_controller_test.rb
+++ b/test/controllers/submissions_controller_test.rb
@@ -171,6 +171,21 @@ class SubmissionsControllerTest < ActionDispatch::IntegrationTest
     assert_response :unprocessable_entity
   end
 
+  test 'unregistered user submitting to exercise in hidden series should fail' do
+    attrs = generate_attr_hash
+    course = create :course
+    exercise = Exercise.find(attrs[:exercise_id])
+    course.series << create(:series, visibility: :hidden)
+    course.series.first.exercises << exercise
+    attrs[:course_id] = course.id
+    user = create :user
+    sign_in user
+
+    create_request attr_hash: attrs
+
+    assert_response :unprocessable_entity
+  end
+
   test 'should get submission edit page' do
     get edit_submission_path(@instance)
     assert_redirected_to activity_url(

--- a/test/models/exercise_test.rb
+++ b/test/models/exercise_test.rb
@@ -149,6 +149,13 @@ class ExerciseTest < ActiveSupport::TestCase
     assert_not exercise.accessible?(@user, course)
   end
 
+  test 'exercise should not be accessible if included via hidden series and user is not a member' do
+    exercise = create :exercise
+    course = create :course
+    create :series, course: course, exercises: [exercise], visibility: :hidden
+    assert_not exercise.accessible?(@user, course)
+  end
+
   test 'convert_visibility_to_access should convert "visible" to "public"' do
     assert_equal 'public', Exercise.convert_visibility_to_access('visible')
   end


### PR DESCRIPTION
This is a bigger behaviour change than strictly necessary. Keeping the
access rights for viewing and submitting the same seems important to
me though.

- [x] Tests were added

Closes #2432.
