### PR TITLE
Improve color scheme of diff highlighting in dark mode

### DIFF
--- a/app/assets/stylesheets/theme/theme-dark.css.scss
+++ b/app/assets/stylesheets/theme/theme-dark.css.scss
@@ -93,9 +93,9 @@
   $feedback-diff-table-header-bg: $body-bg !global;
   $feedback-diff-table-header-fg: $text-secondary !global;
   $feedback-diff-table-ins: $green-900 !global;
-  $feedback-diff-table-ins-strong: $green-800 !global;
+  $feedback-diff-table-ins-strong: $green-700 !global;
   $feedback-diff-table-del: $red-900 !global;
-  $feedback-diff-table-del-strong: $red-800 !global;
+  $feedback-diff-table-del-strong: $red-500 !global;
 
   $skeleton-color: $body-bg !global;
 


### PR DESCRIPTION
This pull request adapts the colours in dark mode that highlight the feedback diff. It should now be more clear where the mistakes in the output occur.

<!-- If there are visual changes, add a screenshot -->
Before:
![Screenshot from 2021-08-03 11-29-08](https://user-images.githubusercontent.com/53220653/127993343-17d62585-6ab2-4b9e-8daf-6538846af282.png)

After:
![Screenshot from 2021-08-03 11-29-54](https://user-images.githubusercontent.com/53220653/127993401-d5e6b2ae-4e2a-44b4-8a63-f789e538f890.png)


Closes #2420 .
