### PR TITLE
A better "all courses" experience

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,7 +1,7 @@
 {
   "plugins": ["jest"],
   "parserOptions": {
-    "ecmaVersion": 2018,
+    "ecmaVersion": 2020,
     "sourceType": "module"
   },
   "extends": ["eslint:recommended", "google", "plugin:jest/recommended"],

--- a/app/assets/javascripts/course.js
+++ b/app/assets/javascripts/course.js
@@ -314,34 +314,29 @@ function initCoursesListing(firstTab) {
         const courseTabs = document.getElementById("course-tabs");
         baseUrl = courseTabs.dataset.baseurl;
 
-        // Switch to clicked tab
         document.querySelectorAll("#course-tabs li a").forEach(tab => {
             tab.addEventListener("click", () => selectTab(tab));
         });
 
-        // Determine which tab to show first
+        // If the url hash is a valid tab, use that, otherwise use the given tab
         const hash = window.location.hash;
-        let tab = document.querySelector(`a[href='${hash}']`);
-        if (!tab) {
-            tab = document.querySelector(`a[href='#${firstTab}']`);
-        }
+        const tab = document.querySelector(`a[href='${hash}']`) ??
+            document.querySelector(`a[href='#${firstTab}']`);
         selectTab(tab);
     }
 
     function selectTab(tab) {
+        // If the current tab is already loaded or if it's blank, do nothing
+        if (!tab || tab.classList.contains("active")) return;
+
         const state = tab.getAttribute("href").substr(1);
-        if (tab.classList.contains("active")) {
-            // The current tab is already loaded, nothing to do
-            return;
-        }
         loadCourses(state);
         document.querySelector("#course-tabs a.active")?.classList?.remove("active");
         tab.classList.add("active");
     }
 
     function loadCourses(tab) {
-        const state = tab ?? getURLParameter("tab");
-        setBaseUrl(`${baseUrl}?tab=${state}`);
+        setBaseUrl(`${baseUrl}?tab=${tab}`);
     }
 }
 

--- a/app/assets/javascripts/course.js
+++ b/app/assets/javascripts/course.js
@@ -306,11 +306,51 @@ function initCourseNew() {
     init();
 }
 
+function initCoursesListing(firstTab) {
+    let baseUrl = "";
+    initCourseTabs(firstTab);
+
+    function initCourseTabs(firstTab) {
+        const courseTabs = document.getElementById("course-tabs");
+        baseUrl = courseTabs.dataset.baseurl;
+
+        // Switch to clicked tab
+        document.querySelectorAll("#course-tabs li a").forEach(tab => {
+            tab.addEventListener("click", () => selectTab(tab));
+        });
+
+        // Determine which tab to show first
+        const hash = window.location.hash;
+        let tab = document.querySelector(`a[href='${hash}']`);
+        if (!tab) {
+            tab = document.querySelector(`a[href='#${firstTab}']`);
+        }
+        selectTab(tab);
+    }
+
+    function selectTab(tab) {
+        const state = tab.getAttribute("href").substr(1);
+        if (tab.classList.contains("active")) {
+            // The current tab is already loaded, nothing to do
+            return;
+        }
+        loadCourses(state);
+        document.querySelector("#course-tabs a.active")?.classList?.remove("active");
+        tab.classList.add("active");
+    }
+
+    function loadCourses(tab) {
+        const state = tab ?? getURLParameter("tab");
+        setBaseUrl(`${baseUrl}?tab=${state}`);
+    }
+}
+
 export {
     initSeriesReorder,
     initCourseForm,
     initCourseNew,
     initCourseShow,
     initCourseMembers,
+    initCoursesListing,
     loadUsers,
 };

--- a/app/assets/stylesheets/components/card.css.scss
+++ b/app/assets/stylesheets/components/card.css.scss
@@ -294,6 +294,7 @@ a.card-title-link:hover {
   line-height: 25px;
 }
 
