### PR TITLE
Make sure series#new 404s when course does not exist

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -121,9 +121,6 @@ gem 'rubyzip', '~> 2.3.0'
 # add request server timings to the devtools
 gem 'rails_server_timings', '~> 1.0.8'
 
-# Maybe in Ruby
-gem 'possibly', '~> 1.0.1'
-
 # bootstrap tokenizer
 gem 'bootstrap_tokenfield_rails', '~> 0.12.1'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -283,7 +283,6 @@ GEM
     parallel (1.20.1)
     parser (2.7.2.0)
       ast (~> 2.4.1)
-    possibly (1.0.1)
     premailer (1.12.1)
       addressable
       css_parser (>= 1.6.0)
@@ -515,7 +514,6 @@ DEPENDENCIES
   omniauth-google-oauth2 (~> 0.8.2)
   omniauth-oauth2 (~> 1.7.1)
   omniauth_openid_connect (~> 0.3.5)
-  possibly (~> 1.0.1)
   premailer-rails (~> 1.11.1)
   pretender (~> 0.3.4)
   puma (~> 5.2.2)

--- a/app/controllers/series_controller.rb
+++ b/app/controllers/series_controller.rb
@@ -47,9 +47,7 @@ class SeriesController < ApplicationController
 
   # GET /series/new
   def new
-    course = Maybe(params[:course_id])
-             .map { |cid| Course.find_by id: cid }
-             .or_nil
+    course = Course.find(params[:course_id])
     authorize course, :add_series?
     @series = Series.new(course: course)
     @title = I18n.t('series.new.title')

--- a/app/helpers/activity_helper.rb
+++ b/app/helpers/activity_helper.rb
@@ -163,18 +163,17 @@ module ActivityHelper
       @footnote_urls = {}
       i = 1
       doc.css('a').each do |anchor|
-        Maybe(anchor.attribute('href')) # get href attribute
-          .map(&:value) # get its value
-          .map { |u| absolutize_url u } # absolutize it
-          .map do |url|
-          # If any of the steps above returned nil, this block isn't executed
+        url = anchor.attribute('href')&.value
+        next if url.nil?
 
-          ref = "<sup class='footnote-url visible-print-inline'>#{i}</sup>"
-          anchor.add_next_sibling ref
+        url = absolutize_url(url)
+        next if url.nil?
 
-          @footnote_urls[i.to_s] = url
-          i += 1
-        end
+        ref = "<sup class='footnote-url visible-print-inline'>#{i}</sup>"
+        anchor.add_next_sibling ref
+
+        @footnote_urls[i.to_s] = url
+        i += 1
       end
     end
 

--- a/test/controllers/series_controller_test.rb
+++ b/test/controllers/series_controller_test.rb
@@ -54,6 +54,12 @@ class SeriesControllerTest < ActionDispatch::IntegrationTest
     assert_equal 'Dirichlet', @instance.reload.name
   end
 
+  test 'new series for non-existent course should 404' do
+    assert_raises ActiveRecord::RecordNotFound do
+      get new_course_series_url(Course.reorder(id: :desc).first.id + 1)
+    end
+  end
+
   test 'update series should redirect to course' do
     instance = update_request_expect(attr_hash: { series: { description: 'new description' } })
     assert_redirected_to course_url(instance.course, series: instance, anchor: instance.anchor)


### PR DESCRIPTION
Note that the test tests for an exception. In production, this exception results in a 404.

I also removed the one remaining use of `Maybe` and removed the gem from our dependencies. IMO, Ruby is not a monadic language, so trying to force a Maybe monad in there seems unnecessary to me, especially since the introduction of the `&.` syntax. I can remove the second commit if people disagree. (Ping @rien, since you introduced both uses of `Maybe` in the codebase.)

- [x] Tests were added
