### PR TITLE
Fix error when trying to create an URL if only path is given 

### DIFF
--- a/app/assets/javascripts/util.js
+++ b/app/assets/javascripts/util.js
@@ -15,7 +15,7 @@ const delay = (function () {
 })();
 
 function updateURLParameter(_url, param, paramVal) {
-    const url = new URL(_url);
+    const url = new URL(_url, window.location.href);
     if (paramVal) {
         url.searchParams.set(param, paramVal);
     } else {
@@ -26,7 +26,7 @@ function updateURLParameter(_url, param, paramVal) {
 
 function updateArrayURLParameter(_url, param, _paramVals) {
     const paramVals = new Set(_paramVals); // remove duplicate items
-    const url = new URL(_url);
+    const url = new URL(_url, window.location.href);
     url.searchParams.delete(param);
     paramVals.forEach(paramVal => {
         url.searchParams.append(param, paramVal);
@@ -35,12 +35,12 @@ function updateArrayURLParameter(_url, param, _paramVals) {
 }
 
 function getURLParameter(name, _url) {
-    const url = new URL(_url ?? window.location.href);
+    const url = new URL(_url ?? window.location.href, window.location.href);
     return url.searchParams.get(name);
 }
 
 function getArrayURLParameter(name, _url) {
-    const url = new URL(_url ?? window.location.href);
+    const url = new URL(_url ?? window.location.href, window.location.href);
     return url.searchParams.getAll(name);
 }
 


### PR DESCRIPTION
This pull request provides a baseURL in the URL creation. This is needed because it is possible only a path is provided instead of a full URL. `window.location.href` is used as baseURL, because `window.location.host` did not provide a valid baseURL ( `dodona.localhost:3000` while `https://dodona.localhost:3000` was needed)

<!-- If there are visual changes, add a screenshot -->

