### PR TITLE
Set current user's name as default value when creating a course

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -62,10 +62,10 @@ class CoursesController < ApplicationController
       @course = Course.new(
         name: @copy_options[:base].name,
         description: @copy_options[:base].description,
-        institution: @copy_options[:base].institution,
+        institution: current_user.institution,
         visibility: @copy_options[:base].visibility,
         registration: @copy_options[:base].registration,
-        teacher: @copy_options[:base].teacher
+        teacher: current_user.full_name
       )
       @copy_options = {
         admins: current_user.course_admin?(@copy_options[:base]),

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -75,7 +75,10 @@ class CoursesController < ApplicationController
       }.merge(@copy_options).symbolize_keys
     else
       @copy_options = nil
-      @course = Course.new(institution: current_user.institution)
+      @course = Course.new(
+        teacher: current_user.full_name,
+        institution: current_user.institution
+      )
     end
 
     @title = I18n.t('courses.new.title')

--- a/app/views/courses/_form.html.erb
+++ b/app/views/courses/_form.html.erb
@@ -51,7 +51,7 @@
     </div>
     <div class="field form-group row">
       <%= f.label :teacher, :class => "col-sm-3 col-form-label" %>
-      <div class="col-sm-6"><%= f.text_field :teacher, class: "form-control", :value => current_user.full_name %></div>
+      <div class="col-sm-6"><%= f.text_field :teacher, class: "form-control" %></div>
       <span class="help-block offset-sm-3 col-sm-6"><%= t ".teacher-help" %></span>
     </div>
     <div class="field form-group row">

--- a/app/views/courses/_form.html.erb
+++ b/app/views/courses/_form.html.erb
@@ -51,7 +51,7 @@
     </div>
     <div class="field form-group row">
       <%= f.label :teacher, :class => "col-sm-3 col-form-label" %>
-      <div class="col-sm-6"><%= f.text_field :teacher, class: "form-control" %></div>
+      <div class="col-sm-6"><%= f.text_field :teacher, class: "form-control", :value => current_user.full_name %></div>
       <span class="help-block offset-sm-3 col-sm-6"><%= t ".teacher-help" %></span>
     </div>
     <div class="field form-group row">


### PR DESCRIPTION
This pull request uses the current user's name as default value for the teacher when creating a new course. When copying an existing course, the current user's name and institution are used as default values.

<!-- If there are visual changes, add a screenshot -->
Before:
![Screenshot from 2021-08-05 17-15-18](https://user-images.githubusercontent.com/53220653/128375969-91107047-1c1c-45c5-856e-f4170b4d8578.png)

After:
![Screenshot from 2021-08-05 17-15-41](https://user-images.githubusercontent.com/53220653/128375984-e82b863c-b5fc-4642-95a9-d7d6c3b080d0.png)

Closes #2660.
