### PR TITLE
Fix scrolling of iFrames on mobile

### DIFF
--- a/app/helpers/activity_helper.rb
+++ b/app/helpers/activity_helper.rb
@@ -69,7 +69,6 @@ module ActivityHelper
                                    dark: dark).html_safe
     resizeframe = %{
       window.iFrameResize({
-          heightCalculationMethod: 'bodyScroll',
           onResized: dodona.afterResize,
           onMessage: dodona.onFrameMessage,
           onScroll: dodona.onFrameScroll,


### PR DESCRIPTION
The culprit seems to be the `heightCalculationMethod: 'bodyScroll'`.
When using the default calculation method (`bodyOffset`), the scrolling
works fine. A bit of history (from https://github.com/dodona-edu/dodona/pull/1234):
- The `bodyScroll` value has been used since the creation of this helper in 04cad8f35d19f7a82eaf3f3bbacd5accb14de23c (no reason given).
- Before that, the value was `max`, added in 5ac1b0be098e401f33a58e8f3f9d013106f3b29f.

That last commit says "Fix iframe styling and resizing", but in my tests, using the default value doesn't break anything. The docs say:

> In cases where CSS styles causes the content to flow outside the body you may need to change this setting to one of the following options.

So it seems like the default value should work for our use.

Closes #2869 .

- [x] Needs to be verified, since I couldn't be bothered to link my phone to my pc.
