### PR TITLE
Truncate column names in Grade overview

### DIFF
--- a/app/assets/stylesheets/components/evaluations.css.scss
+++ b/app/assets/stylesheets/components/evaluations.css.scss
@@ -170,6 +170,7 @@ $user-column-width: 170px;
   .status-header {
     max-width: 100px;
     min-width: 100px;
+    overflow: hidden;
   }
 
   thead tr th:nth-child(2) {


### PR DESCRIPTION
This pull request fixes the truncation of column names in the grading overview. Apparently, the `overflow: hidden` property was missing for the column names, causing the `text-overflow: ellipsis` property to be disabled.

<!-- If there are visual changes, add a screenshot -->
Before:
![Screenshot from 2021-08-05 15-49-15](https://user-images.githubusercontent.com/53220653/128361991-a9c07040-19f4-491f-9e33-bab24c3bd65d.png)

After:
![Screenshot from 2021-08-05 15-49-46](https://user-images.githubusercontent.com/53220653/128362013-e086bd67-bfd4-4227-a978-fe242406a2cf.png)

Closes #2820.
