### PR TITLE
Restore lay-out for inline code

### DIFF
--- a/app/assets/stylesheets/bootstrap_style_overrides.css.scss
+++ b/app/assets/stylesheets/bootstrap_style_overrides.css.scss
@@ -279,6 +279,7 @@ mark,
 blockquote {
   padding-left: 6px;
   border-left: 3px solid $border-color;
+  color: $grey-700;
 }
 
 @media screen {

--- a/app/assets/stylesheets/bootstrap_style_overrides.css.scss
+++ b/app/assets/stylesheets/bootstrap_style_overrides.css.scss
@@ -24,6 +24,8 @@ pre {
 
 code {
   background-color: $code-bg;
+  padding: 0.1em 0.3em;
+  border-radius: 5px;
 }
 
 .img-responsive {

--- a/app/assets/stylesheets/bootstrap_style_overrides.css.scss
+++ b/app/assets/stylesheets/bootstrap_style_overrides.css.scss
@@ -279,7 +279,6 @@ mark,
 blockquote {
   padding-left: 6px;
   border-left: 3px solid $border-color;
-  color: $grey-700;
 }
 
 @media screen {

--- a/app/assets/stylesheets/bootstrap_style_overrides.css.scss
+++ b/app/assets/stylesheets/bootstrap_style_overrides.css.scss
@@ -24,8 +24,9 @@ pre {
 
 code {
   background-color: $code-bg;
-  padding: 0.1em 0.3em;
-  border-radius: 5px;
+  padding-left: 3px;
+  padding-right: 3px;
+  border-radius: 3px;
 }
 
 .img-responsive {


### PR DESCRIPTION
This pull request tries to restore the previous lay-out for inline code and blockquotes.

![Inline_code_before](https://user-images.githubusercontent.com/56451049/119174265-a73ba080-ba68-11eb-8567-9434c9daf054.PNG)


