### PR TITLE
Don't allow browsers to store cached versions of evaluation feedback pages

### DIFF
--- a/app/controllers/feedbacks_controller.rb
+++ b/app/controllers/feedbacks_controller.rb
@@ -29,6 +29,17 @@ class FeedbacksController < ApplicationController
     # the score_item ID in the `warning` param, it will be rendered with
     # the bootstrap warning classes.
     @warning = params[:warning]
+    # Don't allow browsers to store this page. This prevents the
+    # browser from serving a cached copy when pressing the back
+    # button, which can result in problems if the user entered some
+    # data, goes to the next student, and presses the back button.
+    # See https://github.com/dodona-edu/dodona/issues/2813 for more
+    # context. Note that this does mean we have to retransmit the page
+    # every time, where previously we could rely on ETag to avoid
+    # retransmitting the page if nothing changed.
+    # This should be replaced with a simple `no_store` on the next
+    # rails release: https://github.com/rails/rails/pull/40324
+    response.cache_control = 'no-store'
   end
 
   def edit


### PR DESCRIPTION
https://bugs.chromium.org/p/chromium/issues/detail?id=516846 mentions that a `Vary` header should fix this as well, but I don't think we have a request header that we can piggy-back off of to make sure the browser revalidates. See the comment in the change for trade-offs and rationale.

Closes #2813.

Remember to add `?pp=disable` when testing, otherwise our profiler overwrites the `Cache-Control` header anyway.