### PR TITLE
Improve user selection for evaluations

### DIFF
--- a/app/assets/javascripts/evaluation.ts
+++ b/app/assets/javascripts/evaluation.ts
@@ -1,6 +1,6 @@
 import { fetch } from "util.js";
 
-function interceptAddMultiUserClicks(): void {
+export function interceptAddMultiUserClicks(): void {
     let running = false;
     document.querySelectorAll(".user-select-option a").forEach(option => {
         option.addEventListener("click", async event => {
@@ -21,4 +21,18 @@ function interceptAddMultiUserClicks(): void {
     });
 }
 
-export { interceptAddMultiUserClicks };
+export function initCheckboxes(): void {
+    document.querySelectorAll(".evaluation-users-table .user-row").forEach(el => initCheckbox(el));
+}
+
+export function initCheckbox(row: HTMLTableRowElement): void {
+    const checkbox = row.querySelector(".form-check-input") as HTMLInputElement;
+    checkbox.addEventListener("input", async function () {
+        const url = checkbox.getAttribute("data-url");
+        const confirmMessage = checkbox.getAttribute("data-confirm");
+        if (!confirmMessage || confirm(confirmMessage)) {
+            const response = await fetch(url, { method: "POST" });
+            eval(await response.text());
+        }
+    });
+}

--- a/app/assets/javascripts/evaluation.ts
+++ b/app/assets/javascripts/evaluation.ts
@@ -27,12 +27,15 @@ export function initCheckboxes(): void {
 
 export function initCheckbox(row: HTMLTableRowElement): void {
     const checkbox = row.querySelector(".form-check-input") as HTMLInputElement;
-    checkbox.addEventListener("input", async function () {
+    checkbox.addEventListener("change", async function () {
         const url = checkbox.getAttribute("data-url");
         const confirmMessage = checkbox.getAttribute("data-confirm");
         if (!confirmMessage || confirm(confirmMessage)) {
             const response = await fetch(url, { method: "POST" });
             eval(await response.text());
+        } else {
+            // There are no cancelable events for checkbox input, so cancel manually afterwards
+            checkbox.checked = !checkbox.checked;
         }
     });
 }

--- a/app/assets/stylesheets/components/evaluations.css.scss
+++ b/app/assets/stylesheets/components/evaluations.css.scss
@@ -95,6 +95,14 @@
     display: inline-block;
   }
 }
+
+.evaluation-users-table {
+  .form-check-input-large {
+    width: 1.5em;
+    height: 1.5em;
+  }
+}
+
 .feedback {
   padding-bottom: 6px;
   &.correct {

--- a/app/controllers/evaluations_controller.rb
+++ b/app/controllers/evaluations_controller.rb
@@ -110,15 +110,17 @@ class EvaluationsController < ApplicationController
   end
 
   def add_user
-    user = @evaluation.series.course.subscribed_members.find(params[:user_id])
-    @evaluation.update(users: @evaluation.users + [user])
-    render 'refresh_users'
+    @course = @evaluation.series.course
+    @course_membership = @course.course_memberships.find_by(user_id: params[:user_id])
+    @user = @course_membership.user
+    @evaluation.update(users: @evaluation.users + [@user])
   end
 
   def remove_user
-    user = @evaluation.series.course.subscribed_members.find(params[:user_id])
-    @evaluation.update(users: @evaluation.users - [user])
-    render 'refresh_users'
+    @course = @evaluation.series.course
+    @course_membership = @course.course_memberships.find_by(user_id: params[:user_id])
+    @user = @course_membership.user
+    @evaluation.update(users: @evaluation.users - [@user])
   end
 
   def mark_undecided_complete

--- a/app/javascript/packs/evaluation.js
+++ b/app/javascript/packs/evaluation.js
@@ -1,7 +1,9 @@
 import { initDeadlinePicker } from "series.js";
-import { interceptAddMultiUserClicks } from "evaluation.ts";
+import { interceptAddMultiUserClicks, initCheckboxes, initCheckbox } from "evaluation.ts";
 import FeedbackActions from "feedback/actions";
 
 window.dodona.initDeadlinePicker = initDeadlinePicker;
+window.dodona.initCheckboxes = initCheckboxes;
+window.dodona.initCheckbox = initCheckbox;
 window.dodona.interceptAddMultiUserClicks = interceptAddMultiUserClicks;
 window.dodona.FeedbackActions = FeedbackActions;

--- a/app/views/evaluations/_member_row.html.erb
+++ b/app/views/evaluations/_member_row.html.erb
@@ -1,0 +1,38 @@
+<td>
+  <% if @evaluation.users.include?(user) %>
+    <input class="form-check-input form-check-input-large" type="checkbox" checked data-url="<%= remove_user_evaluation_path(@evaluation, user_id: user.id) %>", data-confirm="<%= t('.remove_user_consequences') if confirm %>">
+  <% else %>
+    <input class="form-check-input form-check-input-large" type="checkbox" data-url="<%= add_user_evaluation_path(@evaluation, user_id: user.id) %>">
+  <% end %>
+</td>
+
+<td>
+  <% if course_membership.course_admin? %>
+    <i class="mdi mdi-school course-mdi-icon mdi-18" title='<%= t "users.users_table.course_admin" %>'></i>
+  <% end %>
+  <% if user.username.blank? %>
+    <i class="mdi mdi-alert mdi-18" title='<%= t "users.users_table.no_institution" %>'></i>
+  <% end %>
+</td>
+
+<td>
+  <%= link_to user.full_name, course_member_path(@course, user), title: user.full_name, class: "ellipsis-overflow", target: "_blank" %>
+  <div class="small text-muted">
+    <span><%= user.email %></span>
+  </div>
+</td>
+
+<td class='course-membership-labels'>
+  <% course_membership.course_labels.each do |label| %>
+    <span class="badge bg-primary"><%= label.name %></span>
+  <% end %>
+</td>
+
+<td>
+  <%= render partial: 'user_progress',
+    locals: {
+      series: @evaluation.series,
+      user: user
+    }
+  %>
+</td>

--- a/app/views/evaluations/_members_table.html.erb
+++ b/app/views/evaluations/_members_table.html.erb
@@ -1,5 +1,5 @@
 <div class="table-scroll-wrapper">
-  <table class="table table-index table-resource">
+  <table class="table table-index table-resource evaluation-users-table">
     <thead>
     <tr>
       <th class="status-icon"></th>
@@ -12,56 +12,8 @@
     <tbody>
     <% course_memberships.each do |course_membership| %>
       <% user = course_membership.user %>
-      <tr>
-        <td>
-          <% if @evaluation.users.include?(user) %>
-            <%= button_to remove_user_evaluation_path(@evaluation, user_id: user.id),
-                          remote: true,
-                          title: t('.remove_user'),
-                          data: { confirm: confirm ? t('.remove_user_consequences') : nil },
-                          class: 'btn btn-sm btn-danger' do %>
-              <i class="mdi mdi-delete mdi-18"></i>
-            <% end %>
-          <% else %>
-            <%= button_to add_user_evaluation_path(@evaluation, user_id: user.id),
-                          remote: true,
-                          title: t('.add_user'),
-                          class: 'btn btn-sm btn-success' do %>
-              <i class="mdi mdi-plus mdi-18"></i>
-            <% end %>
-          <% end %>
-        </td>
-
-        <td>
-          <% if course_membership.course_admin? %>
-            <i class="mdi mdi-school course-mdi-icon mdi-18" title='<%= t "users.users_table.course_admin" %>'></i>
-          <% end %>
-          <% if user.username.blank? %>
-            <i class="mdi mdi-alert mdi-18" title='<%= t "users.users_table.no_institution" %>'></i>
-          <% end %>
-        </td>
-
-        <td>
-          <%= link_to user.full_name, course_member_path(@course, user), title: user.full_name, class: "ellipsis-overflow", target: "_blank" %>
-          <div class="small text-muted">
-            <span><%= user.email %></span>
-          </div>
-        </td>
-
-        <td class='course-membership-labels'>
-          <% course_membership.course_labels.each do |label| %>
-            <span class="badge bg-primary"><%= label.name %></span>
-          <% end %>
-        </td>
-
-        <td>
-          <%= render partial: 'user_progress',
-            locals: {
-              series: @evaluation.series,
-              user: user
-            }
-          %>
-        </td>
+      <tr id="user-row-<%= user.id %>" class="user-row <%= "table-active" if @evaluation.users.include?(user) %>">
+        <%= render partial: 'evaluations/member_row', locals: { user: user, course_membership: course_membership, confirm: confirm } %>
       </tr>
     <% end %>
     </tbody>

--- a/app/views/evaluations/add_user.js.erb
+++ b/app/views/evaluations/add_user.js.erb
@@ -1,0 +1,4 @@
+const row = document.querySelector("#user-row-<%= @user.id %>");
+row.innerHTML = "<%= escape_javascript(render 'evaluations/member_row', course_membership: @course_membership, user: @user, confirm: false) %>";
+row.classList.add("table-active");
+dodona.initCheckbox(row);

--- a/app/views/evaluations/add_users.html.erb
+++ b/app/views/evaluations/add_users.html.erb
@@ -64,4 +64,5 @@
 </div>
 <script>
   $(window.dodona.interceptAddMultiUserClicks);
+  $(dodona.initCheckboxes)
 </script>

--- a/app/views/evaluations/add_users.html.erb
+++ b/app/views/evaluations/add_users.html.erb
@@ -64,5 +64,5 @@
 </div>
 <script>
   $(window.dodona.interceptAddMultiUserClicks);
-  $(dodona.initCheckboxes)
+  $(window.dodona.initCheckboxes)
 </script>

--- a/app/views/evaluations/add_users.js.erb
+++ b/app/views/evaluations/add_users.js.erb
@@ -1,2 +1,3 @@
 $("#users-table-wrapper").html("<%= escape_javascript(render partial: 'members_table', locals: {course_memberships: @course_memberships, confirm: false}) %>")
 window.dodona.initTooltips();
+window.dodona.initCheckboxes();

--- a/app/views/evaluations/edit.html.erb
+++ b/app/views/evaluations/edit.html.erb
@@ -1,3 +1,6 @@
+<% content_for :javascripts do %>
+  <%= javascript_pack_tag 'evaluation' %>
+<% end %>
 <div class="row">
   <div class="col-md-10 offset-md-1 col-12">
     <div class="card evaluation-user-select">
@@ -17,3 +20,6 @@
     </div>
   </div>
 </div>
+<script>
+  $(dodona.initCheckboxes)
+</script>

--- a/app/views/evaluations/edit.js.erb
+++ b/app/views/evaluations/edit.js.erb
@@ -1,2 +1,3 @@
 $("#users-table-wrapper").html("<%= escape_javascript(render partial: 'members_table', locals: {course_memberships: @course_memberships, confirm: true}) %>")
 window.dodona.initTooltips();
+window.dodona.initCheckboxes();

--- a/app/views/evaluations/remove_user.js.erb
+++ b/app/views/evaluations/remove_user.js.erb
@@ -1,0 +1,4 @@
+const row = document.querySelector("#user-row-<%= @user.id %>");
+row.innerHTML = "<%= escape_javascript(render 'evaluations/member_row', course_membership: @course_membership, user: @user, confirm: false) %>";
+row.classList.remove("table-active");
+dodona.initCheckbox(row);

--- a/config/locales/views/evaluations/en.yml
+++ b/config/locales/views/evaluations/en.yml
@@ -86,6 +86,6 @@ en:
       remove_users_consequences: "If these students already received feedback, it will be deleted. Are you sure want to remove these students?"
       status: Progress
     member_row:
-      remove_user_consequences: "If this student already received feedback, it will be deleted. Are you sure you want to remove this student?"
+      remove_user_consequences: "If this student already received feedback, that feedback will be deleted. Are you sure you want to remove this student?"
     user_progress:
       not_submitted: Not submitted

--- a/config/locales/views/evaluations/en.yml
+++ b/config/locales/views/evaluations/en.yml
@@ -83,10 +83,9 @@ en:
       invisible_total: "The total score was not released"
       no_grading: "This exercise was not graded"
     members_table:
-      remove_user: Remove student from evaluation
-      remove_user_consequences: "If this student already received feedback, it will be deleted. Are you sure you want to remove this student?"
       remove_users_consequences: "If these students already received feedback, it will be deleted. Are you sure want to remove these students?"
-      add_user: Add student to evaluation
       status: Progress
+    member_row:
+      remove_user_consequences: "If this student already received feedback, it will be deleted. Are you sure you want to remove this student?"
     user_progress:
       not_submitted: Not submitted

--- a/config/locales/views/evaluations/nl.yml
+++ b/config/locales/views/evaluations/nl.yml
@@ -85,6 +85,6 @@ nl:
       remove_users_consequences: "Als deze studenten al feedback gekregen hadden, dan zal deze verwijderd worden. Ben je zeker dat je deze studenten wil verwijderen?"
       status: Voortgang
     member_row:
-      remove_user_consequences: "Als deze student al feedback gekregen had, dan zal deze verwijderd worden. Ben je zeker dat je deze student wil verwijderen?"
+      remove_user_consequences: "Als deze student al feedback gekregen had, dan zal deze feedback verwijderd worden. Ben je zeker dat je deze student wil verwijderen?"
     user_progress:
       not_submitted: Niet ingediend

--- a/config/locales/views/evaluations/nl.yml
+++ b/config/locales/views/evaluations/nl.yml
@@ -82,10 +82,9 @@ nl:
       invisible_total: "De totaalscore werd niet vrijgegeven"
       no_grading: "Deze oefening staat niet op punten"
     members_table:
-      remove_user: Student verwijderen uit evaluatie
-      remove_user_consequences: "Als deze student al feedback gekregen had, dan zal deze verwijderd worden. Ben je zeker dat je deze student wil verwijderen?"
       remove_users_consequences: "Als deze studenten al feedback gekregen hadden, dan zal deze verwijderd worden. Ben je zeker dat je deze studenten wil verwijderen?"
-      add_user: Student toevoegen aan evaluatie
       status: Voortgang
+    member_row:
+      remove_user_consequences: "Als deze student al feedback gekregen had, dan zal deze verwijderd worden. Ben je zeker dat je deze student wil verwijderen?"
     user_progress:
       not_submitted: Niet ingediend


### PR DESCRIPTION
This pull request changes the look of the evaluation user edit table. It also makes sure we only refresh necessary rows instead of refreshing the entire table on each change.

![screenshot_2021-08-03-175318](https://user-images.githubusercontent.com/42220376/128046905-a4e0786b-627a-4283-863f-cc9ae852c054.png)


Closes #2516.
