### PR TITLE
Don't enable the scrollspy if there is no side nav

### DIFF
--- a/app/assets/javascripts/course.js
+++ b/app/assets/javascripts/course.js
@@ -130,10 +130,13 @@ function initCourseShow() {
     const series = Series.findAll().sort((s1, s2) => s1.top - s2.bottom);
 
     function init() {
-        new ScrollSpy(document.getElementById("scrollspy-nav"), {
-            sectionSelector: ".series .anchor",
-            offset: 90,
-        }).activate();
+        const nav = document.getElementById("scrollspy-nav");
+        if (nav) {
+            new ScrollSpy(nav, {
+                sectionSelector: ".series .anchor",
+                offset: 90,
+            }).activate();
+        }
         $(window).scroll(scroll);
         scroll(); // Load series visible on pageload
     }


### PR DESCRIPTION
This pull request prevents loading the scrollspy component is the side navigation isn't present on the page.
This prevented the javascript on the scoped user course page from loading.

Closes #2773 
