### PR TITLE
Adapt prompt colour in dark mode

### DIFF
--- a/app/assets/stylesheets/theme/rouge-dark.css.scss
+++ b/app/assets/stylesheets/theme/rouge-dark.css.scss
@@ -133,7 +133,7 @@
 
   /* Generic.Prompt */
   .highlighter-rouge .gp {
-    color: #f8f8f2
+    color: #8be9fd
   }
 
   /* Generic.Strong */


### PR DESCRIPTION
This pull request adapts the prompt colour in dark mode so it stands more out against the other text. If another colour should be used, please let me know.

<!-- If there are visual changes, add a screenshot -->
Before:
![Screenshot from 2021-08-02 17-27-58](https://user-images.githubusercontent.com/53220653/127886637-33591c9b-511b-4b31-bb62-9cc34ebc2031.png)

After:
![Screenshot from 2021-08-02 17-28-55](https://user-images.githubusercontent.com/53220653/127886655-0aca81e9-c55d-4d0d-af3c-5b2c43050769.png)

Closes #2778 .
