### PR TITLE
Add retry mechanism to docker start

### DIFF
--- a/app/runners/submission_runner.rb
+++ b/app/runners/submission_runner.rb
@@ -115,13 +115,20 @@ class SubmissionRunner
     # process submission in docker container
     # TODO: set user with the --user option
     # TODO: set the workdir with the -w option
+    first_try = true
     begin
       container = Docker::Container.create(**docker_options)
     rescue StandardError => e
-      return build_error 'internal error', 'internal error', [
-        build_message("Error creating docker: #{e}", 'staff', 'plain'),
-        build_message(e.backtrace.join("\n"), 'staff')
-      ]
+      unless first_try
+        return build_error 'internal error', 'internal error', [
+          build_message("Error creating docker: #{e}", 'staff', 'plain'),
+          build_message(e.backtrace.join("\n"), 'staff')
+        ]
+      end
+
+      first_try = false
+      sleep 1
+      retry
     end
 
     # run the container with a timeout.

--- a/test/runners/submission_runner_test.rb
+++ b/test/runners/submission_runner_test.rb
@@ -191,6 +191,19 @@ class SubmissionRunnerTest < ActiveSupport::TestCase
                       accepted: false
   end
 
+  test 'one error in docker creation should not result in internal error' do
+    summary = 'Wow. Such code. Many variables.'
+    Docker::Container.stubs(:create).raises(STRIKE_ERROR).returns(docker_mock(output: {
+      accepted: true,
+      status: 'correct',
+      description: summary
+    }))
+
+    @submission.evaluate
+
+    assert_submission status: 'correct', summary: summary, accepted: true
+  end
+
   test 'random errors should be caught' do
     docker = docker_mock
     docker.stubs(:start).raises(STRIKE_ERROR)


### PR DESCRIPTION
Starting the docker container sometimes fails with the message "docker read timeout reached". This seems to be a temporary failure due to high load. This adds a retry mechanism where the docker container is started again after a second. If it still fails at that point, we go back to the previous behaviour.

- [x] Tests were added

Closes #2048.
