### PR TITLE
Rework how grading results are shown to students

### DIFF
--- a/app/assets/stylesheets/components/evaluations.css.scss
+++ b/app/assets/stylesheets/components/evaluations.css.scss
@@ -187,3 +187,18 @@ a.score-click {
   text-align: right;
   padding-bottom: 5px;
 }
+
+.grade-feedback-table.table {
+  td.subscore-row {
+    padding-left: 30px;
+  }
+
+  td:first-child, th:first-child {
+    max-width: 200px;
+  }
+
+  tr:last-child td {
+    // Restore border at the bottom of the table.
+    border-bottom-width: 1px;
+  }
+}

--- a/app/assets/stylesheets/models/score_items.css.scss
+++ b/app/assets/stylesheets/models/score_items.css.scss
@@ -67,3 +67,17 @@ a.option-btn {
   margin-left: 0;
   flex: 1;
 }
+
+.toggleable-icon {
+  .expanded-icon {
+    display: none;
+  }
+  &[aria-expanded="true"] {
+    .expanded-icon {
+      display: initial;
+    }
+    .collapsed-icon {
+      display: none;
+    }
+  }
+}

--- a/app/policies/score_item_policy.rb
+++ b/app/policies/score_item_policy.rb
@@ -1,5 +1,23 @@
 # This policy contains no query methods, as they are covered by score_items? on the evaluation policy.
 class ScoreItemPolicy < ApplicationPolicy
+  class Scope < Scope
+    def resolve
+      if user&.zeus?
+        scope.all
+      elsif user
+        common = scope.joins(evaluation_exercise: { evaluation: :series })
+        # Students - visible if score item is visible and if evaluation is released.
+        students = common.where(visible: true, evaluation_exercises: { evaluations: { released: true } })
+        # Staff - visible if course administrator
+        staff = common.where(evaluation_exercise: { evaluation: { series: { course_id: user.administrating_courses.map(&:id) } } })
+
+        students.or(staff)
+      else
+        scope.none
+      end
+    end
+  end
+
   def permitted_attributes_for_create
     %i[evaluation_exercise_id maximum name visible description]
   end

--- a/app/views/evaluations/overview.html.erb
+++ b/app/views/evaluations/overview.html.erb
@@ -8,33 +8,78 @@
         <div class="callout callout-info">
           <%= t('.explanation', series: @evaluation.series.name, deadline: l(@evaluation.deadline, format: :submission)) %>
         </div>
-        <table class="table table-resource">
+        <%# If the user can view any of the grades in this evaluation. %>
+        <% graded = policy_scope(@evaluation.score_items).any? %>
+        <table class="table table-resource grade-feedback-table">
           <thead>
             <tr>
               <th><%= t('.exercise') %></th>
-              <th><%= t('.no_annotations') %></th>
-              <th><%= t('.grade') %></th>
+              <th colspan="2"><%= t('.feedback') %></th>
               <th class="actions"></th>
             </tr>
           </thead>
           <tbody>
             <% @feedbacks.each do |fb| %>
+              <% show_total = policy(fb.evaluation_exercise).show_total? %>
+              <% scores = policy_scope(fb.scores).includes(:score_item) %>
               <tr>
