### PR TITLE
Make background color of code blocks in annotations consistent

### DIFF
--- a/app/assets/stylesheets/components/code_listing.css.scss
+++ b/app/assets/stylesheets/components/code_listing.css.scss
@@ -212,19 +212,12 @@ $annotation-info: $info-500;
         line-height: 20px;
       }
 
-      pre:not(.highlight) {
-        padding: 5px 10px;
-        margin-left: 10px;
-        margin-right: 10px;
-        margin-bottom: 8px;
-        border-radius: 3px;
-      }
-
       // Stylize the embedded code block
-      .highlighter-rouge div.highlight {
+      .highlighter-rouge div.highlight, pre:not(.highlight) {
         padding: 5px 10px;
         margin-left: 10px;
         margin-right: 10px;
+        margin-bottom: 10px;
         background: $code-bg;
         border-radius: 3px;
       }

--- a/app/assets/stylesheets/components/code_listing.css.scss
+++ b/app/assets/stylesheets/components/code_listing.css.scss
@@ -41,15 +41,14 @@ $annotation-info: $info-500;
 
       // Highlight for the line numbers.
       .lineno.marked {
-        background-color: $code-bg-warning;
-        border-left: $code-warning-border-left solid $warning-500;
+        background-color: $warning-500;
         // Only do the line number, don't extend to the full height
         background-clip: content-box;
       }
 
       // Highlight for the code itself.
       .lineno.marked .rouge-code pre {
-        background-color: $code-bg-warning;
+        background-color: $warning-500;
       }
 
       .annotation-button {
@@ -204,10 +203,12 @@ $annotation-info: $info-500;
       // Override the normal pre padding & coloring
       pre {
         padding: 0;
-        background-color: transparent;
+        background-color: $code-bg;
+        margin-left: 10px;
+        margin-right: 10px;
         margin-bottom: 0;
         border: none;
-        border-radius: 0;
+        border-radius: 3px;
         white-space: pre-wrap;
         line-height: 20px;
       }

--- a/app/assets/stylesheets/components/code_listing.css.scss
+++ b/app/assets/stylesheets/components/code_listing.css.scss
@@ -217,7 +217,6 @@ $annotation-info: $info-500;
         margin-left: 10px;
         margin-right: 10px;
         margin-bottom: 8px;
-        background: $code-bg;
         border-radius: 3px;
       }
 

--- a/app/assets/stylesheets/components/code_listing.css.scss
+++ b/app/assets/stylesheets/components/code_listing.css.scss
@@ -41,14 +41,15 @@ $annotation-info: $info-500;
 
       // Highlight for the line numbers.
       .lineno.marked {
-        background-color: $warning-500;
+        background-color: $code-bg-warning;
+        border-left: $code-warning-border-left solid $warning-500;
         // Only do the line number, don't extend to the full height
         background-clip: content-box;
       }
 
       // Highlight for the code itself.
       .lineno.marked .rouge-code pre {
-        background-color: $warning-500;
+        background-color: $code-bg-warning;
       }
 
       .annotation-button {

--- a/app/assets/stylesheets/components/code_listing.css.scss
+++ b/app/assets/stylesheets/components/code_listing.css.scss
@@ -204,14 +204,21 @@ $annotation-info: $info-500;
       // Override the normal pre padding & coloring
       pre {
         padding: 0;
-        background-color: $code-bg;
-        margin-left: 10px;
-        margin-right: 10px;
+        background-color: $code-bg !important;
         margin-bottom: 0;
         border: none;
-        border-radius: 3px;
+        border-radius: 0;
         white-space: pre-wrap;
         line-height: 20px;
+      }
+
+      pre:not(.highlight) {
+        padding: 5px 10px;
+        margin-left: 10px;
+        margin-right: 10px;
+        margin-bottom: 8px;
+        background: $code-bg;
+        border-radius: 3px;
       }
 
       // Stylize the embedded code block


### PR DESCRIPTION
This pull request adapts the background color of code blocks in annotations where no programming language was specified, so it is consistent with code blocks where a programming language was specified. This pull request also fixes the issue where code blocks in annotations were marked in case the parent code line was marked.

<!-- If there are visual changes, add a screenshot -->
<ins>Code block specific background issue</ins>
Before:
![Screenshot from 2021-08-04 10-22-07](https://user-images.githubusercontent.com/53220653/128154218-f10e369a-2fa7-4263-b0f3-025f3259e9c1.png)

After:
![Screenshot from 2021-08-04 11-35-09](https://user-images.githubusercontent.com/53220653/128159545-6f3dea8b-c427-48c2-92e7-cf151c93d1b2.png)

<ins>Marked code block issue</ins>
Before:
![Screenshot from 2021-08-04 11-36-56](https://user-images.githubusercontent.com/53220653/128159564-56df3563-63b2-4f30-8ae2-caaf56963a42.png)

After:
![Screenshot from 2021-08-04 11-37-44](https://user-images.githubusercontent.com/53220653/128159579-8e07cde0-086d-4377-bf83-e3ad1c5255b2.png)

Closes #2454.
Closes #2438.
