### PR TITLE
Add featured courses

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -21,16 +21,15 @@ class CoursesController < ApplicationController
     @courses = policy_scope(Course.all)
     @show_my_courses = current_user && current_user.subscribed_courses.count > 0
     @show_institution_courses = current_user&.institution && @courses.where(institution: current_user.institution).count > 0
-    if current_user
-      case params[:tab]
-      when 'institution'
-        @courses = @courses.where(institution: current_user.institution)
-      when 'featured'
-        @courses = @courses.where(featured: true)
-      when 'my'
-        @courses = current_user.subscribed_courses
-      end
+
+    if current_user && params[:tab] == 'institution'
+      @courses = @courses.where(institution: current_user.institution)
+    elsif current_user && params[:tab] == 'my'
+      @courses = current_user.subscribed_courses
+    elsif params[:tab] == 'featured'
+      @courses = @courses.where(featured: true)
     end
+
     @courses = apply_scopes(@courses)
     @courses = @courses.paginate(page: parse_pagination_param(params[:page]))
     @repository = Repository.find(params[:repository_id]) if params[:repository_id]

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -28,6 +28,8 @@ class CoursesController < ApplicationController
       @courses = current_user.subscribed_courses
     elsif params[:tab] == 'featured'
       @courses = @courses.where(featured: true)
+    elsif params[:copy_courses]
+      @courses = @courses.reorder(featured: :desc, year: :desc, name: :asc)
     end
 
     @courses = apply_scopes(@courses)

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -25,6 +25,8 @@ class CoursesController < ApplicationController
       case params[:tab]
       when 'institution'
         @courses = @courses.where(institution: current_user.institution)
+      when 'featured'
+        @courses = @courses.where(featured: true)
       when 'my'
         @courses = current_user.subscribed_courses
       end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -17,6 +17,7 @@
 #  search            :string(4096)
 #  moderated         :boolean          default(FALSE), not null
 #  enabled_questions :boolean          default(TRUE), not null
+#  featured          :boolean          default(FALSE), not null
 #
 
 require 'securerandom'

--- a/app/policies/course_policy.rb
+++ b/app/policies/course_policy.rb
@@ -151,9 +151,9 @@ class CoursePolicy < ApplicationPolicy
   def permitted_attributes
     # record is the Course class on create
     if zeus?
-      %i[name year description visibility registration color teacher institution_id moderated enabled_questions featured]
+      %i[name year description visibility registration teacher institution_id moderated enabled_questions color featured]
     elsif course_admin? || (record == Course && user&.admin?)
-      %i[name year description visibility registration color teacher institution_id moderated enabled_questions]
+      %i[name year description visibility registration teacher institution_id moderated enabled_questions]
     else
       []
     end

--- a/app/policies/course_policy.rb
+++ b/app/policies/course_policy.rb
@@ -150,7 +150,9 @@ class CoursePolicy < ApplicationPolicy
 
   def permitted_attributes
     # record is the Course class on create
-    if course_admin? || (record == Course && user&.admin?)
+    if zeus?
+      %i[name year description visibility registration color teacher institution_id moderated enabled_questions featured]
+    elsif course_admin? || (record == Course && user&.admin?)
       %i[name year description visibility registration color teacher institution_id moderated enabled_questions]
     else
       []

--- a/app/views/courses/_copy_courses_table.html.erb
+++ b/app/views/courses/_copy_courses_table.html.erb
@@ -15,7 +15,12 @@
           <input type="radio" name="course-select" class="form-check-input">
         </td>
         <td>
-          <span><%= course.name %> <span class="text-muted">(<%= course.formatted_year %>)</span></span>
+          <span>
+            <% if course.featured %>
+              <span title='<%= Course.human_attribute_name("featured") %>'><i class='mdi mdi-18 mdi-star-outline'></i></span>
+            <% end %>
+            <%= course.name %> <span class="text-muted">(<%= course.formatted_year %>)</span>
+          </span>
           <br/>
           <small class="text-muted"><%= [course.teacher, course.institution&.name].select(&:present?).join(" - ") %></small>
         </td>

--- a/app/views/courses/_courses_table.html.erb
+++ b/app/views/courses/_courses_table.html.erb
@@ -19,6 +19,9 @@
           <% if current_user&.admin_of?(course) %>
             <span title='<%= t "pages.course_card.course-admin" %>'><i class='mdi mdi-school'></i></span>
           <% end %>