-                <td><%= link_to fb.exercise.name, activity_scoped_path(activity: fb.exercise, series: @evaluation.series) %></td>
-                <td><%= fb.submission.present? ? t('.annotation_count', count: fb.submission.annotations.count) : t('.no_submission') %></td>
-                <td><%= render 'feedbacks/score_link', feedback: fb %></td>
-                <td class="actions">
+                <%# The last row is normally borderless, but this doesn't work due to the rowspan. %>
+                <td class="align-top <%= "border-bottom-0" if fb === @feedbacks.last %>"
+                    rowspan="<%= 1 + scores.length %>">
+                  <%= link_to fb.exercise.name, activity_scoped_path(activity: fb.exercise, series: @evaluation.series) %>
+                </td>
+                <td>
+                  <% if graded %>
+                    <%= t "feedbacks.score_table.total_score" %>
+                    <br>
+                    <span class="text-muted small">
+                      <% if fb.submission.present? %>
+                        <%= t('.annotation_count', count: fb.submission.annotations.count) %>
+                      <% else %>
+                        <%= t('.no_submission') %>
+                      <% end %>
+                    </span>
+                  <% else %>
+                    <% if fb.submission.present? %>
+                      <%= t('.annotation_count', count: fb.submission.annotations.count) %>
+                    <% else %>
+                      <%= t('.no_submission') %>
+                    <% end %>
+                  <% end %>
+                </td>
+                <td class="align-top">
+                  <% if show_total %>
+                    <% if fb.maximum_score %>
+                      <%= format_score fb.score %> / <%= format_score fb.maximum_score %>
+                    <% elsif graded %>
+                      <%= t ".no_grades" %>
+                    <% end %>
+                  <% else %>
+                    <span data-bs-toggle="tooltip" data-bs-placement="top" title="<%= t ".invisible_total" %>">
+                      -
+                    </span>
+                  <% end %>
+                </td>
+                <td class="actions align-top">
                   <% if fb.submission.present? %>
                     <%= link_to submission_path(fb.submission, anchor: 'code') do %>
                       <i class="mdi mdi-chevron-right mdi-18"></i>
                     <% end %>
                   <% end %>
               </tr>
-              <tr class="collapse" id="<%= "score-details-#{fb.id}" %>">
-                <td colspan="4">
-                  <%= render 'feedbacks/score_table', feedback: fb %>
-                </td>
-              </tr>
+              <% scores.each do |score| %>
+                <tr>
+                  <td class="subscore-row">
+                    <%= score.score_item.name %>
+                    <br>
+                    <span class="text-muted small"><%= score.score_item.description %></span>
+                  </td>
+                  <td class="align-top">
+                    <%= format_score score.score %> / <%= format_score score.score_item.maximum %>
+                  </td>
+                  <td></td>
+                </tr>
+              <% end %>
             <% end %>
           </tbody>
         </table>

--- a/app/views/evaluations/overview.html.erb
+++ b/app/views/evaluations/overview.html.erb
@@ -15,7 +15,7 @@
             <tr>
               <th><%= t '.exercise' %></th>
               <th><%= t '.feedback' %></th>
-              <th><%= t '.grade' %></th>
+              <th><%= t '.grade' if graded %></th>
               <th class="actions"></th>
             </tr>
           </thead>

--- a/app/views/evaluations/overview.html.erb
+++ b/app/views/evaluations/overview.html.erb
@@ -31,11 +31,13 @@
                 </td>
                 <td>
                   <% if graded %>
-                    <% if fb.maximum_score %>
-                      <%= t "feedbacks.score_table.total_score" %>
-                    <% else %>
-                      <%= t ".no_grading" %>
-                    <% end %>
+                    <strong>
+                      <% if fb.maximum_score %>
+                        <%= t "feedbacks.score_table.total_score" %>
+                      <% else %>
+                        <%= t ".no_grading" %>
+                      <% end %>
+                    </strong>
                     <br>
                     <span class="text-muted small">
                       <% if fb.submission.present? %>
@@ -53,19 +55,21 @@
                   <% end %>
                 </td>
                 <td class="align-top">
-                  <% if show_total %>
-                    <% if fb.maximum_score %>
-                      <%= format_score fb.score %> / <%= format_score fb.maximum_score %>
-                    <% elsif graded %>
-                      <span data-bs-toggle="tooltip" data-bs-placement="top" title="<%= t ".no_grading" %>">
+                  <strong>
+                    <% if show_total %>
+                      <% if fb.maximum_score %>
+                        <%= format_score fb.score %> / <%= format_score fb.maximum_score %>
+                      <% elsif graded %>
+                        <span data-bs-toggle="tooltip" data-bs-placement="top" title="<%= t ".no_grading" %>">
+                          -
+                        </span>
+                      <% end %>
+                    <% else %>
+                      <span data-bs-toggle="tooltip" data-bs-placement="top" title="<%= t ".invisible_total" %>">
                         -
                       </span>
                     <% end %>
