### PR TITLE
Runtime error link switches to correct tab

### DIFF
--- a/app/assets/javascripts/submission.js
+++ b/app/assets/javascripts/submission.js
@@ -49,7 +49,7 @@ function initSubmissionShow(parentClass, mediaPath, token) {
 
             $(".tab-link-marker").removeClass("tab-link-marker");
             $(".feedback-table .nav-tabs > li a").filter(function () {
-                return $(this).attr("href").indexOf(tab) > 0;
+                return $(this).attr("href").indexOf(`#tab-${tab}`) === 0;
             }).tab("show");
             if (element !== undefined) {
                 $("#element").addClass("tab-link-marker");

--- a/app/assets/javascripts/submission.js
+++ b/app/assets/javascripts/submission.js
@@ -49,7 +49,7 @@ function initSubmissionShow(parentClass, mediaPath, token) {
 
             $(".tab-link-marker").removeClass("tab-link-marker");
             $(".feedback-table .nav-tabs > li a").filter(function () {
-                return $(this).attr("href").indexOf("#" + tab) === 0;
+                return $(this).attr("href").indexOf(tab) > 0;
             }).tab("show");
             if (element !== undefined) {
                 $("#element").addClass("tab-link-marker");

--- a/app/assets/javascripts/submission.js
+++ b/app/assets/javascripts/submission.js
@@ -49,7 +49,7 @@ function initSubmissionShow(parentClass, mediaPath, token) {
 
             $(".tab-link-marker").removeClass("tab-link-marker");
             $(".feedback-table .nav-tabs > li a").filter(function () {
-                return $(this).attr("href").indexOf(`#tab-${tab}`) === 0;
+                return $(this).attr("href").startsWith(`#tab-${tab}`);
             }).tab("show");
             if (element !== undefined) {
                 $("#element").addClass("tab-link-marker");


### PR DESCRIPTION
This pull request fixes the Runtime error tab link. Explanation of the fix: The nav-tab with `href="#code"` was searched. However, the two tabs had `href="#tab-corectheid-0"` and `href="#tab-code-1"`, so the search delivered an empty result. 

<!-- If there are visual changes, add a screenshot -->

Closes #2992.