+          <% if course.featured %>
+            <span title='<%= Course.human_attribute_name("featured") %>'><i class='mdi mdi-star-outline'></i></span>
+          <% end %>
         </td>
         <td title="<%= course.name %>" class="text">
           <span><%= link_to course.name, course, target: '_blank' %></span>

--- a/app/views/courses/_form.html.erb
+++ b/app/views/courses/_form.html.erb
@@ -75,6 +75,16 @@
       <span class="help-block offset-sm-3 col-sm-6"><%= t ".description-help" %></span>
     </div>
 
+    <div class="field form-group row">
+      <%= f.label :questions, t(".questions.title"), class: 'col-sm-3 col-form-label' %>
+      <div class="col-sm-6 pt-2">
+        <div class="form-check <%= "form-switch" unless course.new_record? %>">
+          <%= f.check_box :enabled_questions, class: 'form-check-input' %>
+          <%= f.label :enabled_questions, t(".questions.toggle-label"), class: 'form-check-label' %>
+        </div>
+      </div>
+    </div>
+
     <% if current_user.zeus? %>
       <div class="field form-group row">
         <%= f.label :color, class: 'col-sm-3 col-form-label' %>
@@ -86,17 +96,16 @@
                        {class: 'form-select'} %>
         </div>
       </div>
-    <% end %>
-
-    <div class="field form-group row">
-      <%= f.label :questions, t(".questions.title"), class: 'col-sm-3 col-form-label' %>
-      <div class="col-sm-6 pt-2">
-        <div class="form-check <%= "form-switch" unless course.new_record? %>">
-          <%= f.check_box :enabled_questions, class: 'form-check-input' %>
-          <%= f.label :enabled_questions, t(".questions.toggle-label"), class: 'form-check-label' %>
+      <div class="field form-group row">
+        <%= f.label :featured, t(".featured.title"), class: 'col-sm-3 col-form-label' %>
+        <div class="col-sm-6 pt-2">
+          <div class="form-check">
+            <%= f.check_box :featured, class: 'form-check-input' %>
+            <%= f.label :featured, t(".featured.toggle-label"), class: 'form-check-label' %>
+          </div>
         </div>
       </div>
-    </div>
+    <% end %>
   </div>
 
   <div class="<%= course.new_record? ? "stepper-part stepper-border" : "card-supporting-text card-border" %>">

--- a/app/views/courses/_form.html.erb
+++ b/app/views/courses/_form.html.erb
@@ -85,7 +85,7 @@
       </div>
     </div>
 
-    <% if current_user.zeus? %>
+    <% if f.permission?(:color) %>
       <div class="field form-group row">
         <%= f.label :color, class: 'col-sm-3 col-form-label' %>
         <div class="col-sm-6">
@@ -96,6 +96,8 @@
                        {class: 'form-select'} %>
         </div>
       </div>
+    <% end %>
+    <% if f.permission?(:featured) %>
       <div class="field form-group row">
         <%= f.label :featured, t(".featured.title"), class: 'col-sm-3 col-form-label' %>
         <div class="col-sm-6 pt-2">

--- a/app/views/courses/index.html.erb
+++ b/app/views/courses/index.html.erb
@@ -22,6 +22,7 @@
             <% if @show_institution_courses %>
               <li role="presentation"><a href="#institution"><%= t '.institution_courses', institution: (current_user.institution&.short_name || current_user.institution&.name) %></a></li>
             <% end %>
+            <li role="presentation"><a href="#featured"><%= t '.featured_courses' %></a></li>
             <li role="presentation"><a href="#all"><%= t '.all_courses' %></a></li>
             <% if @show_my_courses %>
               <li role="presentation"><a href="#my"><%= t '.my_courses' %></a></li>
@@ -36,6 +37,6 @@
 </div>
 <script type="text/javascript">
   $(function () {
-    dodona.initCoursesListing('<%= @show_institution_courses ? "institution" : "all" %>');
+    dodona.initCoursesListing('<%= @show_institution_courses ? "institution" : "featured" %>');
   });
 </script>

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -6,6 +6,11 @@
   <div class="col-md-10 col-12 offset-md-1 page-content">
     <div class="card">
       <div class="card-title card-title-colored">
+        <% if @course.featured %>
+          <h2 class='card-title-text float-end' title='<%= Course.human_attribute_name("featured") %>'>
+            <i class="mdi mdi-star-outline"></i>
+          </h2>
+        <% end %>
         <% if !@course.open_for_all? || @course.moderated %>
           <% title = [] %>
           <% title.push t(".registration-#{@course.registration}-info", institution: @course.institution&.name) unless @course.open_for_all? %>