-                  <% else %>
-                    <span data-bs-toggle="tooltip" data-bs-placement="top" title="<%= t ".invisible_total" %>">
-                      -
-                    </span>
-                  <% end %>
+                  </strong>
                 </td>
                 <td class="actions align-top">
                   <% if fb.submission.present? %>

--- a/app/views/evaluations/overview.html.erb
+++ b/app/views/evaluations/overview.html.erb
@@ -13,8 +13,9 @@
         <table class="table table-resource grade-feedback-table">
           <thead>
             <tr>
-              <th><%= t('.exercise') %></th>
-              <th colspan="2"><%= t('.feedback') %></th>
+              <th><%= t '.exercise' %></th>
+              <th><%= t '.feedback' %></th>
+              <th><%= t '.grade' %></th>
               <th class="actions"></th>
             </tr>
           </thead>
@@ -30,7 +31,11 @@
                 </td>
                 <td>
                   <% if graded %>
-                    <%= t "feedbacks.score_table.total_score" %>
+                    <% if fb.maximum_score %>
+                      <%= t "feedbacks.score_table.total_score" %>
+                    <% else %>
+                      <%= t ".no_grading" %>
+                    <% end %>
                     <br>
                     <span class="text-muted small">
                       <% if fb.submission.present? %>
@@ -52,7 +57,9 @@
                     <% if fb.maximum_score %>
                       <%= format_score fb.score %> / <%= format_score fb.maximum_score %>
                     <% elsif graded %>
-                      <%= t ".no_grades" %>
+                      <span data-bs-toggle="tooltip" data-bs-placement="top" title="<%= t ".no_grading" %>">
+                        -
+                      </span>
                     <% end %>
                   <% else %>
                     <span data-bs-toggle="tooltip" data-bs-placement="top" title="<%= t ".invisible_total" %>">

--- a/app/views/feedbacks/_score_link.html.erb
+++ b/app/views/feedbacks/_score_link.html.erb
@@ -6,13 +6,21 @@
 <% total = policy(feedback.evaluation_exercise).show_total? %>
 <% scores = policy_scope(feedback.scores) %>
 <% if total && feedback.score_items.present? %>
-  <%= link_to t("feedbacks.score_link.score", score: format_score(feedback.score), max: format_score(feedback.maximum_score)),
-              "#score-details-#{feedback.id}",
-              title: t("feedbacks.score_link.view_breakdown"), data: { 'bs-toggle': "collapse" } %>
+  <%= link_to "#score-details-#{feedback.id}",
+              class: 'toggleable-icon',
+              title: t("feedbacks.score_link.view_breakdown"), data: { 'bs-toggle': "collapse" } do %>
+    <%= t("feedbacks.score_link.score", score: format_score(feedback.score), max: format_score(feedback.maximum_score)) %>
+    <i class="collapsed-icon mdi mdi-chevron-down mdi-12"></i>
+    <i class="expanded-icon mdi mdi-chevron-up mdi-12"></i>
+  <% end %>
 <% elsif scores.present? %>
-  <%= link_to t("feedbacks.score_link.present", count: scores.length),
-              "#score-details-#{feedback.id}",
-              title: t("feedbacks.score_link.view_breakdown"), data: { 'bs-toggle': "collapse" } %>
+  <%= link_to "#score-details-#{feedback.id}",
+              class: 'toggleable-icon',
+              title: t("feedbacks.score_link.view_breakdown"), data: { 'bs-toggle': "collapse" } do %>
+    <%= t("feedbacks.score_link.present", count: scores.length) %>
+    <i class="collapsed-icon mdi mdi-chevron-down mdi-12"></i>
+    <i class="expanded-icon mdi mdi-chevron-up mdi-12"></i>
+  <% end %>
 <% end %>
 <%# Link to edit screen if needed %>
 <% if policy(feedback).show? && scores.present? %>

--- a/config/locales/views/evaluations/en.yml
+++ b/config/locales/views/evaluations/en.yml
@@ -80,7 +80,7 @@ en:
         one: "One annotation"
         other: "%{count} annotations"
       no_submission: "You had no timely submission for this exercise"
-      invisible_total: "The total score is not visible"
+      invisible_total: "The total score was not released"
       no_grading: "This exercise is not graded"
     members_table:
       remove_user: Remove student from evaluation

