### PR TITLE
Fix export scoping

### DIFF
--- a/app/controllers/series_controller.rb
+++ b/app/controllers/series_controller.rb
@@ -141,7 +141,7 @@ class SeriesController < ApplicationController
       user = User.find_by(email: email)
       if user
         options = { deadline: true, only_last_submission: true, with_info: true, all_students: true, indianio: true }
-        send_zip Zipper.new(item: @series, list: @series.exercises, users: [user], options: options).bundle
+        send_zip Zipper.new(item: @series, list: @series.exercises, users: [user], options: options, for_user: user).bundle
       else
         render json: { errors: ['Unknown email'] }, status: :not_found
       end

--- a/app/helpers/export_helper.rb
+++ b/app/helpers/export_helper.rb
@@ -2,6 +2,8 @@ require 'zip'
 
 module ExportHelper
   class Zipper
+    include Pundit
+
     attr_reader :users, :item, :errors
 
     CONVERT_TO_BOOL = %w[indianio deadline all_students only_last_submission with_info all with_labels].freeze
@@ -19,6 +21,7 @@ module ExportHelper
       @options = get_options(kwargs[:options])
       @list = kwargs[:list]
       @users = kwargs[:users]
+      @for_user = kwargs[:for_user]
       case @item
       when Series
         @list = @item.exercises if all?
@@ -247,7 +250,7 @@ module ExportHelper
     end
 
     def get_submissions_for_series(selected_exercises, users)
-      submissions = Submission.all.where(user_id: users.map(&:id), exercise_id: selected_exercises.map(&:id)).includes(:user, :exercise)
+      submissions = policy_scope(Submission).all.where(user_id: users.map(&:id), exercise_id: selected_exercises.map(&:id)).includes(:user, :exercise)
       submissions = submissions.before_deadline(@options[:deadline]) if deadline?
       submissions = submissions.group(:user_id, :exercise_id).most_recent if only_last_submission?
       submissions.sort_by { |s| [selected_exercises.map(&:id).index(s.exercise_id), users.map(&:id).index(s.user_id), s.id] }
@@ -261,7 +264,7 @@ module ExportHelper
     end
 
     def get_submissions_for_user(selected_courses)
-      return Submission.of_user(@item).includes(:user, :exercise) if all? # allow submissions without a course
+      return policy_scope(Submission).of_user(@item).includes(:user, :exercise) if all? # allow submissions without a course
 
       selected_courses.map { |course| get_submissions_for_course(course.series, @users) }.flatten
     end
@@ -284,6 +287,10 @@ module ExportHelper
       options = params.select { |key, _| SUPPORTED_OPTIONS.include? key.to_s }
       CONVERT_TO_BOOL.each { |key| options[key.to_sym] = ActiveModel::Type::Boolean.new.cast(options[key.to_sym].to_s.downcase) }
       options
+    end
+
+    def current_user
+      @for_user
     end
   end
 end

--- a/app/models/export.rb
+++ b/app/models/export.rb
@@ -26,7 +26,8 @@ class Export < ApplicationRecord
       item: item,
       users: users,
       list: list,
-      options: params
+      options: params,
+      for_user: user
     ).bundle
 
     archive.attach(

--- a/test/controllers/exports_controller_test.rb
+++ b/test/controllers/exports_controller_test.rb
@@ -131,6 +131,24 @@ class ExportsControllerTest < ActionDispatch::IntegrationTest
     assert_zip ActiveStorage::Blob.last.download, options
   end
 
+  test 'should not contain submissions from other courses' do
+    s1 = create :series, :with_submissions, course: @course, exercise_submission_users: @students
+    s2 = create :series, course: (create :course)
+    s2.exercises = s1.exercises
+    s2.course.users = s1.course.users
+    create :submission, exercise: s2.exercises.first, course: s2.course, user: @students.first
+    options = {
+      only_last_submission: false,
+      data: @data,
+      solution_count: Submission.all.in_course(@course).count,
+      all: true
+    }
+    post courses_exports_path(@course), params: options
+    assert_redirected_to exports_path
+    options[:group_by] = 'series'
+    assert_zip ActiveStorage::Blob.last.download, options
+  end
+
   test 'should download one submission per exercise from each series from course' do
     options = {
       only_last_submission: true,


### PR DESCRIPTION
Fixes in this PR are two-fold. First I made sure users can never see submissions that they shouldn't by first `policy_scope`-ing every query. Second I made sure submissions are filtered by course in the series query (which is used in the course query).

- [x] Tests were added

Thank you, @pjvolders, for reporting this issue.