### PR TITLE
Fix error on loading courses page when not signed in

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -21,11 +21,13 @@ class CoursesController < ApplicationController
     @courses = policy_scope(Course.all)
     @show_my_courses = current_user && current_user.subscribed_courses.count > 0
     @show_institution_courses = current_user&.institution && @courses.where(institution: current_user.institution).count > 0
-    case params[:tab]
-    when 'institution'
-      @courses = @courses.where(institution: current_user.institution)
-    when 'my'
-      @courses = current_user.subscribed_courses
+    if current_user
+      case params[:tab]
+      when 'institution'
+        @courses = @courses.where(institution: current_user.institution)
+      when 'my'
+        @courses = current_user.subscribed_courses
+      end
     end
     @courses = apply_scopes(@courses)
     @courses = @courses.paginate(page: parse_pagination_param(params[:page]))


### PR DESCRIPTION
This pull request fixes an error when going to the courses page when not signed in.
In the normal case, there was no error, but the page failed to load if a specific tab was requested using the url (institution or my). These tabs are not shown to signed out users but could be accessed when modifying the url. An extra check was added in the controller.

Closes #2834
