### PR TITLE
Show extra emoji feedback after submitting

### DIFF
--- a/app/assets/javascripts/exercise.js
+++ b/app/assets/javascripts/exercise.js
@@ -298,6 +298,7 @@ function initExerciseShow(exerciseId, programmingLanguage, loggedIn, editorShown
                     $("#activity-feedback-link").data("submission_id") === lastSubmission) {
                     loadFeedback(`/submissions/${lastSubmission}`, lastSubmission);
                 }
+                showFABStatus(status);
                 setTimeout(enableSubmitButton, 100);
                 new Toast(I18n.t("js.submission-processed"));
                 lastSubmission = null;
@@ -306,11 +307,42 @@ function initExerciseShow(exerciseId, programmingLanguage, loggedIn, editorShown
     }
 
     function enableSubmitButton() {
-        $("#editor-process-btn").prop("disabled", false).removeClass("busy mdi-timer-sand-empty mdi-spin").addClass("mdi-play");
+        $("#editor-process-btn")
+            .prop("disabled", false)
+            .removeClass("busy mdi-timer-sand-empty mdi-spin")
+            .addClass("mdi-play");
     }
 
     function disableSubmitButton() {
-        $("#editor-process-btn").prop("disabled", true).removeClass("mdi-play").addClass("busy mdi-timer-sand-empty mdi-spin");
+        $("#editor-process-btn")
+            .prop("disabled", true)
+            .removeClass("mdi-play")
+            .addClass("busy mdi-timer-sand-empty mdi-spin");
+    }
+
+    function showFABStatus(status) {
+        const fab = document.getElementById("submission-copy-btn");
+        const icon = fab.children[0];
+        icon.classList.remove("mdi-pencil");
+        if (status === "correct") {
+            fab.classList.add("correct");
+            icon.classList.add(getPositiveEmoji());
+        } else {
+            fab.classList.add("wrong");
+            icon.classList.add("mdi-emoticon-sad-outline");
+        }
+        setTimeout(resetFABStatus, 4000);
+    }
+    function resetFABStatus() {
+        const fab = document.getElementById("submission-copy-btn");
+        const icon = fab.children[0];
+        fab.classList.remove("correct", "wrong");
+        icon.classList.remove(...icon.classList);
+        icon.classList.add("mdi", "mdi-36", "mdi-pencil");
+    }
+    function getPositiveEmoji() {
+        const emojis = ["check-bold", "thumb-up-outline", "emoticon-happy-outline", "emoticon-excited-outline", "emoticon-cool-outline", "emoticon-kiss-outline", "robot-outline", "unicorn-variant", "cow", "emoticon-poop"];
+        return "mdi-" + emojis[Math.floor(Math.pow(Math.random(), 3) * emojis.length)];
     }
 
     function submissionSuccessful(data, userId) {

--- a/app/assets/javascripts/exercise.js
+++ b/app/assets/javascripts/exercise.js
@@ -341,7 +341,7 @@ function initExerciseShow(exerciseId, programmingLanguage, loggedIn, editorShown
         icon.classList.add("mdi", "mdi-36", "mdi-pencil");
     }
     function getPositiveEmoji() {
-        const emojis = ["check-bold", "thumb-up-outline", "emoticon-happy-outline", "emoticon-excited-outline", "emoticon-cool-outline", "emoticon-kiss-outline", "robot-outline", "unicorn-variant", "cow", "emoticon-poop"];
+        const emojis = ["check-bold", "thumb-up-outline", "emoticon-happy-outline", "emoticon-excited-outline", "emoticon-cool-outline", "shimmer", "party-popper", "arm-flex-outline", "emoticon-kiss-outline", "robot-outline", "cow", "unicorn-variant"];
         return "mdi-" + emojis[Math.floor(Math.pow(Math.random(), 3) * emojis.length)];
     }
 

--- a/app/assets/stylesheets/components/btn.css.scss
+++ b/app/assets/stylesheets/components/btn.css.scss
@@ -159,11 +159,6 @@ button.btn-icon {
     background-color: $brand-danger;
     border-color: $brand-danger;
   }
-
-  &.warning {
-    background-color: $brand-warning;
-    border-color: $brand-warning;
-  }
 }
 
 .btn-fab + .btn-fab {

--- a/app/assets/stylesheets/components/btn.css.scss
+++ b/app/assets/stylesheets/components/btn.css.scss
@@ -149,6 +149,23 @@ button.btn-icon {
   opacity: 1;
 }
 
+.btn-fab {
+  &.correct {
+    background-color: $brand-success;
+    border-color: $brand-success;
+  }
+
+  &.wrong {
+    background-color: $brand-danger;
+    border-color: $brand-danger;
+  }
+
+  &.warning {
+    background-color: $brand-warning;
+    border-color: $brand-warning;
+  }
+}
+
 .btn-fab + .btn-fab {
   margin-left: 20px;
 }


### PR DESCRIPTION
Correctly solving an exercise should be a rewarding experience. With the pull request, after a submission is judged, the FAB temporarily changes color and shows an icon to indicate the result of the submission.

For the duration of 4 seconds, the color and icon of the FAB is changed after judging is completed. If the submission is incorrect, a sad emoji is shown on a red background. If the submission is correct, a positive emoji is shown on a green background. The positive emoji's are picked at random from a list of 10 with a strong bias towards the first elements in the list (`emojis[Math.floor(Math.pow(Math.random(), 3) * emojis.length)]`). This will make some results rare than others.

Currently, the list of positive icons is: `["check-bold", "thumb-up-outline", "emoticon-happy-outline", "emoticon-excited-outline", "emoticon-cool-outline", "shimmer", "party-popper", "arm-flex-outline", "emoticon-kiss-outline", "robot-outline", "cow", "unicorn-variant"]`.

- This was manually tested in both light and dark mode.
- This is really hard to write tests for (also since the current base case has no test). Suggestions are welcome.

**Positive result**

https://user-images.githubusercontent.com/481872/119645604-7ff52280-be1e-11eb-9211-e87101178b1d.mov

**Negative result**

https://user-images.githubusercontent.com/481872/119646092-0f9ad100-be1f-11eb-9d9f-ff2baf9de08e.mov

This change was prototyped in #2760 and discussed in #2761.