### PR TITLE
Make sure cache is invalidated when series has deadline

### DIFF
--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -176,6 +176,7 @@ class Series < ApplicationRecord
   def invalidate_caches(user)
     # Delete all caches for this series.
     invalidate_completed?(user: user)
+    invalidate_completed?(user: user, deadline: deadline) if deadline.present?
     invalidate_started?(user: user)
     invalidate_wrong?(user: user)
   end

--- a/test/models/series_test.rb
+++ b/test/models/series_test.rb
@@ -89,6 +89,30 @@ class SeriesTest < ActiveSupport::TestCase
     assert_not series.completed_before_deadline?(user)
   end
 
+  test 'submitting should invalidate exercise status for series with deadline' do
+    with_cache do
+      course = create :course
+      series = create :series, course: course, deadline: Time.zone.now + 1.day, exercise_count: 1
+      user = create :user
+
+      create :wrong_submission,
+             created_at: Time.zone.now,
+             course: course,
+             exercise: series.exercises[0],
+             user: user
+
+      assert_not series.completed_before_deadline?(user)
+
+      create :correct_submission,
+             created_at: Time.zone.now + 1.hour,
+             course: course,
+             exercise: series.exercises[0],
+             user: user
+
+      assert series.completed_before_deadline?(user)
+    end
+  end
+
   test 'changing deadline and restoring should restore completion status' do
     original_deadline = Time.zone.now + 1.day
 


### PR DESCRIPTION
This pull request makes sure the series status cache is invalidated correctly when there is a deadline. This is an old bug that was only exposed by the recent cache changes.

- [x] Tests were added