--- a/config/locales/views/evaluations/en.yml
+++ b/config/locales/views/evaluations/en.yml
@@ -73,12 +73,15 @@ en:
       released: Feedback was added to your code.
       exercise: Exercise
       no_annotations: "# annotations"
+      feedback: "Feedback"
       grade: Grade
       annotation_count:
-        zero: "No feedback was given"
+        zero: "No annotations"
         one: "One annotation"
         other: "%{count} annotations"
       no_submission: "You had no timely submission for this exercise"
+      no_grades: "None"
+      invisible_total: "The total score is not visible"
     members_table:
       remove_user: Remove student from evaluation
       remove_user_consequences: "If this student already received feedback, it will be deleted. Are you sure you want to remove this student?"

--- a/config/locales/views/evaluations/en.yml
+++ b/config/locales/views/evaluations/en.yml
@@ -81,7 +81,7 @@ en:
         other: "%{count} annotations"
       no_submission: "You had no timely submission for this exercise"
       invisible_total: "The total score was not released"
-      no_grading: "This exercise is not graded"
+      no_grading: "This exercise was not graded"
     members_table:
       remove_user: Remove student from evaluation
       remove_user_consequences: "If this student already received feedback, it will be deleted. Are you sure you want to remove this student?"

--- a/config/locales/views/evaluations/en.yml
+++ b/config/locales/views/evaluations/en.yml
@@ -76,7 +76,7 @@ en:
       feedback: "Feedback"
       grade: Grade
       annotation_count:
-        zero: "No annotations"
+        zero: "No annotations were added to your solution"
         one: "One annotation"
         other: "%{count} annotations"
       no_submission: "You had no timely submission for this exercise"

--- a/config/locales/views/evaluations/en.yml
+++ b/config/locales/views/evaluations/en.yml
@@ -80,8 +80,8 @@ en:
         one: "One annotation"
         other: "%{count} annotations"
       no_submission: "You had no timely submission for this exercise"
-      no_grades: "None"
       invisible_total: "The total score is not visible"
+      no_grading: "This exercise is not graded"
     members_table:
       remove_user: Remove student from evaluation
       remove_user_consequences: "If this student already received feedback, it will be deleted. Are you sure you want to remove this student?"

--- a/config/locales/views/evaluations/nl.yml
+++ b/config/locales/views/evaluations/nl.yml
@@ -75,7 +75,7 @@ nl:
       feedback: "Feedback"
       grade: Score
       annotation_count:
-        zero: "Geen annotaties"
+        zero: "Er werden geen annotaties toegevoegd aan je oplossing"
         one: "Één annotatie"
         other: "%{count} annotaties"
       no_submission: "Je had geen tijdige oplossing voor deze oefening"

--- a/config/locales/views/evaluations/nl.yml
+++ b/config/locales/views/evaluations/nl.yml
@@ -79,7 +79,7 @@ nl:
         one: "Één annotatie"
         other: "%{count} annotaties"
       no_submission: "Je had geen tijdige oplossing voor deze oefening"
-      invisible_total: "De totaalscore is niet zichtbaar"
+      invisible_total: "De totaalscore werd niet vrijgegeven"
       no_grading: "Deze oefening staat niet op punten"
     members_table:
       remove_user: Student verwijderen uit evaluatie

--- a/config/locales/views/evaluations/nl.yml
+++ b/config/locales/views/evaluations/nl.yml
@@ -79,8 +79,8 @@ nl:
         one: "Één annotatie"
         other: "%{count} annotaties"
       no_submission: "Je had geen tijdige oplossing voor deze oefening"
-      no_grades: "Geen"
       invisible_total: "De totaalscore is niet zichtbaar"
+      no_grading: "Deze oefening staat niet op punten"
     members_table:
       remove_user: Student verwijderen uit evaluatie
       remove_user_consequences: "Als deze student al feedback gekregen had, dan zal deze verwijderd worden. Ben je zeker dat je deze student wil verwijderen?"

