### PR TITLE
Tweak Support Us url

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,1 @@
-custom: https://dodona.ugent.be/en/support
+custom: https://dodona.ugent.be/en/support-us

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -7,7 +7,7 @@
     <a href="https://twitter.com/DodonaEdu" target="_blank" rel="noopener">
       <i class="mdi mdi-18 mdi-twitter"></i>
     </a>
-    <%= link_to t("layout.footer.support_dodona"), support_path %>
+    <%= link_to t("layout.footer.support_dodona"), support_us_path %>
     <%= link_to 'Contact', contact_path %>
     <%= link_to 'Status', status_path, target: "_blank", rel: "noopener" %>
     <%= link_to t("layout.footer.privacy_statement"), privacy_path %>

--- a/app/views/pages/_team.en.html.erb
+++ b/app/views/pages/_team.en.html.erb
@@ -10,5 +10,5 @@
     The platform is fully open source: all code is available on
     <a href="https://github.com/dodona-edu/dodona">GitHub</a>.
   </p>
-  <p><strong>Help us keep Dodona free and <%= link_to "support us", support_path %>!</strong></p>
+  <p><strong>Help us keep Dodona free and <%= link_to "support us", support_us_path %>!</strong></p>
 </div>

--- a/app/views/pages/_team.nl.html.erb
+++ b/app/views/pages/_team.nl.html.erb
@@ -10,5 +10,5 @@
     Het platform is volledig open source: alle code is beschikbaar op
     <a href="https://github.com/dodona-edu/dodona">GitHub</a>.
   </p>
-  <p><strong>Help om Dodona gratis te houden en <%= link_to "steun ons", support_path %>!</strong></p>
+  <p><strong>Help om Dodona gratis te houden en <%= link_to "steun ons", support_us_path %>!</strong></p>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,7 +28,7 @@ Rails.application.routes.draw do
     get '/data' => 'pages#data'
     get '/privacy' => 'pages#privacy'
     get '/profile' => 'pages#profile', as: 'profile'
-    get '/support' => 'pages#support'
+    get '/support-us' => 'pages#support'
 
     get '/contact' => 'pages#contact'
     post '/contact' => 'pages#create_contact', as: 'create_contact'

--- a/test/controllers/pages_controller_test.rb
+++ b/test/controllers/pages_controller_test.rb
@@ -65,7 +65,7 @@ class PagesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should get support us page' do
-    get support_url
+    get support_us_url
     assert_response :success
   end
 


### PR DESCRIPTION
The previous url pointed to /support which looked a bit like it was a page where they could get user support from us. It now points to /support-us.