### PR TITLE
Narrow down click region of "Hand in" navigation

### DIFF
--- a/app/views/activities/show.html.erb
+++ b/app/views/activities/show.html.erb
@@ -25,10 +25,12 @@ end %>
 
 <div class="row">
   <% if @activity.exercise? %>
-    <%= link_to '#submission-card', class: "btn btn-lg btn-down col-md-1 d-none d-md-block hidden-print", title: t('.handin') do %>
-      <span class='d-none d-lg-inline'><%= t('.handin') %></span><br>
-      <i class="mdi mdi-chevron-down"></i>
-    <% end %>
+    <div class="col-md-1 p-0">
+      <%= link_to '#submission-card', class: "btn btn-lg btn-down d-none d-md-block hidden-print", title: t('.handin') do %>
+        <span class='d-none d-lg-inline'><%= t('.handin') %></span><br>
+        <i class="mdi mdi-chevron-down"></i>
+      <% end %>
+    </div>
   <% else %>
     <div class="col-md-1 d-none d-md-block hidden-print">&nbsp;</div>
   <% end %>


### PR DESCRIPTION
This pull request narrows down the click region of the "Hand in" navigation. The issue was that the button was declared in the same div as the `col-md-1`, causing the whole column to be a button. I now made the column the parent element, with the button inside it.

<!-- If there are visual changes, add a screenshot -->


Closes #2782 .
