### PR TITLE
Fix/list group dark background

### DIFF
--- a/app/assets/stylesheets/base.css.scss
+++ b/app/assets/stylesheets/base.css.scss
@@ -93,7 +93,3 @@ figcaption {
   white-space: normal;
   overflow-wrap: break-word;
 }
-
-
-// Take dark mode into account
-$list-group-bg: $content-bg;

--- a/app/assets/stylesheets/theme/theme-dark.css.scss
+++ b/app/assets/stylesheets/theme/theme-dark.css.scss
@@ -77,6 +77,8 @@
   $panel-default-text: $text-color !global;
   $panel-default-border: $content-bg !global;
 
+  $list-group-bg: $content-bg !global;
+
   // other overrides
   $text-muted: $white-secondary !global;
 


### PR DESCRIPTION
This pull request fixes the bug where a list group still had the white background in dark mode.

<!-- If there are visual changes, add a screenshot -->
Before:
![Screenshot from 2021-08-02 15-04-35](https://user-images.githubusercontent.com/53220653/127870233-4041daa4-805e-4082-92d5-ac553c8938c7.png)
After:
![Screenshot from 2021-08-02 15-05-01](https://user-images.githubusercontent.com/53220653/127870247-d42943af-71a3-441c-889a-0f7503bcc627.png)


Closes #2485  .
