### PR TITLE
Fix filtering submissions by user label

### DIFF
--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -10,7 +10,7 @@ class SubmissionsController < ApplicationController
   has_scope :by_status, as: 'status'
 
   has_scope :by_course_labels, as: 'course_labels', type: :array do |controller, scope, value|
-    course = Course.find_by(controller.params[:course_id]) if controller.params[:course_id].present?
+    course = Course.find_by(id: controller.params[:course_id]) if controller.params[:course_id].present?
     if course.present? && controller.current_user&.course_admin?(course) && controller.params[:user_id].nil?
       scope.by_course_labels(value, controller.params[:course_id])
     else


### PR DESCRIPTION
This pull request fixes an issue where filtering submissions on a user label didn't work for course admins but where it did for zeus.
The cause was an incorrect use of the `find_by` function which then fetched an incorrect course and caused the admin check to fail.

I checked all other uses of `find_by` but didn't find similar other bugs.

Closes #2785 