### PR TITLE
Add profile scope to the LTI settings

### DIFF
--- a/lib/LTI/auth/settings.rb
+++ b/lib/LTI/auth/settings.rb
@@ -16,7 +16,7 @@ module LTI
             prompt: :none,
             response_mode: :form_post,
             response_type: :id_token,
-            scope: [:openid]
+            scope: [:openid, :profile]
         }
       end
 

--- a/test/controllers/lti_controller_test.rb
+++ b/test/controllers/lti_controller_test.rb
@@ -118,7 +118,7 @@ class LtiFlowTest < ActionDispatch::IntegrationTest
     location = URI.parse(@response.header['Location'])
     assert_equal @provider.authorization_uri, "#{location.scheme}://#{location.host}#{location.path}"
     params = URI.decode_www_form(location.query).to_h.symbolize_keys
-    assert_equal 'openid', params[:scope]
+    assert params[:scope].include? 'openid'
     assert_equal 'id_token', params[:response_type]
     assert_equal @provider.client_id, params[:client_id]
     assert_equal 'https://www.example.com/users/auth/lti/callback', params[:redirect_uri]


### PR DESCRIPTION
This pull request adds the profile scope to the LTI settings. We need this to receive the name from the users authenticating using i-Learn.