### PR TITLE
Add courses link to signed out navbar

### DIFF
--- a/app/views/layouts/_breadcrumbs.html.erb
+++ b/app/views/layouts/_breadcrumbs.html.erb
@@ -8,6 +8,7 @@
   <% if !user_signed_in? %>
     <div class="crumb list">
       <%= link_to(t("layout.menu.activities"), activities_path) %>
+      <%= link_to(t("layout.menu.courses"), courses_path) %>
       <%= link_to(t("layout.menu.support_us"), support_us_path) %>
       <%= link_to(t("layout.menu.manual"), "https://docs.dodona.be/#{I18n.locale}") %>
       <%= link_to(t("layout.menu.contact"), contact_path) %>

--- a/config/locales/views/courses/en.yml
+++ b/config/locales/views/courses/en.yml
@@ -52,7 +52,7 @@ en:
         title: Featured course
         toggle-label: Feature this course
     index:
-      title: All courses
+      title: Courses
       users: "Users"
       exercises: "Exercises"
       institution_courses: "%{institution} courses"

--- a/config/locales/views/courses/nl.yml
+++ b/config/locales/views/courses/nl.yml
@@ -52,7 +52,7 @@ nl:
         title: Uitgelichte cursus
         toggle-label: Deze cursus uitlichten
     index:
-      title: Alle cursussen
+      title: Cursussen
       users: "Gebruikers"
       exercises: "Oefeningen"
       institution_courses: "%{institution} cursussen"

--- a/config/locales/views/defaults/en.yml
+++ b/config/locales/views/defaults/en.yml
@@ -30,6 +30,7 @@ en:
     menu:
       manual: User manual
       activities: Exercises
+      courses: Courses
       support_us: Support us
       contact: Contact
       my_submissions: My submissions

--- a/config/locales/views/defaults/nl.yml
+++ b/config/locales/views/defaults/nl.yml
@@ -30,6 +30,7 @@ nl:
     menu:
       manual: Handleiding
       activities: Oefeningen
+      courses: Cursussen
       support_us: Steun ons
       contact: Contact
       my_submissions: Mijn oplossingen


### PR DESCRIPTION
This pull request adds a link to the courses listing to the signed out navbar. This page was only recently enabled for signed out users.
