### PR TITLE
Rework the contact page

### DIFF
--- a/app/assets/stylesheets/layout/navbar.css.less
+++ b/app/assets/stylesheets/layout/navbar.css.less
@@ -346,6 +346,9 @@
     overflow: hidden;
     text-overflow: ellipsis;
   }
+  .crumb.list a {
+    margin-right: 12px;
+  }
 
   .crumb-separator {
     overflow: hidden;

--- a/app/views/layouts/_breadcrumbs.html.erb
+++ b/app/views/layouts/_breadcrumbs.html.erb
@@ -6,7 +6,12 @@
 
 <div class="crumbs">
   <% if !user_signed_in? %>
-    <div class="crumb"><%= link_to(t("layout.menu.activities"), activities_path) %></div>
+    <div class="crumb list">
+      <%= link_to(t("layout.menu.activities"), activities_path) %>
+      <%= link_to(t("layout.menu.support_us"), support_us_path) %>
+      <%= link_to(t("layout.menu.manual"), "https://docs.dodona.be/#{I18n.locale}") %>
+      <%= link_to(t("layout.menu.contact"), contact_path) %>
+    </div>
   <% elsif @crumbs.present? %>
     <% is_first = true %>
     <% @crumbs.each do |name, path| %>

--- a/app/views/pages/contact.html.erb
+++ b/app/views/pages/contact.html.erb
@@ -6,12 +6,12 @@
       </div>
       <div class="card-supporting-text">
         <div class="col-sm-6">
-          <p>Gebruik het formulier op deze pagina om een bericht te sturen naar het team achter Dodona. We zullen je vraag zo snel mogelijk via email beantwoorden.</p>
-          <p>Op <a href="https://docs.dodona.be/nl" target = "_blank">docs.dodona.be</a> kan je onze handleiding vinden.</p>
-          <p>Heb je een algemene vraag waarvan het antwoord ook voor anderen van nut kan zijn? Overweeg dan om de vraag te stellen op ons <a href="https://github.com/dodona-edu/dodona/discussions" target = "_blank">GitHub discussieforum</a>. Ook voor het melden van bugs en suggereren van nieuwe features kan je daar terecht.</p>
+          <p><%= t('.contact_p1_html') %></p>
+          <p><%= t('.contact_p2_html') %></p>
+          <p><%= t('.contact_p3_html') %></p>
         </div>
         <div class="col-sm-6">
-          <% if !policy(RightsRequest).create? %>
+          <% if policy(RightsRequest).create? %>
             <div class="callout callout-info">
               <h4><%= t('.rights_request_title') %></h4>
               <%= t('.rights_request_redirect_html', url: new_rights_request_path) %>

--- a/app/views/pages/contact.html.erb
+++ b/app/views/pages/contact.html.erb
@@ -8,11 +8,21 @@
         </div>
       </div>
       <div class="card-supporting-text">
-        <% if policy(RightsRequest).create? %>
-          <div class="callout callout-info">
-            <%= t('.rights_request_redirect_html', url: new_rights_request_path) %>
-          </div>
-        <% end %>
+        <div class="col-sm-6">
+          <p>Gebruik het formulier op deze pagina om een bericht te sturen naar het team achter Dodona. We zullen je vraag zo snel mogelijk via email beantwoorden.</p>
+          <p>Op <a href="https://docs.dodona.be/nl" target = "_blank">docs.dodona.be</a> kan je onze handleiding vinden.</p>
+          <p>Heb je een algemene vraag waarvan het antwoord ook voor anderen van nut kan zijn? Overweeg dan om de vraag te stellen op ons <a href="https://github.com/dodona-edu/dodona/discussions" target = "_blank">GitHub discussieforum</a>. Ook voor het melden van bugs en suggereren van nieuwe features kan je daar terecht.</p>
+        </div>
+        <div class="col-sm-6">
+          <% if !policy(RightsRequest).create? %>
+            <div class="callout callout-info">
+              <h4><%= t('.rights_request_title') %></h4>
+              <%= t('.rights_request_redirect_html', url: new_rights_request_path) %>
+            </div>
+          <% end %>
+        </div>
+      </div>
+      <div class="card-supporting-text card-border">
         <%= form_for @contact_form, url: create_contact_path, html: {class: 'form-horizontal'} do |f| %>
           <div class="field form-group">
             <%= f.label t('.name'), :class => "col-sm-2 control-label" %>

--- a/app/views/pages/contact.html.erb
+++ b/app/views/pages/contact.html.erb
@@ -3,9 +3,6 @@
     <div class="card">
       <div class="card-title card-title-colored">
         <h2 class="card-title-text"><%= t('.title') %></h2>
-        <div class="card-title-fab">
-          <%= render 'fab_button', form: "new_contact_form", icon: 'send' %>
-        </div>
       </div>
       <div class="card-supporting-text">
         <div class="col-sm-6">
@@ -49,6 +46,9 @@
             </div>
           <% end %>
         <% end %>
+      </div>
+      <div class="card-actions card-border">
+        <button type="submit" class="btn-primary btn-text pull-right" form="new_contact_form"><%= t('.send') %></a>
       </div>
     </div>
   </div>

--- a/config/locales/views/defaults/en.yml
+++ b/config/locales/views/defaults/en.yml
@@ -29,7 +29,9 @@ en:
       kid: There was an error when communicating with Ufora. You should re-open this page.
     menu:
       manual: User manual
-      activities: Activities
+      activities: Exercises
+      support_us: Support us
+      contact: Contact
       my_submissions: My submissions
       my_questions: My questions
       my_exports: My exports

--- a/config/locales/views/defaults/nl.yml
+++ b/config/locales/views/defaults/nl.yml
@@ -28,8 +28,10 @@ nl:
       iframe: Het lijkt erop dat je Dodona gebruikt binnen een andere webpagina waardoor mogelijk niet alles goed werkt. Laat dit weten aan je lesgever zodat hij het probleem kan oplossen door een instelling in de leeromgeving aan te passen. Ondertussen kan je <a href='%{url}' target='_blank'>op deze link klikken</a> om Dodona te openen in een nieuw venster.
       kid: Er ging iets verkeerd tijdens het communiceren met Ufora. Je opent deze pagina best opnieuw.
     menu:
-      manual: Gebruikershandleiding
-      activities: Leeractiviteiten
+      manual: Handleiding
+      activities: Oefeningen
+      support_us: Steun ons
+      contact: Contact
       my_submissions: Mijn oplossingen
       my_questions: Mijn vragen
       my_exports: Mijn exports

--- a/config/locales/views/pages/en.yml
+++ b/config/locales/views/pages/en.yml
@@ -54,7 +54,8 @@ en:
       subject: Subject
       message: Message
       prompt: Contact us if the problem persists.
-      rights_request_redirect_html: Do you want to request teacher rights for your account? From now on, you can do that <a href="%{url}">using this form</a>.
+      rights_request_title: Teacher rights
+      rights_request_redirect_html: Do you want to request teacher rights for your account? Please use <strong><a href="%{url}">this form</a></strong>.
     create_contact:
       mail_sent: "Your message has been sent. Thanks for getting in touch."
       captcha_failed: reCAPTCHA could not be verified; please try again.

--- a/config/locales/views/pages/en.yml
+++ b/config/locales/views/pages/en.yml
@@ -56,6 +56,7 @@ en:
       prompt: Contact us if the problem persists.
       rights_request_title: Teacher rights
       rights_request_redirect_html: Do you want to request teacher rights for your account? Please use <strong><a href="%{url}">this form</a></strong>.
+      send: Send message
     create_contact:
       mail_sent: "Your message has been sent. Thanks for getting in touch."
       captcha_failed: reCAPTCHA could not be verified; please try again.

--- a/config/locales/views/pages/en.yml
+++ b/config/locales/views/pages/en.yml
@@ -49,6 +49,9 @@ en:
       unknown: 'unknown'
     contact:
       title: Get in touch
+      contact_p1_html: You can use the form on this page to send a message to Team Dodona. We'll answer your question as soon as possible by email.
+      contact_p2_html: "You can find our manual on <a href='https://docs.dodona.be/en' target = '_blank'>docs.dodona.be</a>."
+      contact_p3_html: "If you have a general question of which the answer can be of use to others, please consider posting it on <a href='https://github.com/dodona-edu/dodona/discussions' target = '_blank'>GitHub Discussions</a>. Reporting a bug or requesting a feature can also be done on GitHub."
       name: Name
       email: Email
       subject: Subject

--- a/config/locales/views/pages/nl.yml
+++ b/config/locales/views/pages/nl.yml
@@ -49,6 +49,9 @@ nl:
       unknown: 'onbekende'
     contact:
       title: Contacteer ons
+      contact_p1_html: Gebruik het formulier op deze pagina om een bericht te sturen naar het team achter Dodona. We zullen je vraag zo snel mogelijk via email beantwoorden.
+      contact_p2_html: "Op <a href='https://docs.dodona.be/nl' target = '_blank'>docs.dodona.be</a> kan je onze handleiding vinden."
+      contact_p3_html: "Heb je een algemene vraag waarvan het antwoord ook voor anderen van nut kan zijn? Overweeg dan om de vraag te stellen op ons <a href='https://github.com/dodona-edu/dodona/discussions' target = '_blank'>GitHub discussieforum</a>. Ook voor het melden van bugs en suggereren van nieuwe features kan je daar terecht."
       name: Naam
       email: Email
       subject: Onderwerp

--- a/config/locales/views/pages/nl.yml
+++ b/config/locales/views/pages/nl.yml
@@ -54,7 +54,8 @@ nl:
       subject: Onderwerp
       message: Bericht
       prompt: Contacteer ons als het probleem zich blijft voordoen.
-      rights_request_redirect_html: Wil je lesgeversrechten aanvragen voor je account? Vanaf nu kan je dat <a href="%{url}">via dit formulier</a> doen.
+      rights_request_title: Lesgeversrechten
+      rights_request_redirect_html: Wil je lesgeversrechten aanvragen voor je account? Gebruik dan <strong><a href="%{url}">dit formulier</a></strong>.
     create_contact:
       captcha_failed: reCAPTCHA kon niet geverifieerd worden, probeer opnieuw.
       mail_sent: "Je bericht werd verstuurd. Bedankt om contact op te nemen."

--- a/config/locales/views/pages/nl.yml
+++ b/config/locales/views/pages/nl.yml
@@ -56,6 +56,7 @@ nl:
       prompt: Contacteer ons als het probleem zich blijft voordoen.
       rights_request_title: Lesgeversrechten
       rights_request_redirect_html: Wil je lesgeversrechten aanvragen voor je account? Gebruik dan <strong><a href="%{url}">dit formulier</a></strong>.
+      send: Bericht verzenden
     create_contact:
       captcha_failed: reCAPTCHA kon niet geverifieerd worden, probeer opnieuw.
       mail_sent: "Je bericht werd verstuurd. Bedankt om contact op te nemen."


### PR DESCRIPTION
This pull request adds links to the documentation and GitHub Discussions to the contact page. It also makes the staff request callout more prominent by adding a title.

I also added a few additional links to the top navigation when users are not signed in.

![image](https://user-images.githubusercontent.com/481872/117029768-45a4d380-acff-11eb-84fe-d324d3bca477.png)

Closes #2680 
