### PR TITLE
Align rows in scoresheet

### DIFF
--- a/app/assets/stylesheets/components/table.css.scss
+++ b/app/assets/stylesheets/components/table.css.scss
@@ -8,8 +8,13 @@
   background-attachment: local, local, scroll, scroll;
 }
 
+.user-name {
+  height: 42px;
+}
+
 .status-table-wrapper {
   overflow-x: auto;
+  margin-left: 200px;
 
   .table {
     border-collapse: separate;
@@ -27,12 +32,17 @@
       overflow: hidden;
     }
     .user-name {
+      position: absolute;
+      height: 35px;
       width: 200px;
-      min-width: 200px;
+      left: 18px;
       top: auto;
     }
+    .user-name:not(.sticky-column) {
+      height: 42px;
+    }
     thead .user-name {
-      height: auto;
+      height: auto !important;
     }
   }
 }
@@ -104,4 +114,8 @@ tr.gu-mirror {
     text-align: center;
     color: $text-secondary;
   }
+}
+
+#scoresheet-table-wrapper .user-name{
+  height: 35px;
 }

--- a/app/assets/stylesheets/components/table.css.scss
+++ b/app/assets/stylesheets/components/table.css.scss
@@ -31,7 +31,7 @@
       position: absolute;
       width: 200px;
       left: 18px;
-      height: 35px;
+      height: auto;
       top: auto;
     }
     .user-name:not(.sticky-column) {

--- a/app/assets/stylesheets/components/table.css.scss
+++ b/app/assets/stylesheets/components/table.css.scss
@@ -112,6 +112,6 @@ tr.gu-mirror {
   }
 }
 
-#scoresheet-table-wrapper .user-name{
+#scoresheet-table-wrapper .user-name {
   height: 35px;
 }

--- a/app/assets/stylesheets/components/table.css.scss
+++ b/app/assets/stylesheets/components/table.css.scss
@@ -31,7 +31,6 @@
       position: absolute;
       width: 200px;
       left: 18px;
-      height: 42px;
       top: auto;
     }
     thead .user-name {

--- a/app/assets/stylesheets/components/table.css.scss
+++ b/app/assets/stylesheets/components/table.css.scss
@@ -10,7 +10,6 @@
 
 .status-table-wrapper {
   overflow-x: auto;
-  margin-left: 200px;
 
   .table {
     border-collapse: separate;
@@ -28,9 +27,7 @@
       overflow: hidden;
     }
     .user-name {
-      position: absolute;
       width: 200px;
-      left: 18px;
       top: auto;
     }
     thead .user-name {

--- a/app/assets/stylesheets/components/table.css.scss
+++ b/app/assets/stylesheets/components/table.css.scss
@@ -8,10 +8,6 @@
   background-attachment: local, local, scroll, scroll;
 }
 
-.user-name {
-  height: 42px;
-}
-
 .status-table-wrapper {
   overflow-x: auto;
   margin-left: 200px;
@@ -33,9 +29,9 @@
     }
     .user-name {
       position: absolute;
-      height: 35px;
       width: 200px;
       left: 18px;
+      height: 35px;
       top: auto;
     }
     .user-name:not(.sticky-column) {

--- a/app/assets/stylesheets/components/table.css.scss
+++ b/app/assets/stylesheets/components/table.css.scss
@@ -28,6 +28,7 @@
     }
     .user-name {
       width: 200px;
+      min-width: 200px;
       top: auto;
     }
     thead .user-name {


### PR DESCRIPTION
This pull request fixes the misalignment in the scoresheets. By removing the height component of `.user-name`, the Grade overview table seems to be fixed. This solution however broke the Evaluation detail table. The new problem seems to be caused by some properties in the `status-table-wrapper`, which I think were used to keep the username column at a fixed width of `200px`. I now tried to avoid the new problem by using another way to keep the username column width fixed.

<!-- If there are visual changes, add a screenshot -->
Before:
![Screenshot from 2021-08-04 16-03-28](https://user-images.githubusercontent.com/53220653/128196371-2b333644-88a5-4956-9566-fcf4f8bdc521.png)

After:
![Screenshot from 2021-08-04 16-05-09](https://user-images.githubusercontent.com/53220653/128196410-fbb39e00-5cae-40b7-8734-ecde5f4a735b.png)

Closes #2772.
