### PR TITLE
Fix spinning score items

### DIFF
--- a/app/assets/javascripts/feedback/score.ts
+++ b/app/assets/javascripts/feedback/score.ts
@@ -130,7 +130,14 @@ export default class ScoreForm {
         }
     }
 
-    private sendUpdate(newFocus: HTMLElement | null = null): void {
+    private sendUpdate(newFocus?: HTMLElement): void {
+        // Special case where the value is empty: do as if
+        // the clear button has been pressed.
+        if (this.input.value === "") {
+            this.delete();
+            return;
+        }
+
         let data;
         if (this.existing) {
             data = {

--- a/app/assets/javascripts/feedback/score.ts
+++ b/app/assets/javascripts/feedback/score.ts
@@ -60,6 +60,10 @@ export default class ScoreForm {
             e.preventDefault();
         });
         this.input.addEventListener("change", ev => {
+            // If the score is not valid, don't do anything.
+            if (!this.input.reportValidity()) {
+                return;
+            }
             // Mark as busy to show we are aware an update should happen.
             // If we don't do this, we need a difficult balance between waiting
             // long enough so the delay is useful when using the increment/decrement buttons
@@ -69,12 +73,15 @@ export default class ScoreForm {
                 if (valueOnFocus === (ev.target as HTMLInputElement).value) {
                     return;
                 }
-                if (!this.input.reportValidity()) {
-                    return;
-                }
                 if (updating) {
                     return;
                 }
+
+                // This is delayed, so check validity again.
+                if (!this.input.reportValidity()) {
+                    return;
+                }
+
                 updating = true;
                 this.sendUpdate(document.activeElement as HTMLElement);
             }, 400);

--- a/app/views/feedbacks/_score_actions.html.erb
+++ b/app/views/feedbacks/_score_actions.html.erb
@@ -16,7 +16,7 @@
           <%= button_tag class: "btn btn-secondary btn-sm delete-button", type: :button, disabled: !@score_map.key?(score_item.id) do %>
             <i class="mdi mdi-delete mdi-12" aria-hidden='true'></i>
           <% end %>
-          <%= f.number_field :score, required: true,
+          <%= f.number_field :score,
                              class: "form-control score-input",
                              step: 0.25,
                              tabindex: index + 1,

--- a/test/system/feedbacks_test.rb
+++ b/test/system/feedbacks_test.rb
@@ -180,4 +180,34 @@ class FeedbacksTest < ApplicationSystemTestCase
     assert_equal expected_first, BigDecimal(first_input.value)
     assert_equal BigDecimal('0'), BigDecimal(second_input.value)
   end
+
+  test 'clear button works' do
+    visit(feedback_path(id: @feedback.id))
+
+    delete_button = find(id: "#{@score_item_first.id}-score-form-wrapper").find('.delete-button')
+    accept_confirm do
+      delete_button.click
+    end
+
+    first_input = find(id: "#{@score_item_first.id}-score-form-wrapper").find('.score-input:not(.in-progress)')
+
+    assert_equal '', first_input.value
+    assert_nil Score.find_by(id: @score.id)
+  end
+
+  test 'clearing input field clears score' do
+    visit(feedback_path(id: @feedback.id))
+
+    first_input = find(id: "#{@score_item_first.id}-score-form-wrapper").find('.score-input')
+    second_input = find(id: "#{@score_item_second.id}-score-form-wrapper").find('.score-input')
+
+    # Clear the field by sending backspace key strokes.
+    first_input.fill_in with: '', fill_options: { clear: :backspace }
+    second_input.click
+
+    first_input = find(id: "#{@score_item_first.id}-score-form-wrapper").find('.score-input:not(.in-progress)')
+
+    assert_equal '', first_input.value
+    assert_nil Score.find_by(id: @score.id)
+  end
 end


### PR DESCRIPTION
This pull request changes two related things:

- Don't start the spinning animation when the input is invalid; this gives the impression the value is being saved, but it's not.
- Allow to clear the input field, and interpret it as clearing the grade. E.g. pressing backspace or delete until the field is empty is now equivalent to pressing the delete button.

- [x] Tests were added

Closes #2891
