### PR TITLE
Fix CSP error for JS exercises

### DIFF
--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -23,6 +23,7 @@ class ActivitiesController < ApplicationController
 
   content_security_policy only: %i[show] do |policy|
     policy.frame_src -> { ["'self'", sandbox_url] }
+    policy.worker_src -> { ['blob:'] }
   end
 
   content_security_policy only: %i[description] do |policy|


### PR DESCRIPTION
This pull request fixes a CSP error on pages where the ace editor is loaded in JS mode. More specifically, this PR allows workers to be created from a blob on activity show pages.

Closes #2642 
