### PR TITLE
Create issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -12,4 +12,5 @@ When creating a bug report, please include:
 - a description of what goes wrong on which page
 - the steps to reproduce the bug
 - a screenshot showing the problem, if relevant
+- a link to a page where your problem happens, if relevant
 --->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,15 @@
+---
+name: Bug report
+about: Notify us of an issue with Dodona
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+<!--- 
+When creating a bug report, please include:
+- a description of what goes wrong on which page
+- the steps to reproduce the bug
+- a screenshot showing the problem, if relevant
+--->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,13 @@
+---
+name: Feature request
+about: Suggest a new feature for Dodona
+title: ''
+labels: feature
+assignees: ''
+
+---
+
+<!--- 
+When creating a feature request, please include a clear use case for your request.
+If you're not sure about your request, you can always open a topic in the Discussions tab first.
+--->


### PR DESCRIPTION
This pull requests add issue templates. I have explicitly chosen to not add text to the templates, but merely suggested what should be included using html comments. These comments will not render in de final issue.