### PR TITLE
Use alternative background color for line highlighting in dark mode

### DIFF
--- a/app/assets/stylesheets/components/code_listing.css.scss
+++ b/app/assets/stylesheets/components/code_listing.css.scss
@@ -41,14 +41,15 @@ $annotation-info: $info-500;
 
       // Highlight for the line numbers.
       .lineno.marked {
-        background-color: $warning-500;
+        background-color: $code-bg-warning;
+        border-left: 0.3em solid $warning-500;
         // Only do the line number, don't extend to the full height
         background-clip: content-box;
       }
 
       // Highlight for the code itself.
       .lineno.marked .rouge-code pre {
-        background-color: $warning-500;
+        background-color: $code-bg-warning;
       }
 
       .annotation-button {

--- a/app/assets/stylesheets/components/code_listing.css.scss
+++ b/app/assets/stylesheets/components/code_listing.css.scss
@@ -42,7 +42,7 @@ $annotation-info: $info-500;
       // Highlight for the line numbers.
       .lineno.marked {
         background-color: $code-bg-warning;
-        border-left: 0.3em solid $warning-500;
+        border-left: $code-warning-border-left solid $warning-500;
         // Only do the line number, don't extend to the full height
         background-clip: content-box;
       }

--- a/app/assets/stylesheets/theme/theme-dark.css.scss
+++ b/app/assets/stylesheets/theme/theme-dark.css.scss
@@ -23,7 +23,7 @@
   $danger-800: $red-200 !global;
   $danger-500: $red-300 !global;
   $info-500: $light-blue-300 !global;
-  $warning-500: $orange-400 !global;
+  $warning-500: $amber-500 !global;
 
   $body-bg: $blue-grey-800 !global;
   $content-bg: $blue-grey-900 !global;
@@ -53,6 +53,7 @@
 
   $code-bg: $body-bg !global;
   $code-light-bg: $body-bg !global;
+  $code-bg-warning: rgba(80, 52, 18, 0.4) !global;
 
   $alert-warning-bg: inherit !global;
   $alert-info-bg: inherit !global;

--- a/app/assets/stylesheets/theme/theme-dark.css.scss
+++ b/app/assets/stylesheets/theme/theme-dark.css.scss
@@ -54,6 +54,7 @@
   $code-bg: $body-bg !global;
   $code-light-bg: $body-bg !global;
   $code-bg-warning: rgba(80, 52, 18, 0.4) !global;
+  $code-warning-border-left: 0.5em !global;
 
   $alert-warning-bg: inherit !global;
   $alert-info-bg: inherit !global;

--- a/app/assets/stylesheets/theme/theme-dark.css.scss
+++ b/app/assets/stylesheets/theme/theme-dark.css.scss
@@ -23,7 +23,7 @@
   $danger-800: $red-200 !global;
   $danger-500: $red-300 !global;
   $info-500: $light-blue-300 !global;
-  $warning-500: $amber-500 !global;
+  $warning-500: $amber-300 !global;
 
   $body-bg: $blue-grey-800 !global;
   $content-bg: $blue-grey-900 !global;

--- a/app/assets/stylesheets/theme/theme-dark.css.scss
+++ b/app/assets/stylesheets/theme/theme-dark.css.scss
@@ -23,7 +23,7 @@
   $danger-800: $red-200 !global;
   $danger-500: $red-300 !global;
   $info-500: $light-blue-300 !global;
-  $warning-500: $amber-300 !global;
+  $warning-500: $orange-400 !global;
 
   $body-bg: $blue-grey-800 !global;
   $content-bg: $blue-grey-900 !global;

--- a/app/assets/stylesheets/theme/theme-light.css.scss
+++ b/app/assets/stylesheets/theme/theme-light.css.scss
@@ -76,6 +76,7 @@ $danger: $brand-danger;
 
 $code-bg: $grey-200;
 $code-light-bg: $grey-100;
+$code-bg-warning: $amber-500;
 $code-color: $text-color;
 $page-header-border-color: $black-divider;
 $panel-primary-heading-bg: $primary-500;

--- a/app/assets/stylesheets/theme/theme-light.css.scss
+++ b/app/assets/stylesheets/theme/theme-light.css.scss
@@ -77,6 +77,7 @@ $danger: $brand-danger;
 $code-bg: $grey-200;
 $code-light-bg: $grey-100;
 $code-bg-warning: $amber-500;
+$code-warning-border-left: 0;
 $code-color: $text-color;
 $page-header-border-color: $black-divider;
 $panel-primary-heading-bg: $primary-500;


### PR DESCRIPTION
This pull request adapts the color for highlighting code lines in dark mode in case of a runtime error. The code line should now be more readable.

<!-- If there are visual changes, add a screenshot -->
Before:
![Screenshot from 2021-08-03 12-07-59](https://user-images.githubusercontent.com/53220653/127998823-c02ed3db-ec80-4c3c-8a2b-d412630937b6.png)

After:
![Screenshot from 2021-08-03 14-41-54](https://user-images.githubusercontent.com/53220653/128018074-36936eee-3726-4a9b-adbc-0f415d812a0a.png)


Closes #2412 .
