### PR TITLE
Show score item description on hover during evaluation

### DIFF
--- a/app/views/feedbacks/_feedback_actions.html.erb
+++ b/app/views/feedbacks/_feedback_actions.html.erb
@@ -88,9 +88,9 @@
       <div class="row">
         <div class="col-sm-12">
           <% if score_item.description != '' %>
-            <div data-bs-toggle="tooltip" data-bs-placement="left" title="<%=  strip_tags markdown(score_item.description)  %>">
-              <strong><%= score_item.name %></strong>
-            </div>
+            <strong data-bs-toggle="tooltip" data-bs-placement="left" title="<%=  strip_tags markdown(score_item.description)  %>">
+              <%= score_item.name %>
+            </strong>
           <% else %>
             <strong><%= score_item.name %></strong>
           <% end %>

--- a/app/views/feedbacks/_feedback_actions.html.erb
+++ b/app/views/feedbacks/_feedback_actions.html.erb
@@ -87,12 +87,13 @@
       <% score = @score_map.fetch(score_item.id, Score.new(score_item: score_item, feedback: @feedback)) %>
       <div class="row">
         <div class="col-sm-12">
-          <i class="mdi mdi-information-outline mdi-12" 
-             data-bs-toggle="tooltip" 
-             data-bs-placement="left" 
-             title="<%=  strip_tags markdown(score_item.description) %>">
-          </i>
-          <strong><%= score_item.name %></strong>
+          <% if score_item.description != '' %>
+            <div data-bs-toggle="tooltip" data-bs-placement="left" title="<%=  strip_tags markdown(score_item.description)  %>">
+              <strong><%= score_item.name %></strong>
+            </div>
+          <% else %>
+            <strong><%= score_item.name %></strong>
+          <% end %>
         </div>
       </div>
       <%= render 'feedbacks/score_actions', score: score, score_item: score_item, index: index %>

--- a/app/views/feedbacks/_feedback_actions.html.erb
+++ b/app/views/feedbacks/_feedback_actions.html.erb
@@ -88,7 +88,7 @@
       <div class="row">
         <div class="col-sm-12">
           <% if score_item.description.present? %>
-            <strong data-bs-toggle="tooltip" data-bs-placement="left" title="<%= strip_tags markdown(score_item.description)  %>">
+            <strong data-bs-toggle="tooltip" data-bs-placement="left" title="<%= strip_tags markdown(score_item.description) %>">
               <%= score_item.name %>
             </strong>
           <% else %>

--- a/app/views/feedbacks/_feedback_actions.html.erb
+++ b/app/views/feedbacks/_feedback_actions.html.erb
@@ -87,6 +87,11 @@
       <% score = @score_map.fetch(score_item.id, Score.new(score_item: score_item, feedback: @feedback)) %>
       <div class="row">
         <div class="col-sm-12">
+          <i class="mdi mdi-information-outline mdi-12" 
+             data-bs-toggle="tooltip" 
+             data-bs-placement="left" 
+             title="<%=  strip_tags markdown(score_item.description) %>">
+          </i>
           <strong><%= score_item.name %></strong>
         </div>
       </div>

--- a/app/views/feedbacks/_feedback_actions.html.erb
+++ b/app/views/feedbacks/_feedback_actions.html.erb
@@ -87,8 +87,8 @@
       <% score = @score_map.fetch(score_item.id, Score.new(score_item: score_item, feedback: @feedback)) %>
       <div class="row">
         <div class="col-sm-12">
-          <% if score_item.description != '' %>
-            <strong data-bs-toggle="tooltip" data-bs-placement="left" title="<%=  strip_tags markdown(score_item.description)  %>">
+          <% if score_item.description.present? %>
+            <strong data-bs-toggle="tooltip" data-bs-placement="left" title="<%= strip_tags markdown(score_item.description)  %>">
               <%= score_item.name %>
             </strong>
           <% else %>


### PR DESCRIPTION
This pull request adds an information icon next to the name of the score item during the evaluation of an exercise. Hovering over this icon activates a tooltip that displays the description of this score item.

<!-- If there are visual changes, add a screenshot -->
Before:
![Screenshot from 2021-08-18 14-39-10](https://user-images.githubusercontent.com/53220653/129900662-27b7fec6-29a9-40da-9ad4-0679949ee6b6.png)

After:
![Screenshot from 2021-08-18 14-36-17](https://user-images.githubusercontent.com/53220653/129900685-fc01379f-0e56-4f07-b75c-9eb0377edf42.png)

Closes #2804.
