### PR TITLE
Standardize column names in csv exports

### DIFF
--- a/app/helpers/export_helper.rb
+++ b/app/helpers/export_helper.rb
@@ -184,8 +184,9 @@ module ExportHelper
           csv << if indianio?
                    %w[filename status submission_id name_en name_nl exercise_id]
                  else
-                   headers = %w[filename full_name id status submission_id name_en name_nl exercise_id created_at]
+                   headers = %w[filename id username last_name first_name full_name email]
                    headers << 'labels' if labels?
+                   headers << %w[status submission_id name_en name_nl exercise_id created_at]
                    headers
                  end
           submissions.each do |submission|
@@ -226,8 +227,9 @@ module ExportHelper
       csv << if indianio?
                [filename, submission&.status, submission&.id, exercise.name_en, exercise.name_nl, exercise.id]
              else
-               row = [filename, user.full_name, user.id, submission&.status, submission&.id, exercise.name_en, exercise.name_nl, exercise.id, submission&.created_at]
+               row = [filename, user.id, user.username, user.last_name, user.first_name, user.full_name, user.email]
                row << @users_labels[user].map(&:name).join(';') if labels?
+               row << [submission&.status, submission&.id, exercise.name_en, exercise.name_nl, exercise.id, submission&.created_at]
                row
              end
     end

--- a/app/models/evaluation.rb
+++ b/app/models/evaluation.rb
@@ -114,14 +114,14 @@ class Evaluation < ApplicationRecord
   def grades_csv
     sheet = evaluation_sheet
     CSV.generate(force_quotes: true) do |csv|
-      headers = ['Name', 'Email', 'Total Score', 'Total Max']
+      headers = ['id', 'username', 'last_name', 'first_name', 'full_name', 'email', 'Total Score', 'Total Max']
       headers += sheet[:evaluation_exercises].flat_map { |e| ["#{e.exercise.name} Score", "#{e.exercise.name} Max"] }
       csv << headers
       users.order(last_name: :asc, first_name: :asc).each do |user|
         feedback_l = sheet[:feedbacks][user.id]
         total_score = sheet[:averages][user.id]
         total_max = sheet[:evaluation_exercises].map(&:maximum_score).reject(&:nil?).sum
-        row = [user.full_name, user.email, total_score, total_max]
+        row = [user.id, user.username, user.first_name, user.last_name, user.full_name, user.email, total_score, total_max]
         row += feedback_l.flat_map { |f| [f.score, f.maximum_score] }
         csv << row
       end

--- a/test/controllers/evaluations_controller_test.rb
+++ b/test/controllers/evaluations_controller_test.rb
@@ -407,7 +407,7 @@ class EvaluationsControllerTest < ActionDispatch::IntegrationTest
     assert_equal 1 + evaluation.evaluation_users.length, csv.size
 
     header = csv.shift
-    assert_equal 4 + evaluation.evaluation_exercises.length * 2, header.length
+    assert_equal 8 + evaluation.evaluation_exercises.length * 2, header.length
 
     # Get which users will have a score
     # First, the users we added a score for.
@@ -422,9 +422,9 @@ class EvaluationsControllerTest < ActionDispatch::IntegrationTest
     score_item_exercise_position = header.index { |h| h == "#{exercise.exercise.name} Score" }
     csv.each do |line|
       # Only one exercise has a score.
-      if users.key?(line[1])
+      if users.key?(line[5])
         exported_score = BigDecimal(line.delete_at(score_item_exercise_position))
-        assert_equal users[line[1]], exported_score
+        assert_equal users[line[5]], exported_score
       else
         exported_score = line.delete_at(score_item_exercise_position)
         assert_equal '', exported_score
@@ -433,7 +433,7 @@ class EvaluationsControllerTest < ActionDispatch::IntegrationTest
       assert_equal score_item.maximum, exported_max
 
       # All other scores should be nil.
-      assert line[4..].all?(&:empty?)
+      assert line[8..].all?(&:empty?)
     end
 
     sign_out @course_admin
@@ -482,25 +482,24 @@ class EvaluationsControllerTest < ActionDispatch::IntegrationTest
 
     # Total score should equal sum of scores, Total max should equal the sum of maximum scores
     csv.each do |line|
-      puts line
       # Possible that total maximum is present, but all scores are empty en thus total score is empty
       total_maximum = 0
-      if line[2] == ''
-        (4...line.length - 1).step(2).each do |index|
+      if line[6] == ''
+        (8...line.length - 1).step(2).each do |index|
           assert_equal line[index], ''
           total_maximum += BigDecimal(line[index + 1]) unless line[index + 1] == ''
         end
       else
         total_score = 0
-        (4..line.length - 1).step(2).each do |index|
+        (8..line.length - 1).step(2).each do |index|
           total_score += BigDecimal(line[index]) unless line[index] == ''
           total_maximum += BigDecimal(line[index + 1]) unless line[index + 1] == ''
         end
 
-        assert_equal BigDecimal(line[2]), total_score
+        assert_equal BigDecimal(line[6]), total_score
 
       end
-      assert_equal BigDecimal(line[3]), total_maximum
+      assert_equal BigDecimal(line[7]), total_maximum
     end
   end
 

--- a/test/testhelpers/export_zip_helper.rb
+++ b/test/testhelpers/export_zip_helper.rb
@@ -28,7 +28,7 @@ module SeriesZipHelper
   def check_csv(entry)
     csv = entry.get_input_stream.read
     header = csv.split("\n").first
-    %w[filename status submission_id exercise_id name_nl name_en].each do |h|
+    %w[filename id username last_name first_name full_name email status submission_id exercise_id name_nl name_en].each do |h|
       assert header.include?("\"#{h}\""), "info.csv header did not include #{h}"
     end
   end


### PR DESCRIPTION
This pull request implements a more consistent csv header format that at least contains the columns `id`, `username`, `last_name`, `first_name`, `email`.

<!-- If there are visual changes, add a screenshot -->

Closes #2801.
