### PR TITLE
Change clipboard icon to avoid confusion

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -115,7 +115,7 @@ module ApplicationHelper
                type: 'button',
                title: t('js.copy-to-clipboard'),
                data: { clipboard_target: selector } do
-      tag.i(class: 'mdi mdi-clipboard-text mdi-18')
+      tag.i(class: 'mdi mdi-clipboard-outline mdi-18')
     end
   end
 

--- a/app/helpers/renderers/feedback_code_renderer.rb
+++ b/app/helpers/renderers/feedback_code_renderer.rb
@@ -23,7 +23,7 @@ class FeedbackCodeRenderer
       if @code.present?
         # Not possible to use clipboard_button_for here since the behaviour is different.
         @builder.button(class: 'btn btn-secondary copy-btn', id: "copy-to-clipboard-#{@instance}", title: I18n.t('js.code.copy-to-clipboard'), 'data-bs-toggle': 'tooltip', 'data-bs-placement': 'top') do
-          @builder.i(class: 'mdi mdi-clipboard-text mdi-18') {}
+          @builder.i(class: 'mdi mdi-clipboard-outline mdi-18') {}
         end
       end
       @builder.script(type: 'application/javascript') do


### PR DESCRIPTION
This pull request changes the clipboard icon to avoid confusion with the activity icon.
**Before**
![image](https://user-images.githubusercontent.com/481872/124352260-b2edbb80-dbff-11eb-81dc-a162262ca947.png)

**After**
![image](https://user-images.githubusercontent.com/481872/124352252-a8cbbd00-dbff-11eb-9c3e-81124f94328c.png)


This commit was cherry-picked from #2903.

Closes #2215.