### PR TITLE
html-encode the text of machine annotations

### DIFF
--- a/app/assets/javascripts/code_listing/machine_annotation.ts
+++ b/app/assets/javascripts/code_listing/machine_annotation.ts
@@ -9,9 +9,13 @@ export interface MachineAnnotationData {
 export class MachineAnnotation extends Annotation {
     constructor(data: MachineAnnotationData) {
         // Filter out lines only containing dashes.
-        const text = data.text.split("\n")
+        let text = data.text.split("\n")
             .filter(s => !s.match("^--*$"))
             .join("\n");
+        // use the dom engine to encode the text to html
+        const node = document.createElement("span");
+        node.textContent = text;
+        text = node.innerHTML;
         super(data.row + 1, text, data.type);
     }
 

--- a/test/javascript/code_listing.test.ts
+++ b/test/javascript/code_listing.test.ts
@@ -58,6 +58,12 @@ test("create feedback table with default settings", () => {
     expect(document.querySelectorAll(".annotation").length).toBe(3);
 });
 
+test("html in annotations should be escaped", () => {
+    codeListing.addMachineAnnotations([{ "text": "<b>test</b>", "row": 0, "type": "warning" }]);
+
+    expect(document.querySelector(".annotation .annotation-text").textContent).toBe("<b>test</b>");
+});
+
 test("feedback table should support more than 1 annotation per row (first and last row)", () => {
     codeListing.addMachineAnnotations([
         { "text": "Value could be assigned", "row": 0, "type": "warning" },


### PR DESCRIPTION
This pull request fixes an issue where machine annotations containing a `<` were not properly rendered. The cause was that the text of the annotations was injected as html into the page. This PR add html encoding to the text of machine annotations and adds a test for this.

This might break the annotations of linters outputting html instead of text.

Closes #2050 