--- a/config/locales/models/en.yml
+++ b/config/locales/models/en.yml
@@ -42,6 +42,7 @@ en:
         visibility: Visibility
         registration: Registration
         moderated: Moderated
+        featured: Featured course
         visibilities:
           visible_for_all: Visible for everyone
           visible_for_institution: Only visible for members of the configured institution

--- a/config/locales/models/nl.yml
+++ b/config/locales/models/nl.yml
@@ -43,6 +43,7 @@ nl:
         visibility: Zichtbaarheid
         registration: Registratie
         moderated: Gemodereerd
+        featured: Uitgelichte cursus
         visibilities:
           visible_for_all: Zichtbaar voor iedereen
           visible_for_institution: Zichtbaar voor gebruikers van de ingestelde onderwijsinstelling

--- a/config/locales/views/courses/en.yml
+++ b/config/locales/views/courses/en.yml
@@ -56,6 +56,7 @@ en:
       users: "Users"
       exercises: "Exercises"
       institution_courses: "%{institution} courses"
+      featured_courses: Featured courses
       all_courses: "All courses"
       my_courses: "My courses"
     new:

--- a/config/locales/views/courses/en.yml
+++ b/config/locales/views/courses/en.yml
@@ -48,6 +48,9 @@ en:
       questions:
         title: Questions
         toggle-label: Allow students to pose questions
+      featured:
+        title: Featured course
+        toggle-label: Feature this course
     index:
       title: All courses
       users: "Users"

--- a/config/locales/views/courses/nl.yml
+++ b/config/locales/views/courses/nl.yml
@@ -48,6 +48,9 @@ nl:
       questions:
         title: Vragen
         toggle-label: Sta toe dat studenten vragen stellen
+      featured:
+        title: Uitgelichte cursus
+        toggle-label: Deze cursus uitlichten
     index:
       title: Alle cursussen
       users: "Gebruikers"

--- a/config/locales/views/courses/nl.yml
+++ b/config/locales/views/courses/nl.yml
@@ -56,6 +56,7 @@ nl:
       users: "Gebruikers"
       exercises: "Oefeningen"
       institution_courses: "%{institution} cursussen"
+      featured_courses: Uitgelichte cursussen
       all_courses: "Alle cursussen"
       my_courses: "Mijn cursussen"
     new:

--- a/db/migrate/20210612104516_add_featured_to_courses.rb
+++ b/db/migrate/20210612104516_add_featured_to_courses.rb
@@ -1,0 +1,6 @@
+class AddFeaturedToCourses < ActiveRecord::Migration[6.1]
+  def change
+    add_column :courses, :featured, :boolean, default: false, null: false
+    add_index :courses, :featured
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_16_085755) do
+ActiveRecord::Schema.define(version: 2021_06_12_104516) do
 
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
@@ -187,6 +187,8 @@ ActiveRecord::Schema.define(version: 2021_04_16_085755) do
     t.string "search", limit: 4096
     t.boolean "moderated", default: false, null: false
     t.boolean "enabled_questions", default: true, null: false
+    t.boolean "featured", default: false, null: false
+    t.index ["featured"], name: "index_courses_on_featured"
     t.index ["institution_id"], name: "index_courses_on_institution_id"
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -85,7 +85,7 @@ if Rails.env.development?
   %w[red pink purple deep-purple indigo teal orange brown blue-grey].each do |color|
     Label.create name: Faker::GreekPhilosophers.unique.name, color: color
   end
