### PR TITLE
Add contact links to the create issue page

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,6 @@
+contact_links:
+  - name: GitHub Discussions
+    url: https://github.com/dodona-edu/dodona/discussions
+    about: Please ask questions or discuss potential feature requests here.
+  - name: Dodona documentation
+    url: https://docs.dodona.be


### PR DESCRIPTION
This pull request adds links to the documentation and github discussions to the create issue page.
