### PR TITLE
Fix typo: ask question instead of pose question

### DIFF
--- a/config/locales/views/courses/en.yml
+++ b/config/locales/views/courses/en.yml
@@ -47,7 +47,7 @@ en:
       secret-link-placeholder: "This link will be generated after creation"
       questions:
         title: Questions
-        toggle-label: Allow students to pose questions
+        toggle-label: Allow students to ask questions
       featured:
         title: Featured course
         toggle-label: Feature this course

--- a/test/system/questions_test.rb
+++ b/test/system/questions_test.rb
@@ -18,7 +18,7 @@ class QuestionsTest < ApplicationSystemTestCase
     sign_in @student
   end
 
-  test 'Can pose question for each line of the available lines of code' do
+  test 'Can ask question for each line of the available lines of code' do
     visit(submission_path(id: @submission.id))
     click_link 'Code'
 
@@ -37,7 +37,7 @@ class QuestionsTest < ApplicationSystemTestCase
     end
   end
 
-  test 'Can pose global question about code' do
+  test 'Can ask global question about code' do
     visit(submission_path(id: @submission.id))
     click_link 'Code'
 


### PR DESCRIPTION
This pull request fixes a typo and uses "ask question" instead of "pose question" because it is a specific question directed to someone.
