### PR TITLE
Use built-in concurrency checks for deployments

### DIFF
--- a/.github/workflows/deploy-images.yml
+++ b/.github/workflows/deploy-images.yml
@@ -7,16 +7,16 @@ on:
         description: 'Image to deploy, leave empty for all'     
         required: false
 
+concurrency: 
+  group: deploy-images
+  cancel-in-progress: true
+
 jobs:
   deploy:
     environment: 
       name: images
     runs-on: ubuntu-latest
     steps:
-    - name: Cancel previous deployments
-      uses: styfle/cancel-workflow-action@0.9.0
-      with:
-        access_token: ${{ github.token }}
     - name: Install SSH key
       uses: shimataro/ssh-key-action@v2
       with:

--- a/.github/workflows/deploy-mestra.yml
+++ b/.github/workflows/deploy-mestra.yml
@@ -6,6 +6,10 @@ on:
     types:
       - labeled
 
+concurrency: 
+  group: deploy-mestra
+  cancel-in-progress: true
+
 jobs:
   deploy:
     if: ${{ github.event.action == 'labeled' && github.event.label.name == 'deploy' }}
@@ -14,10 +18,6 @@ jobs:
       url: https://mestra.ugent.be
     runs-on: ubuntu-latest
     steps:
-    - name: Cancel previous deployments
-      uses: styfle/cancel-workflow-action@0.9.0
-      with:
-        access_token: ${{ github.token }}
     - name: Install SSH key
       uses: shimataro/ssh-key-action@v2
       with:

--- a/.github/workflows/deploy-naos.yml
+++ b/.github/workflows/deploy-naos.yml
@@ -3,6 +3,10 @@ name: Deploy Naos
 on:
   workflow_dispatch:
 
+concurrency: 
+  group: deploy-naos
+  cancel-in-progress: true
+
 jobs:
   deploy:
     environment: 
@@ -10,10 +14,6 @@ jobs:
       url: https://naos.ugent.be
     runs-on: ubuntu-latest
     steps:
-    - name: Cancel previous deployments
-      uses: styfle/cancel-workflow-action@0.9.0
-      with:
-        access_token: ${{ github.token }}
     - name: Install SSH key
       uses: shimataro/ssh-key-action@v2
       with:

--- a/.github/workflows/restart-workers.yml
+++ b/.github/workflows/restart-workers.yml
@@ -4,16 +4,16 @@ name: Restart workers
 on:
   workflow_dispatch:
 
+concurrency: 
+  group: restart-workers
+  cancel-in-progress: true
+
 jobs:
   deploy:
     environment: 
       name: workers
     runs-on: ubuntu-latest
     steps:
-    - name: Cancel previous deployments
-      uses: styfle/cancel-workflow-action@0.9.0
-      with:
-        access_token: ${{ github.token }}
     - name: Install SSH key
       uses: shimataro/ssh-key-action@v2
       with:


### PR DESCRIPTION
The deploy scripts had some manual checks to ensure that a deploy never runs twice at the same time. Github actions now supports this natively (in beta) by adding [a concurrency parameter](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency). This pull requests removes the manual checks and switches to the built-in ones.

>Concurrency ensures that only a single job or workflow using the same concurrency group will run at a time. A concurrency group can be any string or expression.

*(sorry for the separate commits, I had to use the browser because my local editor is running a long job by accident)*