-  
+
   puts "Creating programming languages (#{Time.now - start})"
   ICON_MAP = {
     'python' => 'language-python',
@@ -114,6 +114,7 @@ if Rails.env.development?
   courses << Course.create(description: 'This is a test course.', name: 'Closed Test Course', year: '2020-2021', registration: 'closed', visibility: 'hidden', moderated: false, teacher: 'Graaf van Rommelgem')
   courses << Course.create(description: 'This is a test course.', name: 'Old Open for All Test Course', year: '2019-2020', registration: 'open_for_all', visibility: 'visible_for_all', teacher: 'Prof. Gobelijn')
   courses << Course.create(description: 'This is a test course.', name: 'Very Old Open for All Test Course', year: '2018-2019', registration: 'open_for_all', visibility: 'visible_for_all', teacher: 'Prof. Gobelijn')
+  courses << Course.create(description: 'This is a test course.', name: 'Featured course', year: '2018-2019', registration: 'open_for_all', visibility: 'visible_for_all', teacher: 'Prof. Zonnebloem', featured: true)
 
   puts "Adding users to courses (#{Time.now - start})"
 
@@ -133,7 +134,7 @@ if Rails.env.development?
   # add some students to the moderated course
   pending = students.sample(60)
   courses[2].pending_members.concat(pending - courses[2].enrolled_members)
-  
+
   puts "Adding labels to courses (#{Time.now - start})"
   courses.each do |course|
     cl = CourseLabel.create course_id: course.id, name: Faker::CryptoCoin.unique.coin_name, created_at: Time.now, updated_at: Time.now

--- a/test/controllers/courses_controller_test.rb
+++ b/test/controllers/courses_controller_test.rb
@@ -437,8 +437,8 @@ class CoursesPermissionControllerTest < ActionDispatch::IntegrationTest
   test 'signed out users should be able to see the courses listing' do
     get courses_url
     assert_response :success
-    # we only expect the "all courses" tab to show for signed out users
-    assert_select '#course-tabs li', 1
+    # we only expect the "all courses" and "featured courses" tabs to show for signed out users
+    assert_select '#course-tabs li', 2
   end
 
   test 'users should be able to filter courses' do
@@ -464,6 +464,22 @@ class CoursesPermissionControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     courses = JSON.parse response.body
     assert_equal 2, courses.length
+  end
+
+  test 'featured courses should only show featured courses' do
+    get courses_url, params: { format: :json }
+    assert_response :success
+    courses = JSON.parse response.body
+    assert_equal 1, courses.length
+    get courses_url, params: { format: :json, tab: 'featured' }
+    assert_response :success
+    courses = JSON.parse response.body
+    assert_equal 0, courses.length
+    @course.update(featured: true)
+    get courses_url, params: { format: :json, tab: 'featured' }
+    assert_response :success
+    courses = JSON.parse response.body
+    assert_equal 1, courses.length
   end
 
   test 'users should be able to favorite subscribed courses' do

--- a/test/factories/courses.rb
+++ b/test/factories/courses.rb
@@ -17,6 +17,7 @@
 #  search            :string(4096)
 #  moderated         :boolean          default(FALSE), not null
 #  enabled_questions :boolean          default(TRUE), not null
+#  featured          :boolean          default(FALSE), not null
 #
 
 FactoryBot.define do

--- a/test/models/course_test.rb
+++ b/test/models/course_test.rb
@@ -17,6 +17,7 @@
 #  search            :string(4096)
 #  moderated         :boolean          default(FALSE), not null
 #  enabled_questions :boolean          default(TRUE), not null
+#  featured          :boolean          default(FALSE), not null
 #
 
 require 'test_helper'

--- a/test/system/courses_test.rb
+++ b/test/system/courses_test.rb
@@ -20,7 +20,7 @@ class CoursesTest < ApplicationSystemTestCase
     sign_in zeus
 
     visit(courses_path)
-    assert_selector '#course-tabs li', count: 3
+    assert_selector '#course-tabs li', count: 4
     assert_selector 'a[href="#institution"].active'
     assert_selector '#courses-table-wrapper tbody tr', count: 2
 


### PR DESCRIPTION
This pull request adds the concept of "featured courses" to Dodona which can be used to highlight specific courses such as De Programmeursleerling or the Youtube course and exercises of @deepeebee. In addition this would help avoid confusion caused by copies of those courses.

`featured` is a course flag that can only be set by zeus users. Featured courses are listed in a separated tab on the all courses page and are listed first in the copy course listing.

![image](https://user-images.githubusercontent.com/481872/121817432-c1d8f200-cc81-11eb-969a-f897b6b938a7.png)
![image](https://user-images.githubusercontent.com/481872/121817449-d4532b80-cc81-11eb-9f84-2bd0d1f0030e.png)
![image](https://user-images.githubusercontent.com/481872/121817461-e46b0b00-cc81-11eb-9dc8-9f106e5b792e.png)
![image](https://user-images.githubusercontent.com/481872/121817472-f2b92700-cc81-11eb-95ee-01d9092bece0.png)
![image](https://user-images.githubusercontent.com/481872/121817493-0ebcc880-cc82-11eb-8fae-f907f1a29b01.png)


Closes #2780 
