### PR TITLE
Fix missing select arrow on score item copy modal

### DIFF
--- a/app/views/score_items/_copy.html.erb
+++ b/app/views/score_items/_copy.html.erb
@@ -15,7 +15,7 @@
                                   :id,
                                   ->(e) { e.exercise.name },
                                   { include_blank: t("score_items.copy.choose") },
-                                  { class: "form-control", required: true } %>
+                                  { class: "form-select", required: true } %>
         </div>
       </div>
     </div>


### PR DESCRIPTION
This pull request fixes a missing dropdown arrow. This is due to a change in bootstrap 5 (the class of a select should be `form-select` instead of `form-control`. This was previously fixed for other selects, but because this one was created using a rails helper, I missed it. I searched for other such constructs but didn't find any.

Closes #2805
