### PR TITLE
Add `Total Score` and `Total Max` to csv grade export

### DIFF
--- a/app/models/evaluation.rb
+++ b/app/models/evaluation.rb
@@ -118,7 +118,6 @@ class Evaluation < ApplicationRecord
       headers += sheet[:evaluation_exercises].flat_map { |e| ["#{e.exercise.name} Score", "#{e.exercise.name} Max"] }
       csv << headers
       users.order(last_name: :asc, first_name: :asc).each do |user|
-        row = 
         feedback_l = sheet[:feedbacks][user.id]
         total_score = sheet[:averages][user.id]
         total_max = sheet[:evaluation_exercises].map(&:maximum_score).reject(&:nil?).sum

--- a/app/models/evaluation.rb
+++ b/app/models/evaluation.rb
@@ -121,7 +121,7 @@ class Evaluation < ApplicationRecord
         row = [user.full_name, user.email]
         feedback_l = sheet[:feedbacks][user.id]
         total_score = sheet[:averages][user.id]
-        total_max = sheet[:evaluation_exercises].map(&:maximum_score).sum
+        total_max = sheet[:evaluation_exercises].map(&:maximum_score).reject(&:nil?).sum
         row += [total_score, total_max]
         row += feedback_l.flat_map { |f| [f.score, f.maximum_score] }
         csv << row

--- a/app/models/evaluation.rb
+++ b/app/models/evaluation.rb
@@ -114,12 +114,15 @@ class Evaluation < ApplicationRecord
   def grades_csv
     sheet = evaluation_sheet
     CSV.generate(force_quotes: true) do |csv|
-      headers = %w[Name Email]
+      headers = ['Name', 'Email', 'Total Score', 'Total Max']
       headers += sheet[:evaluation_exercises].flat_map { |e| ["#{e.exercise.name} Score", "#{e.exercise.name} Max"] }
       csv << headers
       users.order(last_name: :asc, first_name: :asc).each do |user|
         row = [user.full_name, user.email]
         feedback_l = sheet[:feedbacks][user.id]
+        average = sheet[:averages][user.id]
+        maximum = sheet[:evaluation_exercises].map(&:maximum_score).sum
+        row += [average, maximum]
         row += feedback_l.flat_map { |f| [f.score, f.maximum_score] }
         csv << row
       end

--- a/app/models/evaluation.rb
+++ b/app/models/evaluation.rb
@@ -120,9 +120,9 @@ class Evaluation < ApplicationRecord
       users.order(last_name: :asc, first_name: :asc).each do |user|
         row = [user.full_name, user.email]
         feedback_l = sheet[:feedbacks][user.id]
-        average = sheet[:averages][user.id]
-        maximum = sheet[:evaluation_exercises].map(&:maximum_score).sum
-        row += [average, maximum]
+        total_score = sheet[:averages][user.id]
+        total_max = sheet[:evaluation_exercises].map(&:maximum_score).sum
+        row += [total_score, total_max]
         row += feedback_l.flat_map { |f| [f.score, f.maximum_score] }
         csv << row
       end

--- a/app/models/evaluation.rb
+++ b/app/models/evaluation.rb
@@ -118,11 +118,11 @@ class Evaluation < ApplicationRecord
       headers += sheet[:evaluation_exercises].flat_map { |e| ["#{e.exercise.name} Score", "#{e.exercise.name} Max"] }
       csv << headers
       users.order(last_name: :asc, first_name: :asc).each do |user|
-        row = [user.full_name, user.email]
+        row = 
         feedback_l = sheet[:feedbacks][user.id]
         total_score = sheet[:averages][user.id]
         total_max = sheet[:evaluation_exercises].map(&:maximum_score).reject(&:nil?).sum
-        row += [total_score, total_max]
+        row = [user.full_name, user.email, total_score, total_max]
         row += feedback_l.flat_map { |f| [f.score, f.maximum_score] }
         csv << row
       end

