### PR TITLE
Fix issues with markdown code blocks

### DIFF
--- a/app/assets/stylesheets/bootstrap_style_overrides.css.scss
+++ b/app/assets/stylesheets/bootstrap_style_overrides.css.scss
@@ -20,6 +20,13 @@ pre {
   background-color: $code-bg;
   border: 1px solid $hairlinegray;
   border-radius: $border-radius-base;
+
+  code {
+    // Code inside a pre block is not an inline element, so don't add padding.
+    // See #2763
+    padding-left: 0;
+    padding-right: 0;
+  }
 }
 
 code {


### PR DESCRIPTION
As described in #2763, the result was:
![image](https://user-images.githubusercontent.com/1756811/119500224-db180e00-bd67-11eb-88a0-6e4e60fef542.png)


But now is:
![image](https://user-images.githubusercontent.com/1756811/119498395-e0745900-bd65-11eb-9073-68295696a08b.png)

- The space at the front was indeed the padding on the `code` element, from #2756. Fixed by setting padding to 0 when the `code` is inside a `pre`.
- The extra new line was only in Chromium-based browsers for me, not in Firefox. I think this is some weird Chromium bug, since removing the padding also seems to have fixed this, and I haven't found any other CSS (or HTML) code that would lead to a newline in Chrome but not Firefox.


Closes #2763.
