### PR TITLE
Fix some grading bugs

### DIFF
--- a/app/views/feedbacks/_feedback_actions.html.erb
+++ b/app/views/feedbacks/_feedback_actions.html.erb
@@ -98,12 +98,7 @@
 
   <h4 class="ellipsis-overflow" title="<%= @feedback.user.full_name %>"><%= @feedback.user.full_name %></h4>
   <div class="user-feedback-row">
-    <% @feedback.evaluation.evaluation_exercises.map do |ex|
-      Feedback.find_by(evaluation_user: @feedback.evaluation_user,
-                       evaluation_exercise: ex)
-    end.each do |feedback| %>
-      <%= render partial: 'evaluations/feedback_status', locals: { evaluation: feedback.evaluation, feedback: feedback, current: @feedback } %>
-    <% end %>
+    <%= render partial: 'feedbacks/user_feedback_row', locals: { current_feedback: @feedback } %>
   </div>
 </div>
 

--- a/app/views/feedbacks/_score_actions.html.erb
+++ b/app/views/feedbacks/_score_actions.html.erb
@@ -26,10 +26,10 @@
           <%= button_tag class: "btn btn-secondary max-text", disabled: true, type: :button, data: { max: format_score(score_item.maximum, lang='en', numeric_only=true) } do %>
             / <%= format_score(score_item.maximum) %>
           <% end %>
-          <%= button_tag class: "btn btn-secondary btn-sm single-zero-button", type: :button do %>
+          <%= button_tag class: "btn btn-secondary btn-sm single-zero-button", type: :button, title: t('.give_zero_one') do %>
             <i class="mdi mdi-thumb-down mdi-12" aria-hidden='true'></i>
           <% end %>
-          <%= button_tag class: "btn btn-secondary btn-sm single-max-button", type: :button do %>
+          <%= button_tag class: "btn btn-secondary btn-sm single-max-button", type: :button, title: t('.give_max_one', score: format_score(score_item.maximum)) do %>
             <i class="mdi mdi-thumb-up mdi-12" aria-hidden='true'></i>
           <% end %>
         </div>

--- a/app/views/feedbacks/_user_feedback_row.html.erb
+++ b/app/views/feedbacks/_user_feedback_row.html.erb
@@ -1,0 +1,6 @@
+<% current_feedback.evaluation.evaluation_exercises.map do |ex|
+  Feedback.find_by(evaluation_user: current_feedback.evaluation_user,
+                   evaluation_exercise: ex)
+end.each do |feedback| %>
+  <%= render partial: 'evaluations/feedback_status', locals: { evaluation: feedback.evaluation, feedback: feedback, current: current_feedback } %>
+<% end %>

--- a/app/views/scores/show.js.erb
+++ b/app/views/scores/show.js.erb
@@ -2,5 +2,7 @@
 <%# The index is set with JS once known. %>
 $("#<%= @score.score_item.id %>-score-form-wrapper")
     .replaceWith("<%= escape_javascript(render 'feedbacks/score_actions', score: @score, score_item: @score.score_item, index: @order) %>");
+$(".user-feedback-row")
+    .html("<%= escape_javascript(render 'feedbacks/user_feedback_row', current_feedback: @feedback) %>");
 window.dodona.feedbackActions.initScoreForm("<%= @score.score_item.id %>");
 window.dodona.feedbackActions.setTotal("<%= format_score @total %>");

--- a/config/locales/views/feedbacks/en.yml
+++ b/config/locales/views/feedbacks/en.yml
@@ -37,7 +37,8 @@ en:
       give_max_all: "Assign the maximal score to all score items"
       give_zero_all: "Assign 0 to all score items"
     score_actions:
-      give_one: "Assign %{score} to this score item"
+      give_max_one: "Assign %{score} to this score item"
+      give_zero_one: "Geef 0 aan dit scoreonderdeel"
     overview:
       annotations:
         count: "Amount of annotations by teacher"

--- a/config/locales/views/feedbacks/en.yml
+++ b/config/locales/views/feedbacks/en.yml
@@ -38,7 +38,7 @@ en:
       give_zero_all: "Assign 0 to all score items"
     score_actions:
       give_max_one: "Assign %{score} to this score item"
-      give_zero_one: "Geef 0 aan dit scoreonderdeel"
+      give_zero_one: "Assign 0 to this score item"
     overview:
       annotations:
         count: "Amount of annotations by teacher"

--- a/config/locales/views/feedbacks/nl.yml
+++ b/config/locales/views/feedbacks/nl.yml
@@ -37,7 +37,8 @@ nl:
       give_max_all: "Geef de maximumscore aan alle scoreonderdelen"
       give_zero_all: "Geef 0 aan alle scoreonderdelen"
     score_actions:
-      give_one: "Geef %{score} aan dit scoreonderdeel"
+      give_max_one: "Geef %{score} aan dit scoreonderdeel"
+      give_zero_one: "Geef 0 aan dit scoreonderdeel"
     overview:
       annotations:
         count: "Aantal opmerkingen door lesgever"


### PR DESCRIPTION
This pull request fixes two items from #2695.

- Adds tooltips to min/max buttons
- Refresh the user feedback row when adding grades (so the row is updated as completed when all scores are filled in)
  I've extracted this row to a new partial, and added the partial to the js update code.
