### PR TITLE
Fix inconsistent series navigation for course admins

### DIFF
--- a/app/controllers/evaluations_controller.rb
+++ b/app/controllers/evaluations_controller.rb
@@ -12,7 +12,7 @@ class EvaluationsController < ApplicationController
   def show
     redirect_to add_users_evaluation_path(@evaluation) if @evaluation.users.count == 0
     @feedbacks = @evaluation.evaluation_sheet
-    @crumbs = [[@evaluation.series.course.name, course_url(@evaluation.series.course)], [@evaluation.series.name, series_url(@evaluation.series)], [I18n.t('evaluations.show.evaluation'), '#']]
+    @crumbs = [[@evaluation.series.course.name, course_url(@evaluation.series.course)], [@evaluation.series.name, breadcrumb_series_path(@evaluation.series, current_user)], [I18n.t('evaluations.show.evaluation'), '#']]
     @title = I18n.t('evaluations.show.evaluation')
   end
 
@@ -42,7 +42,7 @@ class EvaluationsController < ApplicationController
 
     @crumbs = [
       [@evaluation.series.course.name, course_url(@evaluation.series.course)],
-      [@evaluation.series.name, series_url(@evaluation.series)],
+      [@evaluation.series.name, breadcrumb_series_path(@evaluation.series, current_user)],
       [I18n.t('evaluations.show.evaluation'), evaluation_url(@evaluation)],
       [I18n.t('evaluations.edit.title'), '#']
     ]
@@ -55,7 +55,7 @@ class EvaluationsController < ApplicationController
     @user_count_series = @evaluation.series.course.enrolled_members.where(id: Submission.where(exercise_id: @evaluation.exercises, course_id: @evaluation.series.course_id).select('DISTINCT user_id')).count
     @crumbs = [
       [@evaluation.series.course.name, course_url(@evaluation.series.course)],
-      [@evaluation.series.name, series_url(@evaluation.series)],
+      [@evaluation.series.name, breadcrumb_series_path(@evaluation.series, current_user)],
       [I18n.t('evaluations.show.evaluation'), evaluation_url(@evaluation)],
       [I18n.t('evaluations.add_users.title'), '#']
     ]

--- a/app/controllers/exports_controller.rb
+++ b/app/controllers/exports_controller.rb
@@ -1,4 +1,6 @@
 class ExportsController < ApplicationController
+  include SeriesHelper
+  
   before_action :set_user,
                 only: %i[new_series_export new_course_export create_series_export create_course_export]
 
@@ -13,7 +15,7 @@ class ExportsController < ApplicationController
     @series = Series.find(params[:id])
     authorize @series, :export?
     authorize @user, :export? if @user
-    @crumbs = [[@series.course.name, course_path(@series.course)], [@series.name, series_path(@series)], [I18n.t('exports.download_submissions.title'), '#']]
+    @crumbs = [[@series.course.name, course_path(@series.course)], [@series.name, breadcrumb_series_path(@series, current_user)], [I18n.t('exports.download_submissions.title'), '#']]
     @data = { item: @series,
               users: ([@user] if @user),
               list: @series.exercises,

--- a/app/controllers/exports_controller.rb
+++ b/app/controllers/exports_controller.rb
@@ -1,6 +1,6 @@
 class ExportsController < ApplicationController
   include SeriesHelper
-  
+
   before_action :set_user,
                 only: %i[new_series_export new_course_export create_series_export create_course_export]
 

--- a/app/controllers/score_items_controller.rb
+++ b/app/controllers/score_items_controller.rb
@@ -1,4 +1,6 @@
 class ScoreItemsController < ApplicationController
+  include SeriesHelper
+
   before_action :set_score_item, only: %i[destroy update]
   before_action :set_evaluation
 
@@ -94,7 +96,7 @@ class ScoreItemsController < ApplicationController
 
     @crumbs = [
       [@evaluation.series.course.name, course_path(@evaluation.series.course)],
-      [@evaluation.series.name, series_path(@evaluation.series)],
+      [@evaluation.series.name, breadcrumb_series_path(@evaluation.series, current_user)],
       [I18n.t('evaluations.show.evaluation'), evaluation_path(@evaluation)]
     ]
   end

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -1,4 +1,6 @@
 class SubmissionsController < ApplicationController
+  include SeriesHelper
+
   before_action :set_submission, only: %i[show download evaluate edit media]
   before_action :set_submissions, only: %i[index mass_rejudge]
   before_action :ensure_trailing_slash, only: :show
@@ -41,7 +43,7 @@ class SubmissionsController < ApplicationController
                    [@user.full_name, user_path(@user)]
                  end
     elsif @series
-      @crumbs << [@series.course.name, course_path(@series.course)] << [@series.name, @series.hidden? ? series_path(@series) : course_path(@series.course, anchor: @series.anchor)]
+      @crumbs << [@series.course.name, course_path(@series.course)] << [@series.name, breadcrumb_series_path(@series, current_user)]
     elsif @course
       @crumbs << [@course.name, course_path(@course)]
     elsif @judge


### PR DESCRIPTION
This pull request fixes the inconsistent series navigations for course admins. When clicking on a series link in the navbar, course admins were sometimes redirected to the series page and other times redirected to the course page. This happened because the helper function `breadcrumb_series_path` wasn't used consistently.

<!-- If there are visual changes, add a screenshot -->


Closes #2217.
