### PR TITLE
Reduce use of light colors for scoring in dark mode

### DIFF
--- a/app/assets/stylesheets/theme/theme-dark.css.scss
+++ b/app/assets/stylesheets/theme/theme-dark.css.scss
@@ -107,6 +107,7 @@
   $table-hover-bg: $body-bg !global;
 
   $input-group-addon-bg: $grey-800 !global;
+  $input-group-addon-border-color: lighten($input-group-addon-bg, 10%) !global;
 
   $form-select-indicator-color: $text-color !global;
 
@@ -116,5 +117,9 @@
 
   .dark-only {
     display: unset;
+  }
+
+  .input-group input {
+    border-color: $input-group-addon-border-color;
   }
 }

--- a/app/views/feedbacks/_feedback_actions.html.erb
+++ b/app/views/feedbacks/_feedback_actions.html.erb
@@ -64,10 +64,10 @@
         <div class="col-4 score-buttons">
           <div class="btn-group" role="group">
             <%= button_tag class: "btn btn-secondary btn-sm", id: 'zero-button', title: t(".give_zero_all") do %>
-              <i class="mdi mdi-thumb-down mdi-12" aria-hidden='true'></i>
+              <i class="mdi mdi-thumb-down-outline mdi-12" aria-hidden='true'></i>
             <% end %>
             <%= button_tag class: "btn btn-secondary btn-sm", id: 'max-button', title: t(".give_max_all") do %>
-              <i class="mdi mdi-thumb-up mdi-12" aria-hidden='true'></i>
+              <i class="mdi mdi-thumb-up-outline mdi-12" aria-hidden='true'></i>
             <% end %>
           </div>
         </div>

--- a/app/views/feedbacks/_score_actions.html.erb
+++ b/app/views/feedbacks/_score_actions.html.erb
@@ -14,7 +14,7 @@
       <div class="control-wrapper">
         <div class="input-group">
           <%= button_tag class: "btn btn-secondary btn-sm delete-button", type: :button, disabled: !@score_map.key?(score_item.id) do %>
-            <i class="mdi mdi-delete mdi-12" aria-hidden='true'></i>
+            <i class="mdi mdi-delete-outline mdi-12" aria-hidden='true'></i>
           <% end %>
           <%= f.number_field :score,
                              class: "form-control score-input",
@@ -27,10 +27,10 @@
             / <%= format_score(score_item.maximum) %>
           <% end %>
           <%= button_tag class: "btn btn-secondary btn-sm single-zero-button", type: :button, title: t('.give_zero_one') do %>
-            <i class="mdi mdi-thumb-down mdi-12" aria-hidden='true'></i>
+            <i class="mdi mdi-thumb-down-outline mdi-12" aria-hidden='true'></i>
           <% end %>
           <%= button_tag class: "btn btn-secondary btn-sm single-max-button", type: :button, title: t('.give_max_one', score: format_score(score_item.maximum)) do %>
-            <i class="mdi mdi-thumb-up mdi-12" aria-hidden='true'></i>
+            <i class="mdi mdi-thumb-up-outline mdi-12" aria-hidden='true'></i>
           <% end %>
         </div>
         <div class="dodona-progress dodona-progress-indeterminate">


### PR DESCRIPTION
This pull request makes the scoring when evaluating less visually prominent by using outline buttons and using a different border color for the input groups.

![screenshot_2021-08-03-105825](https://user-images.githubusercontent.com/42220376/127989552-c1a16ce9-731f-4704-8ed4-2d8f6d708118.png)
![screenshot_2021-08-03-110145](https://user-images.githubusercontent.com/42220376/127989554-9adcb21f-36c0-4828-887a-1ac56519fe52.png)
