### PR TITLE
Tweak annotations style

### DIFF
--- a/app/assets/javascripts/code_listing/annotation.ts
+++ b/app/assets/javascripts/code_listing/annotation.ts
@@ -19,8 +19,8 @@ export abstract class Annotation {
         this.type = type;
     }
 
-    protected get body(): HTMLSpanElement {
-        const body = document.createElement("span") as HTMLSpanElement;
+    protected get body(): HTMLDivElement {
+        const body = document.createElement("div") as HTMLDivElement;
         body.classList.add("annotation-text");
         body.innerHTML = this.text;
         return body;

--- a/app/assets/stylesheets/components/code_listing.css.scss
+++ b/app/assets/stylesheets/components/code_listing.css.scss
@@ -193,8 +193,12 @@ $annotation-info: $info-500;
     }
 
     .annotation-text {
-      display: block;
       word-break: break-word;
+      padding-bottom: 4px;
+
+      p:last-child {
+        margin-bottom: 0;
+      }
 
       // Override the normal pre padding & coloring
       pre {


### PR DESCRIPTION
This pull request slightly tweaks the annotation style to account for changes made by bootstrap 5. 
- The last paragraph in an annotation now doesn't add a bottom margin
- The annotation-text gets a bottom padding
- Annotation-text is now a div instead of a span with block styling

**Before**
![image](https://user-images.githubusercontent.com/481872/121660136-4ae60280-caa3-11eb-8d17-78de9378cdc1.png)

**After**
![image](https://user-images.githubusercontent.com/481872/121660204-5afde200-caa3-11eb-8afa-057a7e2d7d2d.png)