--- a/test/controllers/evaluations_controller_test.rb
+++ b/test/controllers/evaluations_controller_test.rb
@@ -407,7 +407,7 @@ class EvaluationsControllerTest < ActionDispatch::IntegrationTest
     assert_equal 1 + evaluation.evaluation_users.length, csv.size
 
     header = csv.shift
-    assert_equal 2 + evaluation.evaluation_exercises.length * 2, header.length
+    assert_equal 4 + evaluation.evaluation_exercises.length * 2, header.length
 
     # Get which users will have a score
     # First, the users we added a score for.
@@ -433,7 +433,7 @@ class EvaluationsControllerTest < ActionDispatch::IntegrationTest
       assert_equal score_item.maximum, exported_max
 
       # All other scores should be nil.
-      assert line[2..].all?(&:empty?)
+      assert line[4..].all?(&:empty?)
     end
 
     sign_out @course_admin

--- a/test/controllers/evaluations_controller_test.rb
+++ b/test/controllers/evaluations_controller_test.rb
@@ -450,6 +450,69 @@ class EvaluationsControllerTest < ActionDispatch::IntegrationTest
     assert_response :redirect # Redirect to sign in page
   end
 
+  test 'grade export contains correct data' do
+    # Create an evaluation, a score item and add a score.
+    post evaluations_path, params: {
+      evaluation: {
+        series_id: @series.id,
+        deadline: DateTime.now
+      }
+    }
+    evaluation = @series.evaluation
+    evaluation.update(users: @series.course.enrolled_members)
+    # Add a score to a non-nil submission
+    feedback1 = evaluation.feedbacks.where.not(submission_id: nil).sample
+    exercise1 = feedback1.evaluation_exercise
+    score_item1 = create :score_item, evaluation_exercise: exercise1, maximum: 20
+    score1 = create :score, score_item: score_item1, feedback: feedback1, score: 15
+
+    # Add a score to another submission
+    feedback2 = evaluation.feedbacks.where(evaluation_id: feedback1.evaluation_id).where.not(submission_id: nil, submission_id: feedback1.submission_id).sample
+    exercise2 = feedback2.evaluation_exercise
+    score_item2 = create :score_item, evaluation_exercise: exercise2, maximum: 10
+    score2 = create :score, score_item: score_item2, feedback: feedback2, score: 7.5
+
+    get export_grades_evaluation_path evaluation, format: :csv
+    assert_response :success
+    assert_equal 'text/csv', response.content_type
+
+    # Check the contents of the csv file.
+    csv = CSV.parse response.body
+    header = csv.shift
+
+    # Total score should equal sum of scores, Total max should equal the sum of maximum scores
+    csv.each do |line|
+      # Possible that total maximum is present, but all scores are empty en thus total score is empty
+      if line[2] == ""
+        total_maximum = 0
+        (4...line.length-1).step(2).each do |index|
+          assert_equal line[index], ""
+
+          unless line[index+1] == ""
+            total_maximum += BigDecimal(line[index+1])
+          end
+        end
+
+        assert_equal BigDecimal(line[3]), total_maximum
+      
+      else
+        total_score = 0
+        total_maximum = 0
+        (4..line.length-1).step(2).each do |index|
+          unless line[index] == ""
+            total_score += BigDecimal(line[index])
+          end
+          unless line[index+1] == ""
+            total_maximum += BigDecimal(line[index+1])
+          end
+        end
+
+        assert_equal BigDecimal(line[2]), total_score
+        assert_equal BigDecimal(line[3]), total_maximum
+      end
+    end
+  end
+
   test 'course admins can change grade visibility' do
     evaluation = create :evaluation, :with_submissions
     evaluation.series.course.administrating_members << @course_admin


### PR DESCRIPTION
This pull request adds the `Total Score` and `Total Max` per student to the csv grade report.

<!-- If there are visual changes, add a screenshot -->

- [x] Test were added

Closes #2816.
