### PR TITLE
Don't allow out of bounds values when grading

### DIFF
--- a/app/models/score.rb
+++ b/app/models/score.rb
@@ -24,12 +24,7 @@ class Score < ApplicationRecord
 
   validates :score, presence: true, numericality: { greater_than: -1000, less_than: 1000 }
   validates :score_item_id, uniqueness: { scope: :feedback_id }
-
-  def out_of_bounds?
-    return false if score.nil?
-
-    score < BigDecimal('0') || score > score_item.maximum
-  end
+  validate :not_out_of_bounds
 
   private
 
@@ -40,5 +35,12 @@ class Score < ApplicationRecord
 
   def uncomplete
     feedback.update(completed: false)
+  end
+
+  def not_out_of_bounds
+    return if score.nil?
+    return if score >= BigDecimal('0') && score <= score_item.maximum
+
+    errors.add(:score, 'out of bounds')
   end
 end

--- a/app/views/feedbacks/_score_actions.html.erb
+++ b/app/views/feedbacks/_score_actions.html.erb
@@ -4,13 +4,7 @@
                namespace: score_item.id,
                html: { class: "form-inline score-form col-12", data: { url: url, new: score.persisted? } } do |f| %>
     <%= f.hidden_field :expected_score, value: score.score, class: "expected-score" %>
-    <% e = if score&.out_of_bounds?
-             'has-error'
-           elsif @warning.present? && @warning == score&.id&.to_s
-             'has-warning'
-           end
-    %>
-    <div class="form-group input <%= e %>">
+    <div class="form-group input <%= 'has-warning' if @warning.present? && @warning == score&.id&.to_s %>">
       <div class="control-wrapper">
         <div class="input-group">
           <%= button_tag class: "btn btn-secondary btn-sm delete-button", type: :button, disabled: !@score_map.key?(score_item.id) do %>
@@ -20,8 +14,8 @@
                              class: "form-control score-input",
                              step: 0.25,
                              tabindex: index + 1,
-                             min: -999.75,
-                             max: 999.75,
+                             min: 0,
+                             max: score_item.maximum,
                              value: format_score(f.object.score, lang='en', numeric_only=true) %>
           <%= button_tag class: "btn btn-secondary max-text", disabled: true, type: :button, data: { max: format_score(score_item.maximum, lang='en', numeric_only=true) } do %>
             / <%= format_score(score_item.maximum) %>

--- a/test/models/score_test.rb
+++ b/test/models/score_test.rb
@@ -61,4 +61,14 @@ class ScoreTest < ActiveSupport::TestCase
 
     assert_not score.save
   end
+
+  test 'out of bounds values are rejected' do
+    score = build :score, feedback: @feedback, score_item: @score_item1, score: BigDecimal('-1')
+
+    assert_not score.save
+
+    score.score = BigDecimal('11.0')
+
+    assert_not score.save
+  end
 end

--- a/test/system/feedbacks_test.rb
+++ b/test/system/feedbacks_test.rb
@@ -82,13 +82,13 @@ class FeedbacksTest < ApplicationSystemTestCase
     first_input = find(id: "#{@score_item_first.id}-score-form-wrapper").find('.score-input')
 
     # Submit score using enter key.
-    first_input.fill_in with: '16.0'
+    first_input.fill_in with: '6.0'
     first_input.send_keys :enter
 
     find(id: "#{@score_item_first.id}-score-form-wrapper").find('.score-input:not(.in-progress)')
 
     @score.reload
-    assert_equal BigDecimal('16'), @score.score
+    assert_equal BigDecimal('6'), @score.score
   end
 
   test 'concurrent modifications are shown' do
@@ -101,7 +101,7 @@ class FeedbacksTest < ApplicationSystemTestCase
     second_input = find(id: "#{@score_item_second.id}-score-form-wrapper").find('.score-input')
 
     # Attempt to modify on the page.
-    first_input.fill_in with: '-9.0'
+    first_input.fill_in with: '3.0'
     second_input.click
 
     first_input = find(id: "#{@score_item_first.id}-score-form-wrapper").find('.score-input:not(.in-progress)')
@@ -109,23 +109,6 @@ class FeedbacksTest < ApplicationSystemTestCase
 
     assert_equal '2', first_input.value
     assert_includes parent[:class], 'has-warning'
-  end
-
-  test 'invalid value is allowed but show as error' do
-    visit(feedback_path(id: @feedback.id))
-
-    first_input = find(id: "#{@score_item_first.id}-score-form-wrapper").find('.score-input')
-    second_input = find(id: "#{@score_item_second.id}-score-form-wrapper").find('.score-input')
-
-    # Attempt to modify on the page.
-    first_input.fill_in with: '-9.0'
-    second_input.click
-
-    first_input = find(id: "#{@score_item_first.id}-score-form-wrapper").find('.score-input:not(.in-progress)')
-    parent = find(id: "#{@score_item_first.id}-score-form-wrapper").find('.form-group.input')
-
-    assert_equal '-9', first_input.value
-    assert_includes parent[:class], 'has-error'
   end
 
   test 'all zero works' do


### PR DESCRIPTION
This pull request removes the ability to enter out of bounds values when grading.

- [x] Tests were added

Closes #2814.
