### PR TITLE
Hide messages from search engine snippets

### DIFF
--- a/app/views/layouts/_main_container.html.erb
+++ b/app/views/layouts/_main_container.html.erb
@@ -1,5 +1,5 @@
 <div id="main-container" class="<%= content_for?(:container_class) ? yield(:container_class) : "container" %> main">
-  <div class="page-messages hidden-print">
+  <div class="page-messages hidden-print" data-nosnippet>
     <% flash.each do |key, value| %>
       <% type = flash_to_bootstrap(key) %>
       <% if value.present? && type.present? %>


### PR DESCRIPTION
This pull request adds the `data-nosnippet` attribute to our messages div. This will hopefully prevent these messages showing up in search engine snippets which is now the case in Google, Bing and DuckDuckGo.

I haven't found a lot of info about this attribute in other search engines than Google, so I'll leave the original issue open and we'll check again in a few weeks if this is fixed.

#2868 

---

![image](https://user-images.githubusercontent.com/481872/122645384-b15dc700-d11a-11eb-9e14-f6eeb786ebce.png)
![image](https://user-images.githubusercontent.com/481872/122645415-ca667800-d11a-11eb-8d12-97a2203a6492.png)
![image](https://user-images.githubusercontent.com/481872/122645436-e10ccf00-d11a-11eb-9296-a2f3f7113383.png)
