### PR TITLE
Use built-in yarn cache for GitHub Actions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,17 +27,7 @@ jobs:
       uses: actions/setup-node@v2
       with:
         node-version: 12.x
-    - name: Get the Yarn cache directory
-      id: yarn-cache
-      run: |
-        echo "::set-output name=dir::$(yarn cache dir)"
-    - name: Cache Yarn dependencies
-      uses: actions/cache@v2.1.6
-      with:
-        path: ${{ steps.yarn-cache.outputs.dir }}
-        key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-yarn-
+        cache: yarn
     - name: Install dependencies
       run: |
         yarn install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,17 +30,7 @@ jobs:
       uses: actions/setup-node@v2
       with:
         node-version: 12.x
-    - name: Get the Yarn cache directory
-      id: yarn-cache
-      run: |
-        echo "::set-output name=dir::$(yarn cache dir)"
-    - name: Cache Yarn dependencies
-      uses: actions/cache@v2.1.6
-      with:
-        path: ${{ steps.yarn-cache.outputs.dir }}
-        key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-yarn-
+        cache: yarn
     - name: Install JS dependencies
       run: |
         yarn install
@@ -64,17 +54,7 @@ jobs:
       uses: actions/setup-node@v2
       with:
         node-version: 12.x
-    - name: Get the Yarn cache directory
-      id: yarn-cache
-      run: |
-        echo "::set-output name=dir::$(yarn cache dir)"
-    - name: Cache Yarn dependencies
-      uses: actions/cache@v2.1.6
-      with:
-        path: ${{ steps.yarn-cache.outputs.dir }}
-        key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-yarn-
+        cache: yarn
     - name: Install dependencies
       run: |
         yarn install
@@ -109,19 +89,9 @@ jobs:
       uses: actions/setup-node@v2
       with:
         node-version: 12.x
+        cache: yarn
     - name: Setup chromium-chromedriver
       uses: nanasess/setup-chromedriver@master
-    - name: Get the Yarn cache directory
-      id: yarn-cache
-      run: |
-        echo "::set-output name=dir::$(yarn cache dir)"
-    - name: Cache Yarn dependencies
-      uses: actions/cache@v2.1.6
-      with:
-        path: ${{ steps.yarn-cache.outputs.dir }}
-        key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-yarn-
     - name: Install JS dependencies
       run: |
         yarn install


### PR DESCRIPTION
This pull request removes our custom yarn cache code and uses the newly released built-in cache instead.
