### PR TITLE
Clone exercise on conversion to content page

### DIFF
--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -94,6 +94,10 @@ class Activity < ApplicationRecord
     false
   end
 
+  def becomes_content_page?
+    exercise? && Activity.parse_type(merged_config['type']) == ContentPage.name
+  end
+
   def full_path
     return Pathname.new '' unless path
 


### PR DESCRIPTION
When converting an exercise with submissions to a content page, clone the exercise as a deleted exercise and attach all submissions to that clone before proceeding with the conversion.

- [x] Tests were added

Closes #2364.
