### PR TITLE
Lower the number of workers on mestra

### DIFF
--- a/config/deploy/mestra.rb
+++ b/config/deploy/mestra.rb
@@ -7,7 +7,7 @@ server 'mestra.ugent.be', user: 'dodona', roles: %i[web app worker], ssh_options
 set :branch, ENV['GITHUB_SHA'] || 'develop'
 set :rails_env, :development
 
-set :delayed_job_workers, 3
+set :delayed_job_workers, 1
 
 set :bundle_without, ''
 


### PR DESCRIPTION
Mestra only has limited memory and often goes out of memory. We don't need 3 workers on this machine anyway.
