### PR TITLE
Tweak teacher rights request flow

### DIFF
--- a/app/policies/rights_request_policy.rb
+++ b/app/policies/rights_request_policy.rb
@@ -9,6 +9,10 @@ class RightsRequestPolicy < ApplicationPolicy
     user&.zeus?
   end
 
+  def new?
+    user
+  end
+
   def create?
     user&.student? && user.institution.present? && user.rights_request.nil?
   end

--- a/app/views/pages/contact.html.erb
+++ b/app/views/pages/contact.html.erb
@@ -11,7 +11,7 @@
           <p><%= t('.contact_p3_html') %></p>
         </div>
         <div class="col-lg-6">
-          <% if policy(RightsRequest).create? %>
+          <% if policy(RightsRequest).new? %>
             <div class="callout callout-info">
               <h4><%= t('.rights_request_title') %></h4>
               <%= t('.rights_request_redirect_html', url: new_rights_request_path) %>

--- a/app/views/rights_requests/new.html.erb
+++ b/app/views/rights_requests/new.html.erb
@@ -3,12 +3,20 @@
     <div class="card">
       <div class="card-title card-title-colored">
         <h2 class="card-title-text"><%= t ".title" %></h2>
-        <div class="card-title-fab">
-          <%= render 'fab_button', form: 'new_rights_request', icon: 'send' %>
-        </div>
+        <% if policy(RightsRequest).create? %>
+          <div class="card-title-fab">
+            <%= render 'fab_button', form: 'new_rights_request', icon: 'send' %>
+          </div>
+        <% end %>
       </div>
       <div class="card-supporting-text">
-        <%= render 'form', rights_request: @rights_request %>
+        <% if policy(RightsRequest).create? %>
+          <%= render 'form', rights_request: @rights_request %>
+        <% else %>
+          <div class="callout callout-info">
+            <p><%= t '.request_not_possible' %></p>
+          </div>
+        <% end %>
       </div>
     </div>
   </div>

--- a/app/views/rights_requests/new.html.erb
+++ b/app/views/rights_requests/new.html.erb
@@ -13,9 +13,17 @@
         <% if policy(RightsRequest).create? %>
           <%= render 'form', rights_request: @rights_request %>
         <% else %>
-          <div class="callout callout-info">
-            <p><%= t '.request_not_possible' %></p>
-          </div>
+          <div class="callout callout-info"><p>
+            <% if !current_user&.student? %>
+              <%= t '.request_not_possible_no_student' %>
+            <% elsif !current_user.rights_request.nil? %>
+              <%= t '.request_not_possible_pending' %>
+            <% elsif !current_user.institution.present? %>
+              <%= t '.request_not_possible_no_institution' %>
+            <% else %>
+              <%= t '.request_not_possible' %>
+            <% end %>
+          </p></div>
         <% end %>
       </div>
     </div>

--- a/config/locales/views/rights_requests/en.yml
+++ b/config/locales/views/rights_requests/en.yml
@@ -2,6 +2,7 @@ en:
   rights_requests:
     new:
       title: Request teacher rights
+      request_not_possible: It looks like you already have teacher rights or that a previous request is still pending. You can't make a new request at this time.
     form:
       process_help: We will check your request as soon as possible. You will receive an email once we've responded to it.
       institution-help: We do not yet have a proper name for your educational institution. Suggest one here.

--- a/config/locales/views/rights_requests/en.yml
+++ b/config/locales/views/rights_requests/en.yml
@@ -3,6 +3,9 @@ en:
     new:
       title: Request teacher rights
       request_not_possible: It looks like you already have teacher rights or that a previous request is still pending. You can't make a new request at this time.
+      request_not_possible_pending: It looks like a previous request is still pending, so you can't make a new request at this time.
+      request_not_possible_no_student: It looks like you already have teacher rights, so there's no need to request them again.
+      request_not_possible_no_institution: It looks like there is no institution associated with your used, so unfortunately you can't request teacher rights.
     form:
       process_help: We will check your request as soon as possible. You will receive an email once we've responded to it.
       institution-help: We do not yet have a proper name for your educational institution. Suggest one here.

--- a/config/locales/views/rights_requests/en.yml
+++ b/config/locales/views/rights_requests/en.yml
@@ -5,7 +5,7 @@ en:
       request_not_possible: It looks like you already have teacher rights or that a previous request is still pending. You can't make a new request at this time.
       request_not_possible_pending: It looks like a previous request is still pending, so you can't make a new request at this time.
       request_not_possible_no_student: It looks like you already have teacher rights, so there's no need to request them again.
-      request_not_possible_no_institution: It looks like there is no institution associated with your used, so unfortunately you can't request teacher rights.
+      request_not_possible_no_institution: It looks like there is no institution associated with your account, so unfortunately you can't request teacher rights.
     form:
       process_help: We will check your request as soon as possible. You will receive an email once we've responded to it.
       institution-help: We do not yet have a proper name for your educational institution. Suggest one here.

--- a/config/locales/views/rights_requests/nl.yml
+++ b/config/locales/views/rights_requests/nl.yml
@@ -2,6 +2,7 @@ nl:
   rights_requests:
     new:
       title: Lesgeversrechten aanvragen
+      request_not_possible: Het lijkt erop dat je al lesgeversrechten heb of dat er een aanvraag lopende is. Je kan op dit moment geen nieuwe aanvraag doen.
     form:
       process_help: We bekijken je aanvraag zo snel mogelijk. Je krijgt een email op het moment dat we je aanvraag verwerkt hebben.
       institution-help: We hebben nog geen naam voor je onderwijsinstelling. Stel er hier een voor.

--- a/config/locales/views/rights_requests/nl.yml
+++ b/config/locales/views/rights_requests/nl.yml
@@ -3,6 +3,9 @@ nl:
     new:
       title: Lesgeversrechten aanvragen
       request_not_possible: Het lijkt erop dat je al lesgeversrechten heb of dat er een aanvraag lopende is. Je kan op dit moment geen nieuwe aanvraag doen.
+      request_not_possible_pending: Het lijkt erop dat er nog een aanvraag lopende is, dus je kan momenteel geen nieuwe aanvraag doen.
+      request_not_possible_no_student: Het lijkt erop dat je al lesgeversrechten hebt, dus het is niet nodig om deze opnieuw aan te vragen.
+      request_not_possible_no_institution: Er is geen onderwijsinstelling gekoppeld met je account. Het is niet mogelijk om lesgeversrechten aan te vragen.
     form:
       process_help: We bekijken je aanvraag zo snel mogelijk. Je krijgt een email op het moment dat we je aanvraag verwerkt hebben.
       institution-help: We hebben nog geen naam voor je onderwijsinstelling. Stel er hier een voor.


### PR DESCRIPTION
This pull request slightly tweaks the rights request form to make it less confusing if you already have rights. The callout on the contact page is now shown if you are signed in (instead of only if you were eligible). Gating is done on the actual form page. It there shows the form if you are eligible or a message otherwise.

For this, the policy was split into a separate `new?` policy.

Closes #2699 