### PR TITLE
Don't activate drawer if it isn't there

### DIFF
--- a/app/assets/javascripts/drawer.ts
+++ b/app/assets/javascripts/drawer.ts
@@ -8,10 +8,10 @@ export class Drawer {
 
         document
             .querySelector(toggleSelector)
-            .addEventListener("click", () => this.toggle());
+            ?.addEventListener("click", () => this.toggle());
         document
             .querySelector(backgroundSelector)
-            .addEventListener("click", () => this.hide());
+            ?.addEventListener("click", () => this.hide());
     }
 
     toggle(): void {


### PR DESCRIPTION
This pull request fixes a JS error for signed out users. The logic to activate the drawer failed because there is no drawer on those pages.

I checked if `?.` gets transpiled correctly by babel which is the case.

Closes #2631 
