### PR TITLE
Fix more caching issues

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -57,6 +57,9 @@ Rails/HelperInstanceVariable:
   Enabled: false
 Rails/OutputSafety:
   Enabled: false
+Rails/SkipsModelValidations:
+  AllowedMethods:
+    - touch
 Rails/UnknownEnv:
   Environments:
     - development

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -25,16 +25,15 @@ class Series < ApplicationRecord
   include Cacheable
   include Tokenable
 
-  USER_COMPLETED_CACHE_STRING = '/series/%<id>s/user/%<user_id>s/completed'.freeze
-  USER_STARTED_CACHE_STRING = '/series/%<id>s/user/%<user_id>s/started'.freeze
-  USER_WRONG_CACHE_STRING = '/series/%<id>s/user/%<user_id>s/wrong'.freeze
+  USER_COMPLETED_CACHE_STRING = '/series/%<id>s/user/%<user_id>s/completed/%<updated_at>s/%<deadline>s'.freeze
+  USER_STARTED_CACHE_STRING = '/series/%<id>s/user/%<user_id>s/started/%<updated_at>s'.freeze
+  USER_WRONG_CACHE_STRING = '/series/%<id>s/user/%<user_id>s/wrong/%<updated_at>s'.freeze
 
   enum visibility: { open: 0, hidden: 1, closed: 2 }
 
   before_save :regenerate_activity_tokens, if: :visibility_changed?
   before_create :generate_access_token
-  before_destroy :set_being_destroyed
-  after_save :invalidate_activity_statuses_and_caches, if: :saved_change_to_deadline?
+  after_save :invalidate_activity_statuses, if: :saved_change_to_deadline?
 
   belongs_to :course
   has_many :series_memberships, dependent: :destroy
@@ -94,7 +93,7 @@ class Series < ApplicationRecord
   end
 
   invalidateable_instance_cacheable(:completed?,
-                                    ->(this, options) { format(USER_COMPLETED_CACHE_STRING, user_id: options[:user].id.to_s, id: this.id.to_s) })
+                                    ->(this, options) { format(USER_COMPLETED_CACHE_STRING, user_id: options[:user].id.to_s, id: this.id.to_s, updated_at: this.updated_at.to_f.to_s, deadline: options[:deadline].present?.to_s) })
 
   def completed_before_deadline?(user)
     completed?(deadline: deadline, user: user)
@@ -111,14 +110,14 @@ class Series < ApplicationRecord
   end
 
   invalidateable_instance_cacheable(:started?,
-                                    ->(this, options) { format(USER_STARTED_CACHE_STRING, user_id: options[:user].id.to_s, id: this.id.to_s) })
+                                    ->(this, options) { format(USER_STARTED_CACHE_STRING, user_id: options[:user].id.to_s, id: this.id.to_s, updated_at: this.updated_at.to_f.to_s) })
 
   def wrong?(options)
     activities.any? { |a| a.wrong_for?(options[:user], self) }
   end
 
   invalidateable_instance_cacheable(:wrong?,
-                                    ->(this, options) { format(USER_WRONG_CACHE_STRING, user_id: options[:user].id.to_s, id: this.id.to_s) })
+                                    ->(this, options) { format(USER_WRONG_CACHE_STRING, user_id: options[:user].id.to_s, id: this.id.to_s, updated_at: this.updated_at.to_f.to_s) })
 
   def indianio_support
     indianio_token.present?
@@ -170,17 +169,8 @@ class Series < ApplicationRecord
     end
   end
 
-  def invalidate_activity_statuses_and_caches
+  def invalidate_activity_statuses
     ActivityStatus.delete_by(series: self)
-    delay.invalidate_status_cache
-  end
-
-  def invalidate_status_cache
-    # Remove the caches for each user.
-    exercises.includes(submissions: :user)
-             .flat_map { |exercise| exercise.submissions.map(&:user) }
-             .uniq
-             .each { |user| invalidate_caches(user) }
   end
 
   def invalidate_caches(user)
@@ -188,15 +178,5 @@ class Series < ApplicationRecord
     invalidate_completed?(user: user)
     invalidate_started?(user: user)
     invalidate_wrong?(user: user)
-  end
-
-  def being_destroyed?
-    @being_destroyed
-  end
-
-  private
-
-  def set_being_destroyed
-    @being_destroyed = true
   end
 end

--- a/app/models/series_membership.rb
+++ b/app/models/series_membership.rb
@@ -26,7 +26,7 @@ class SeriesMembership < ApplicationRecord
 
   def invalidate_caches
     course.invalidate_activities_count_cache
-    series.delay.invalidate_status_cache unless series.being_destroyed?
+    series.touch
   end
 
   def invalidate_status

--- a/test/controllers/series_controller_test.rb
+++ b/test/controllers/series_controller_test.rb
@@ -65,16 +65,6 @@ class SeriesControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to course_url(course)
   end
 
-  test 'destroy series should not queue jobs' do
-    @instance = create(:series, :with_submissions)
-    old = Delayed::Worker.delay_jobs
-    Delayed::Worker.delay_jobs = true
-    assert_jobs_enqueued(0) do
-      destroy_request
-    end
-    Delayed::Worker.delay_jobs = old
-  end
-
   test 'should generate scoresheet' do
     series = create(:series, :with_submissions)
     get scoresheet_series_path(series)

