### PR TITLE
Change dependabot labels key name

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
     time: "13:00"
     timezone: Europe/Brussels
   open-pull-requests-limit: 99
-  default_labels:
+  labels:
     - "dependencies"
   ignore:
   - dependency-name: sprockets
@@ -21,7 +21,7 @@ updates:
     time: "13:00"
     timezone: Europe/Brussels
   open-pull-requests-limit: 99
-  default_labels:
+  labels:
     - "dependencies"
   ignore:
   - dependency-name: webpack-cli
@@ -35,5 +35,5 @@ updates:
     time: "13:00"
     timezone: Europe/Brussels
   open-pull-requests-limit: 99
-  default_labels:
+  labels:
     - "dependencies"


### PR DESCRIPTION
Seems like the key changed very recently. The action did not complain this morning. https://docs.github.com/en/code-security/supply-chain-security/configuration-options-for-dependency-updates#labels
