### PR TITLE
Fix Python Tutor height after maximization

### DIFF
--- a/app/assets/javascripts/pythia_submission.js
+++ b/app/assets/javascripts/pythia_submission.js
@@ -93,7 +93,7 @@ function initPythiaSubmissionShow(submissionCode, activityPath) {
 
                 const number = document.createElement("td");
                 number.className = "line-nr";
-                number.textContent = (i === maxLines) ? "": i + 1;
+                number.textContent = (i === maxLines) ? "" : i + 1;
                 tr.appendChild(number);
 
                 const line = document.createElement("td");
@@ -130,6 +130,7 @@ function initPythiaSubmissionShow(submissionCode, activityPath) {
             $tutor.removeClass("fullscreen");
             $("#tutorviz").height($("#tutorviz").data("standardheight"));
         } else {
+            $("#tutorviz").data("standardheight", $("#tutorviz").height());
             $tutor.addClass("fullscreen");
             $("#tutorviz").height("100%");
         }


### PR DESCRIPTION
This pull request fixes the height of the Python Tutor after exiting the fullscreen window. When entering fullscreen modus and afterwards exiting, the Python Tutor modal kept the height of the fullscreen modus instead of going back to its standardheight. This is because the data property `standardheight` was not yet initialized.

<!-- If there are visual changes, add a screenshot -->
Before:
![Screenshot from 2021-08-16 16-26-31](https://user-images.githubusercontent.com/53220653/129580001-28eaf54c-eb92-45da-9d7f-4ba4e1171016.png)

After:
![Screenshot from 2021-08-16 16-25-59](https://user-images.githubusercontent.com/53220653/129580024-74c33019-bf7b-44c9-9b40-c514e7366468.png)

Closes #2762.
