### PR TITLE
Set skip_test_database for mestra

### DIFF
--- a/config/deploy/mestra.rb
+++ b/config/deploy/mestra.rb
@@ -7,6 +7,8 @@ server 'mestra.ugent.be', user: 'dodona', roles: %i[web app worker], ssh_options
 set :branch, ENV['GITHUB_SHA'] || 'develop'
 set :rails_env, :development
 
+set :default_env, {skip_test_database: true}
+
 set :delayed_job_workers, 1
 
 set :bundle_without, ''


### PR DESCRIPTION
This pull request sets the environment variable `skip_test_database` to avoid creating the test database while deploying mestra.