--- a/config/locales/views/evaluations/nl.yml
+++ b/config/locales/views/evaluations/nl.yml
@@ -72,13 +72,15 @@ nl:
       explanation: Een cursusbeheerder evalueerde je oplossingen voor de reeks "%{series}". Voor elke oefening werd je laatst ingediende oplossing voor %{deadline} automatisch geselecteerd, maar de cursusbeheerder selecteerde mogelijks handmatig een andere oplossing. Merk op dat deze evaluatie niet noodzakelijk betekent dat er feedback werd toevoegd aan elk van je oplossingen.
       released: Er werd feedback gegeven op je code
       exercise: Oefening
-      no_annotations: "# annotaties"
+      feedback: "Feedback"
       grade: Score
       annotation_count:
-        zero: "Er werd geen feedback gegeven"
+        zero: "Geen annotaties"
         one: "Één annotatie"
         other: "%{count} annotaties"
       no_submission: "Je had geen tijdige oplossing voor deze oefening"
+      no_grades: "Geen"
+      invisible_total: "De totaalscore is niet zichtbaar"
     members_table:
       remove_user: Student verwijderen uit evaluatie
       remove_user_consequences: "Als deze student al feedback gekregen had, dan zal deze verwijderd worden. Ben je zeker dat je deze student wil verwijderen?"

--- a/test/policies/score_item_policy_test.rb
+++ b/test/policies/score_item_policy_test.rb
@@ -1,0 +1,45 @@
+require 'test_helper'
+
+class ScoreItemPolicyTest < ActiveSupport::TestCase
+  setup do
+    @evaluation = create :evaluation, :with_submissions
+    @staff_member = create :staff
+    @evaluation.series.course.administrating_members << @staff_member
+
+    exercise = @evaluation.evaluation_exercises.first
+    @feedback = @evaluation.feedbacks.first
+    @score_item1 = create :score_item, evaluation_exercise: exercise, visible: true
+    @score_item2 = create :score_item, evaluation_exercise: exercise, visible: false
+  end
+
+  test 'zeus can see all score items' do
+    # Not completed feedbacks
+    zeus = create :zeus
+    assert_equal [@score_item1, @score_item2].sort, Pundit.policy_scope!(zeus, ScoreItem).sort
+    # Completed feedbacks
+    @evaluation.update!(released: true)
+    assert_equal [@score_item1, @score_item2].sort, Pundit.policy_scope!(zeus, ScoreItem).sort
+  end
+
+  test 'course administrator can seel all score items for own course' do
+    assert_equal [@score_item1, @score_item2].sort, Pundit.policy_scope!(@staff_member, ScoreItem).sort
+    @evaluation.update!(released: true)
+    assert_equal [@score_item1, @score_item2].sort, Pundit.policy_scope!(@staff_member, ScoreItem).sort
+  end
+
+  test 'student can only see released, visible score items' do
+    random = create :user
+    assert_equal [], Pundit.policy_scope!(@feedback.evaluation_user.user, ScoreItem)
+    assert_equal [], Pundit.policy_scope!(random, Score)
+
+    @evaluation.update!(released: true)
+    assert_equal [@score_item1], Pundit.policy_scope!(@feedback.evaluation_user.user, ScoreItem)
+    assert_equal [], Pundit.policy_scope!(random, Score)
+  end
+
+  test 'not logged in can see nothing' do
+    assert_equal [], Pundit.policy_scope!(nil, ScoreItem)
+    @evaluation.update!(released: true)
+    assert_equal [], Pundit.policy_scope!(nil, ScoreItem)
+  end
+end

--- a/test/policies/score_policy_test.rb
+++ b/test/policies/score_policy_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class UserPolicyTest < ActiveSupport::TestCase
+class ScorePolicyTest < ActiveSupport::TestCase
   setup do
     @evaluation = create :evaluation, :with_submissions
     @staff_member = create :staff


### PR DESCRIPTION
This pull request adds a chevron to indicate there are score details:

![image](https://user-images.githubusercontent.com/1756811/119496709-0f89cb00-bd64-11eb-975e-bb580871cb19.png)

It changes when open:
![image](https://user-images.githubusercontent.com/1756811/119496778-22040480-bd64-11eb-9fae-0c5e3e6ba064.png)

Closes #2743.
