### PR TITLE
Scope exercise path in evaluation overview

### DIFF
--- a/app/views/evaluations/overview.html.erb
+++ b/app/views/evaluations/overview.html.erb
@@ -20,7 +20,7 @@
           <tbody>
             <% @feedbacks.each do |fb| %>
               <tr>
-                <td><%= link_to fb.exercise.name, activity_path(fb.exercise) %></td>
+                <td><%= link_to fb.exercise.name, activity_scoped_path(activity: fb.exercise, series: @evaluation.series) %></td>
                 <td><%= fb.submission.present? ? t('.annotation_count', count: fb.submission.annotations.count) : t('.no_submission') %></td>
                 <td><%= render 'feedbacks/score_link', feedback: fb %></td>
                 <td class="actions">


### PR DESCRIPTION
This pull request fixes an issue reported by @chvp  in #2695 (although this also seems to have been an issue from before grading):

> Exercises linked in student view of evaluation don't link into course scope, resulting in an unauthorized error for students.