### PR TITLE
Update supported browsers

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,8 +1,8 @@
 >= 0.5%
 last 3 major versions
 not dead
-Chrome >= 60
-Firefox >= 60
+Chrome >= 69
+Firefox >= 62
 Firefox ESR
 iOS >= 12
 Safari >= 12


### PR DESCRIPTION
This pull request updates the browsers we support according to the rule "3 year old browsers at the start of the year". This means that the minimal supported Chrome version gets bumped from 60 to 69 and Firefox from 60 to 62. Safari stays at 12.

Closes #2918