+.card-tab .nav-tabs li a.active,
 .card-tab .nav-tabs li.active a,
 .card-tab .nav-tabs li a:hover,
 .card-tab .nav-tabs li a:focus {

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -22,7 +22,6 @@ class CoursesController < ApplicationController
     @courses = apply_scopes(@courses)
     @copy_courses = params[:copy_courses]
     @courses = @courses.paginate(page: parse_pagination_param(params[:page]))
-    @grouped_courses = @courses.group_by(&:year)
     @repository = Repository.find(params[:repository_id]) if params[:repository_id]
     @institution = Institution.find(params[:institution_id]) if params[:institution_id]
     @title = I18n.t('courses.index.title')

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -19,6 +19,8 @@ class CoursesController < ApplicationController
   def index
     authorize Course
     @courses = policy_scope(Course.all)
+    @show_my_courses = current_user && current_user.subscribed_courses.count > 0
+    @show_institution_courses = current_user && @courses.where(institution: current_user.institution).count > 0
     case params[:tab]
     when 'institution'
       @courses = @courses.where(institution: current_user.institution)

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -19,11 +19,17 @@ class CoursesController < ApplicationController
   def index
     authorize Course
     @courses = policy_scope(Course.all)
+    case params[:tab]
+    when 'institution'
+      @courses = @courses.where(institution: current_user.institution)
+    when 'my'
+      @courses = current_user.subscribed_courses
+    end
     @courses = apply_scopes(@courses)
-    @copy_courses = params[:copy_courses]
     @courses = @courses.paginate(page: parse_pagination_param(params[:page]))
     @repository = Repository.find(params[:repository_id]) if params[:repository_id]
     @institution = Institution.find(params[:institution_id]) if params[:institution_id]
+    @copy_courses = params[:copy_courses]
     @title = I18n.t('courses.index.title')
   end
 

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -20,7 +20,7 @@ class CoursesController < ApplicationController
     authorize Course
     @courses = policy_scope(Course.all)
     @show_my_courses = current_user && current_user.subscribed_courses.count > 0
-    @show_institution_courses = current_user && @courses.where(institution: current_user.institution).count > 0
+    @show_institution_courses = current_user&.institution && @courses.where(institution: current_user.institution).count > 0
     case params[:tab]
     when 'institution'
       @courses = @courses.where(institution: current_user.institution)

--- a/app/javascript/packs/course.js
+++ b/app/javascript/packs/course.js
@@ -4,6 +4,7 @@ import {
     initCourseForm,
     initCourseNew,
     initCourseShow,
+    initCoursesListing,
     loadUsers,
 } from "course.js";
 
@@ -18,6 +19,7 @@ window.dodona.initCourseForm = initCourseForm;
 window.dodona.initCourseNew = initCourseNew;
 window.dodona.initCourseShow = initCourseShow;
 window.dodona.initCourseMembers = initCourseMembers;
+window.dodona.initCoursesListing = initCoursesListing;
 window.dodona.loadUsers = loadUsers;
 
 window.dodona.questionTable = RefreshingQuestionTable;

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -155,7 +155,7 @@ class Course < ApplicationRecord
 
   scope :by_name, ->(name) { where('name LIKE ?', "%#{name}%") }
   scope :by_teacher, ->(teacher) { where('teacher LIKE ?', "%#{teacher}%") }
-  scope :by_institution, ->(institution) { where(institution: [institution, nil]) }
+  scope :by_institution, ->(institution) { where(institution: institution) }
   default_scope { order(year: :desc, name: :asc) }
 
   token_generator :secret, unique: false, length: 5

--- a/app/policies/course_policy.rb
+++ b/app/policies/course_policy.rb
@@ -18,7 +18,7 @@ class CoursePolicy < ApplicationPolicy
   end
 
   def index?
-    user
+    true
   end
 
   def show?

--- a/app/views/courses/_courses_table.html.erb
+++ b/app/views/courses/_courses_table.html.erb
@@ -16,7 +16,7 @@
     <% courses.each do |course| %>
       <tr>
         <td>
-          <% if current_user.admin_of?(course) %>
+          <% if current_user&.admin_of?(course) %>
             <span title='<%= t "pages.course_card.course-admin" %>'><i class='mdi mdi-school'></i></span>
           <% end %>
         </td>

--- a/app/views/courses/_courses_table.html.erb
+++ b/app/views/courses/_courses_table.html.erb
@@ -39,4 +39,7 @@
     <% end %>
     </tbody>
   </table>
+  <center>
+    <%= page_navigation_links courses, true, 'courses' %>
+  </center>
 </div>

--- a/app/views/courses/_courses_table.html.erb
+++ b/app/views/courses/_courses_table.html.erb
@@ -2,17 +2,24 @@
   <table class="table table-index table-resource">
     <thead>
     <tr>
+      <th class="status-icon"></th>
       <th><%= Course.human_attribute_name("name") %></th>
       <th><%= Course.human_attribute_name("teacher") %></th>
       <th><%= Course.human_attribute_name("year") %></th>
       <th><%= Course.human_attribute_name("institution") %></th>
       <th><%= t 'courses.index.users' %></th>
+      <th><%= t 'courses.index.exercises' %></th>
       <th></th>
     </tr>
     </thead>
     <tbody>
     <% courses.each do |course| %>
       <tr>
+        <td>
+          <% if current_user.admin_of?(course) %>
+            <span title='<%= t "pages.course_card.course-admin" %>'><i class='mdi mdi-school'></i></span>
+          <% end %>
+        </td>
         <td title="<%= course.name %>" class="text">
           <span><%= link_to course.name, course, target: '_blank' %></span>
         </td>
@@ -20,6 +27,7 @@
         <td><%= course.formatted_year %></td>
         <td><%= course.institution&.name || t('courses.form.no_institution') %></td>
         <td><%= course.subscribed_members_count %></td>
+        <td><%= course.exercises_count %></td>
         <td class="actions">
           <% if policy(course).edit? %>
             <%= link_to edit_course_path(course), class: "btn btn-sm btn-secondary" do %>

--- a/app/views/courses/_repo_courses_table.html.erb
+++ b/app/views/courses/_repo_courses_table.html.erb
@@ -1,5 +1,13 @@
 <div class="table-scroll-wrapper">
   <table class="table table-index table-resource">
+    <colgroup>
+      <col class="col-4"/>
+      <col class="col-2"/>
+      <col class="col-2"/>
+      <col class="col-2"/>
+      <col class="col-1"/>
+      <col class="col-1"/>
+    </colgroup>
     <thead>
     <tr>
       <th><%= Course.human_attribute_name("name") %></th>
@@ -20,12 +28,10 @@
         <td><%= course.formatted_year %></td>
         <td><%= course.institution&.name || t('courses.form.no_institution') %></td>
         <td><%= course.subscribed_members_count %></td>
-        <td class="actions">
-          <% if policy(course).edit? %>
-            <%= link_to edit_course_path(course), class: "btn btn-sm btn-secondary" do %>
-              <i class="mdi mdi-pencil mdi-18"></i>
-            <% end %>
-          <% end %>
+        <td class="repository-course-button-cell" data-course_id="<%= course.id %>" data-repository_id="<%= @repository.id %>">
+          <% show_delete_button = local_assigns.fetch(:show_delete_button, false) %>
+          <%= render partial: 'repositories/repository_course_buttons',
+                      locals: {repository: @repository, course: course, show_delete_button: show_delete_button} %>
         </td>
       </tr>
     <% end %>

--- a/app/views/courses/index.html.erb
+++ b/app/views/courses/index.html.erb
@@ -15,8 +15,9 @@
     </div>
     <div class="card course-search">
       <%= render partial: 'layouts/searchbar', locals: {institutions: Institution.all, eager: !filter_institutions} %>
-    </div>
-    <div id="grouped-course-cards-wrapper">
+      <div class="card-supporting-text">
+        <div id="courses-table-wrapper"></div>
+      </div>
     </div>
   </div>
 </div>

--- a/app/views/courses/index.html.erb
+++ b/app/views/courses/index.html.erb
@@ -19,9 +19,13 @@
       <div class="card-supporting-text">
         <div class="card-tab">
           <ul id="course-tabs" class="nav nav-tabs" data-baseurl="<%= courses_path %>" role="tablist">
-            <li role="presentation"><a href="#institution">Institution courses</a></li>
+            <% if @show_institution_courses %>
+              <li role="presentation"><a href="#institution">Institution courses</a></li>
+            <% end %>
             <li role="presentation"><a href="#all">All courses</a></li>
-            <li role="presentation"><a href="#my">My courses</a></li>
+            <% if @show_my_courses %>
+              <li role="presentation"><a href="#my">My courses</a></li>
+            <% end %>
           </ul>
         </div>
         <%= render partial: 'layouts/searchbar', locals: {institutions: Institution.all, eager: false } %>
@@ -32,6 +36,6 @@
 </div>
 <script type="text/javascript">
   $(function () {
-    dodona.initCoursesListing("institution");
+    dodona.initCoursesListing('<%= @show_institution_courses ? "institution" : "all" %>');
   });
 </script>

--- a/app/views/courses/index.html.erb
+++ b/app/views/courses/index.html.erb
@@ -1,4 +1,6 @@
-<% filter_institutions = current_user&.institution.present? && current_user&.institution.courses.any? %>
+<%= content_for :javascripts do %>
+  <%= javascript_pack_tag 'course' %>
+<% end %>
 <div class="row">
   <div class="col-12">
     <div class="page-subtitle">
@@ -14,21 +16,22 @@
       </div>
     </div>
     <div class="card course-search">
-      <%= render partial: 'layouts/searchbar', locals: {institutions: Institution.all, eager: !filter_institutions} %>
       <div class="card-supporting-text">
+        <div class="card-tab">
+          <ul id="course-tabs" class="nav nav-tabs" data-baseurl="<%= courses_path %>" role="tablist">
+            <li role="presentation"><a href="#institution">Institution courses</a></li>
+            <li role="presentation"><a href="#all">All courses</a></li>
+            <li role="presentation"><a href="#my">My courses</a></li>
+          </ul>
+        </div>
+        <%= render partial: 'layouts/searchbar', locals: {institutions: Institution.all, eager: false } %>
         <div id="courses-table-wrapper"></div>
       </div>
     </div>
   </div>
 </div>
-<% if filter_institutions %>
-  <script type="text/javascript">
-      $(function () {
-          <% if @institution.present? %>
-            dodona.addTokenToSearch("institutions", "<%= @institution.name %>");
-          <% else %>
-            dodona.addTokenToSearch("institutions", "<%= current_user.institution.name %>");
-          <% end %>
-      });
-  </script>
-<% end %>
+<script type="text/javascript">
+  $(function () {
+    dodona.initCoursesListing("institution");
+  });
+</script>

--- a/app/views/courses/index.html.erb
+++ b/app/views/courses/index.html.erb
@@ -20,11 +20,11 @@
         <div class="card-tab">
           <ul id="course-tabs" class="nav nav-tabs" data-baseurl="<%= courses_path %>" role="tablist">
             <% if @show_institution_courses %>
-              <li role="presentation"><a href="#institution">Institution courses</a></li>
+              <li role="presentation"><a href="#institution"><%= t '.institution_courses', institution: (current_user.institution&.short_name || current_user.institution&.name) %></a></li>
             <% end %>
-            <li role="presentation"><a href="#all">All courses</a></li>
+            <li role="presentation"><a href="#all"><%= t '.all_courses' %></a></li>
             <% if @show_my_courses %>
-              <li role="presentation"><a href="#my">My courses</a></li>
+              <li role="presentation"><a href="#my"><%= t '.my_courses' %></a></li>
             <% end %>
           </ul>
         </div>

--- a/app/views/courses/index.js.erb
+++ b/app/views/courses/index.js.erb
@@ -9,5 +9,5 @@ if (dodona.copyCoursesLoaded) {
     dodona.copyCoursesLoaded();
 }
 <% else %>
-$("#grouped-course-cards-wrapper").html("<%= escape_javascript(render partial: 'grouped_course_cards', locals: {grouped_courses: @grouped_courses}) %>")
+$("#courses-table-wrapper").html("<%= escape_javascript(render partial: 'courses/courses_table', locals: {courses: @courses}) %>")
 <% end %>

--- a/app/views/courses/index.js.erb
+++ b/app/views/courses/index.js.erb
@@ -1,5 +1,5 @@
 <% if @repository %>
-$("#courses-table-wrapper").html("<%= escape_javascript(render partial: 'courses/courses_table', locals: {courses: @courses}) %>")
+$("#courses-table-wrapper").html("<%= escape_javascript(render partial: 'courses/repo_courses_table', locals: {courses: @courses}) %>")
 if (dodona.repositoryCoursesLoaded) {
     dodona.repositoryCoursesLoaded();
 }

--- a/config/locales/views/courses/en.yml
+++ b/config/locales/views/courses/en.yml
@@ -51,6 +51,7 @@ en:
     index:
       title: All courses
       users: "Users"
+      exercises: "Exercises"
     new:
       title: Create course
       empty: "Empty course"

--- a/config/locales/views/courses/en.yml
+++ b/config/locales/views/courses/en.yml
@@ -52,6 +52,9 @@ en:
       title: All courses
       users: "Users"
       exercises: "Exercises"
+      institution_courses: "%{institution} courses"
+      all_courses: "All courses"
+      my_courses: "My courses"
     new:
       title: Create course
       empty: "Empty course"

--- a/config/locales/views/courses/nl.yml
+++ b/config/locales/views/courses/nl.yml
@@ -51,6 +51,7 @@ nl:
     index:
       title: Alle cursussen
       users: "Gebruikers"
+      exercises: "Oefeningen"
     new:
       title: Cursus aanmaken
       empty: "Lege cursus"

--- a/config/locales/views/courses/nl.yml
+++ b/config/locales/views/courses/nl.yml
@@ -52,6 +52,9 @@ nl:
       title: Alle cursussen
       users: "Gebruikers"
       exercises: "Oefeningen"
+      institution_courses: "%{institution} cursussen"
+      all_courses: "Alle cursussen"
+      my_courses: "Mijn cursussen"
     new:
       title: Cursus aanmaken
       empty: "Lege cursus"

--- a/test/system/courses_test.rb
+++ b/test/system/courses_test.rb
@@ -1,0 +1,34 @@
+require 'capybara/minitest'
+require 'application_system_test_case'
+
+class CoursesTest < ApplicationSystemTestCase
+  include Devise::Test::IntegrationHelpers
+  # Make the Capybara DSL available in all integration tests
+  include Capybara::DSL
+  # Make `assert_*` methods behave like Minitest assertions
+  include Capybara::Minitest::Assertions
+
+  test 'Can view courses page with working tabs' do
+    zeus = create(:zeus)
+    c1 = create :course, series_count: 1, activities_per_series: 1, submissions_per_exercise: 1
+    c2 = create :course, series_count: 1, activities_per_series: 1, submissions_per_exercise: 1
+    c3 = create :course, series_count: 1, activities_per_series: 1, submissions_per_exercise: 1
+    c1.administrating_members.concat(zeus)
+    c2.update(institution: zeus.institution)
+    c3.update(institution: zeus.institution)
+
+    sign_in zeus
+
+    visit(courses_path)
+    assert_selector '#course-tabs li', count: 3
+    assert_selector 'a[href="#institution"].active'
+    assert_selector '#courses-table-wrapper tbody tr', count: 2
+
+    find('#course-tabs').click_link 'All courses'
+    assert_selector 'a[href="#all"].active'
+    assert_selector '#courses-table-wrapper tbody tr', count: 3
+    find('#course-tabs').click_link 'My courses'
+    assert_selector 'a[href="#my"].active'
+    assert_selector '#courses-table-wrapper tbody tr', count: 1
+  end
+end


### PR DESCRIPTION
This pull request improves the "all courses" experience.

Right now, the "all courses" experience isn't great. Especially, because this is one of the first pages a new user encounters.
The cards are visually pleasing, but make it hard to scan if you're looking for something specific. In addition, the filter options can be confusing because filtering for an institution also lists courses for outside that institution.

To make it easier to scan the page, the course listing was reverted to a standard table instead of using the cards. To avoid confusion with the filter, 3 tabs are shown: "institution courses", "all courses" and "my courses". By default, the first tab is shown.

In addition, it also makes the courses page available for users who are not signed in.

Follow up issue: Featured courses (#2780)

**Before**
![image](https://user-images.githubusercontent.com/481872/120653773-502ec600-c481-11eb-9d5b-77fc89747d32.png)

**After**
![image](https://user-images.githubusercontent.com/481872/120653910-718fb200-c481-11eb-8e01-1c1c34cc4ae2.png)

Closes #1118