--- a/test/models/series_test.rb
+++ b/test/models/series_test.rb
@@ -79,13 +79,14 @@ class SeriesTest < ActiveSupport::TestCase
            exercise: series.exercises[0],
            user: user
 
-    assert_equal true, series.completed_before_deadline?(user)
+    assert series.completed_before_deadline?(user)
+    travel 1.second
 
     series.update(deadline: Time.zone.now - 1.day)
 
     ActivityStatus.clear_status_store
 
-    assert_equal false, series.completed_before_deadline?(user)
+    assert_not series.completed_before_deadline?(user)
   end
 
   test 'changing deadline and restoring should restore completion status' do
@@ -104,20 +105,22 @@ class SeriesTest < ActiveSupport::TestCase
                              course: course,
                              user: user
 
-    assert_equal true, series.completed_before_deadline?(user)
+    assert series.completed_before_deadline?(user)
+    travel 1.second
 
     series.update(deadline: now - 1.day)
 
     ActivityStatus.clear_status_store
 
-    assert_equal false, series.completed_before_deadline?(user)
+    assert_not series.completed_before_deadline?(user)
+    travel 1.second
 
     # Reset the deadline to the original one to ensure the status was not removed.
     series.update(deadline: original_deadline)
 
     ActivityStatus.clear_status_store
 
-    assert_equal true, series.completed_before_deadline?(user)
+    assert series.completed_before_deadline?(user)
   end
 
   test 'changing deadline clears status cache' do
@@ -134,14 +137,16 @@ class SeriesTest < ActiveSupport::TestCase
 
       create :wrong_submission, created_at: now - 3.days, user: user, course: course, exercise: exercise
 
-      assert_equal false, series.completed_before_deadline?(user)
+      assert_not series.completed_before_deadline?(user)
+      travel 1.second
 
       # Move the deadline up
       series.update(deadline: now + 5.days)
       # Simulate we have a new request
       ActivityStatus.clear_status_store
 
-      assert_equal false, series.completed_before_deadline?(user)
+      assert_not series.completed_before_deadline?(user)
+      travel 1.second
 
       create :correct_submission, created_at: now + 2.days, user: user, course: course, exercise: exercise
 
@@ -149,7 +154,27 @@ class SeriesTest < ActiveSupport::TestCase
       series.update(deadline: original_deadline)
       ActivityStatus.clear_status_store
 
-      assert_equal true, series.completed_before_deadline?(user)
+      assert series.completed_before_deadline?(user)
+    end
+  end
+
+  test 'adding exercises to empty series clears status cache' do
+    with_cache do
+      course = create :course
+      series = create :series, course: course
+      user = create :user
+
+      assert series.completed_before_deadline?(user)
+      travel 1.second
+
+      # Simulate we have a new request
+      ActivityStatus.clear_status_store
+
+      exercise = create :exercise
+      series.exercises << exercise
+      series.reload
+
+      assert_not series.completed_before_deadline?(user)
     end
   end
 
@@ -163,7 +188,8 @@ class SeriesTest < ActiveSupport::TestCase
       series.exercises << exercise
 
       create :correct_submission, user: user, course: course, exercise: exercise
-      assert_equal true, series.completed_before_deadline?(user)
+      assert series.completed_before_deadline?(user)
+      travel 1.second
 
       # Simulate we have a new request
       ActivityStatus.clear_status_store
@@ -172,7 +198,7 @@ class SeriesTest < ActiveSupport::TestCase
       series.exercises << exercise
 
       series.reload
-      assert_equal false, series.completed_before_deadline?(user)
+      assert_not series.completed_before_deadline?(user)
     end
   end
 
@@ -196,24 +222,27 @@ class SeriesTest < ActiveSupport::TestCase
 
       create :correct_submission, user: user, course: course, exercise: exercise, created_at: now + 2.days
       ActivityStatus.clear_status_store
-      assert_equal true, series.completed_before_deadline?(user)
+      assert series.completed_before_deadline?(user)
+      travel 1.second
 
       series.exercises.delete(exercise)
       series.reload
       ActivityStatus.clear_status_store
 
-      assert_equal true, series.completed_before_deadline?(user)
+      assert series.completed_before_deadline?(user)
+      travel 1.second
 
       series.update(deadline: now + 1.day)
 
       ActivityStatus.clear_status_store
-      assert_equal true, series.completed_before_deadline?(user)
+      assert series.completed_before_deadline?(user)
+      travel 1.second
 
       series.exercises << exercise
       ActivityStatus.clear_status_store
       series.reload
 
-      assert_equal false, series.completed_before_deadline?(user)
+      assert_not series.completed_before_deadline?(user)
     end
   end
 


### PR DESCRIPTION
The cache could still be wrong if a user had not submitted to a series yet (or had not submitted after an exercise was removed), since the submissions to the series were used to determine the users for which the cache had to be cleared.

I've opted to change the caching mechanism so that it uses the timestamp a series was updated at when building the cache string. This could clear the cache a bit more than necessary (title and description changes will also trigger a cache clear), but I don't foresee this happening on a regular basis.

Note that this could also still fail: MySQL uses second precision for timestamps, so if a teacher changes a series, a cache store is triggered and the series is changed again all in the same second, a wrong value could be stored in the cache. This case seems exceedingly unlikely to me though.

- [x] Tests were added