### PR TITLE
Handle score creating conflicts

### DIFF
--- a/app/assets/javascripts/feedback/actions.ts
+++ b/app/assets/javascripts/feedback/actions.ts
@@ -110,8 +110,12 @@ export default class FeedbackActions {
         }).then(async response => {
             if (response.ok) {
                 eval(await response.text());
+            } else if ([403, 404, 422].includes(response.status)) {
+                new dodona.Toast(I18n.t("js.score.conflict"));
+                await this.refresh();
             } else {
                 new dodona.Toast(I18n.t("js.score.unknown"));
+                await this.refresh();
             }
         });
     }

--- a/app/controllers/feedbacks_controller.rb
+++ b/app/controllers/feedbacks_controller.rb
@@ -49,14 +49,19 @@ class FeedbacksController < ApplicationController
     attrs = permitted_attributes(@feedback)
     attrs['scores_attributes'].each { |s| s['last_updated_by_id'] = current_user.id } if attrs['scores_attributes'].present?
 
-    @feedback.update(attrs)
+    updated = @feedback.update(attrs)
     # We might have updated scores, so recalculate the map.
     @score_map = @feedback.scores.index_by(&:score_item_id)
 
     respond_to do |format|
-      format.html { redirect_to evaluation_feedback_path(@feedback.evaluation, @feedback) }
-      format.json { render :show, status: :ok, location: @feedback }
-      format.js { render :show }
+      if updated
+        format.html { redirect_to evaluation_feedback_path(@feedback.evaluation, @feedback) }
+        format.json { render :show, status: :ok, location: @feedback }
+        format.js { render :show }
+      else
+        format.json { render json: @feedback.errors, status: :unprocessable_entity }
+        format.js { render :show, status: :unprocessable_entity }
+      end
     end
   end
 

--- a/app/controllers/scores_controller.rb
+++ b/app/controllers/scores_controller.rb
@@ -6,24 +6,28 @@ class ScoresController < ApplicationController
     @score = Score.new(permitted_attributes(Score))
     @score.last_updated_by = current_user
     authorize @score
+    saved = @score.save
+    set_common
     respond_to do |format|
-      if @score.save
-        set_common
+      if saved
         format.js { render :show }
         format.json { render :show, status: :created, location: [@evaluation, @score] }
       else
+        format.js { render :show, status: :unprocessable_entity }
         format.json { render json: @score.errors, status: :unprocessable_entity }
       end
     end
   end
 
   def update
+    updated = @score.update(permitted_attributes(Score))
+    set_common
     respond_to do |format|
-      if @score.update(permitted_attributes(Score))
-        set_common
+      if updated
         format.js { render :show }
-        format.json { render :show, status: :created, location: [@evaluation, @score] }
+        format.json { render :show, status: :ok, location: [@evaluation, @score] }
       else
+        format.js { render :show, status: :unprocessable_entity }
         format.json { render json: @score.errors, status: :unprocessable_entity }
       end
     end

--- a/app/models/score.rb
+++ b/app/models/score.rb
@@ -23,6 +23,7 @@ class Score < ApplicationRecord
   after_save :maybe_complete_feedback
 
   validates :score, presence: true, numericality: { greater_than: -1000, less_than: 1000 }
+  validates :score_item_id, uniqueness: { scope: :feedback_id }
 
   def out_of_bounds?
     return false if score.nil?

--- a/test/controllers/feedbacks_controller_test.rb
+++ b/test/controllers/feedbacks_controller_test.rb
@@ -1,0 +1,42 @@
+require 'test_helper'
+
+class FeedbacksControllerTest < ActionDispatch::IntegrationTest
+  include EvaluationHelper
+
+  def setup
+    @evaluation = create :evaluation, :with_submissions
+    exercise = @evaluation.evaluation_exercises.first
+    @score_item1 = create :score_item, evaluation_exercise: exercise,
+                                       description: 'First item',
+                                       maximum: '10.0'
+    @score_item2 = create :score_item, evaluation_exercise: exercise,
+                                       description: 'Second item',
+                                       maximum: '17.0'
+    @feedback = @evaluation.feedbacks.first
+
+    @course_admin = create(:staff)
+    @course_admin.administrating_courses << @evaluation.series.course
+    sign_in @course_admin
+  end
+
+  test 'score errors are handled when updating feedback' do
+    create :score, feedback: @feedback, score_item: @score_item1
+
+    patch evaluation_feedback_path(@evaluation, @feedback, format: :json), params: {
+      feedback: {
+        scores_attributes: [
+          {
+            score_item_id: @score_item1.id,
+            score: '12.0'
+          },
+          {
+            score_item_id: @score_item2.id,
+            score: '12.0'
+          }
+        ]
+      }
+    }
+
+    assert_response :unprocessable_entity
+  end
+end

--- a/test/controllers/scores_controller_test.rb
+++ b/test/controllers/scores_controller_test.rb
@@ -121,4 +121,20 @@ class ScoresControllerTest < ActionDispatch::IntegrationTest
     }
     assert_response :forbidden
   end
+
+  test 'should handle errors when saving' do
+    create :score, score_item: @score_item, feedback: @feedback, score: '10.0'
+
+    post evaluation_scores_path(@evaluation, format: :json), params: {
+      score: {
+        score: '5.0',
+        score_item_id: @score_item.id,
+        feedback_id: @feedback.id
+      }
+    }
+
+    assert_response :unprocessable_entity
+    score = Score.find_by!(score_item: @score_item, feedback: @feedback)
+    assert_equal BigDecimal('10'), score.score
+  end
 end

--- a/test/models/score_test.rb
+++ b/test/models/score_test.rb
@@ -54,4 +54,11 @@ class ScoreTest < ActiveSupport::TestCase
     assert @feedback.completed?
     assert_empty @feedback.score_items
   end
+
+  test 'duplicate scores are rejected' do
+    create :score, feedback: @feedback, score_item: @score_item1
+    score = build :score, feedback: @feedback, score_item: @score_item1
+
+    assert_not score.save
+  end
 end


### PR DESCRIPTION
There are two parts to this:
- For individual scores, the db index was already there, so it sufficed to add the constraint to the model.
- For using the min/max buttons, which go via the feedback model update method, I've added some error handling, as that can now fail as wel.

- [x] Tests were added

Fixes an issue reported in #2695.
