### PR TITLE
Fix code tab not automatically loading during feedback

### DIFF
--- a/app/views/feedbacks/show.html.erb
+++ b/app/views/feedbacks/show.html.erb
@@ -83,9 +83,11 @@
 </div>
 <% if @feedback.submission.present? %>
   <script>
-    window.MathJax.startup.promise.then(() => {
-      window.dodona.codeListing.setEvaluation(<%= @feedback.evaluation.id %>)
+      $(function () {
+        window.MathJax.startup.promise.then(() => {
+          window.dodona.codeListing.setEvaluation(<%= @feedback.evaluation.id %>);
+        });
         $(".nav.nav-tabs li:last-child a").tab("show");
-    });
+      });
   </script>
 <% end %>


### PR DESCRIPTION
This pull request fixes the tab-switching-to-code during feedback. The issue was caused because the call to switch the tab was made before the page was ready.

Closes #2784 
