### PR TITLE
Provide correct user URL in submissions.json

### DIFF
--- a/app/controllers/course_members_controller.rb
+++ b/app/controllers/course_members_controller.rb
@@ -33,6 +33,10 @@ class CourseMembersController < ApplicationController
     @course_labels = CourseLabel.where(course: @course)
     @series = policy_scope(@course.series)
     @series_loaded = 5
+    @users_lables = @course.course_memberships
+                           .includes(:course_labels, :user)
+                           .map { |m| [m.user, m.course_labels] }
+                           .to_h
   end
 
   def edit

--- a/app/controllers/course_members_controller.rb
+++ b/app/controllers/course_members_controller.rb
@@ -33,7 +33,7 @@ class CourseMembersController < ApplicationController
     @course_labels = CourseLabel.where(course: @course)
     @series = policy_scope(@course.series)
     @series_loaded = 5
-    @users_lables = @course.course_memberships
+    @users_labels = @course.course_memberships
                            .includes(:course_labels, :user)
                            .map { |m| [m.user, m.course_labels] }
                            .to_h

--- a/app/controllers/course_members_controller.rb
+++ b/app/controllers/course_members_controller.rb
@@ -33,10 +33,6 @@ class CourseMembersController < ApplicationController
     @course_labels = CourseLabel.where(course: @course)
     @series = policy_scope(@course.series)
     @series_loaded = 5
-    @users_labels = @course.course_memberships
-                           .includes(:course_labels, :user)
-                           .map { |m| [m.user, m.course_labels] }
-                           .to_h
   end
 
   def edit

--- a/app/views/course_members/_course_member_data.json.jbuilder
+++ b/app/views/course_members/_course_member_data.json.jbuilder
@@ -1,0 +1,9 @@
+json.extract! user,
+              :id,
+              :username,
+              :first_name,
+              :last_name,
+              :email
+json.status course_membership.status
+json.labels course_membership.course_labels, :name
+json.url course_member_url(course_membership.course, user, format: :json)

--- a/app/views/course_members/index.json.jbuilder
+++ b/app/views/course_members/index.json.jbuilder
@@ -1,5 +1,3 @@
 json.array! @course_memberships do |cm|
-  json.extract! cm.user, :id, :username, :first_name, :last_name, :email
-  json.status cm.status
-  json.url course_member_url(cm.course, cm.user, format: :json)
+  json.partial! 'course_member_data', locals: { user: cm.user, course_membership: cm }
 end

--- a/app/views/course_members/index.json.jbuilder
+++ b/app/views/course_members/index.json.jbuilder
@@ -1,4 +1,5 @@
 json.array! @course_memberships do |cm|
-  json.extract! cm.user, :id, :username, :permission, :first_name, :last_name, :email
+  json.extract! cm.user, :id, :username, :first_name, :last_name, :email
+  json.status cm.status
   json.url course_member_url(cm.course, cm.user, format: :json)
 end

--- a/app/views/course_members/show.json.jbuilder
+++ b/app/views/course_members/show.json.jbuilder
@@ -4,3 +4,4 @@ json.extract! @user,
               :first_name,
               :last_name,
               :email
+              

--- a/app/views/course_members/show.json.jbuilder
+++ b/app/views/course_members/show.json.jbuilder
@@ -5,4 +5,4 @@ json.extract! @user,
               :last_name,
               :email
 json.status @course_membership.status
-json.labels @users_labels[@user], :name
+json.labels @course_membership.course_labels, :name

--- a/app/views/course_members/show.json.jbuilder
+++ b/app/views/course_members/show.json.jbuilder
@@ -1,8 +1,1 @@
-json.extract! @user,
-              :id,
-              :username,
-              :first_name,
-              :last_name,
-              :email
-json.status @course_membership.status
-json.labels @course_membership.course_labels, :name
+json.partial! 'course_member_data', locals: { user: @user, course_membership: @course_membership }

--- a/app/views/course_members/show.json.jbuilder
+++ b/app/views/course_members/show.json.jbuilder
@@ -4,4 +4,5 @@ json.extract! @user,
               :first_name,
               :last_name,
               :email
-              
+json.status @course_membership.status
+json.labels @users_lables[@user], :name

--- a/app/views/course_members/show.json.jbuilder
+++ b/app/views/course_members/show.json.jbuilder
@@ -1,0 +1,6 @@
+json.extract! @user,
+              :id,
+              :username,
+              :first_name,
+              :last_name,
+              :email

--- a/app/views/course_members/show.json.jbuilder
+++ b/app/views/course_members/show.json.jbuilder
@@ -5,4 +5,4 @@ json.extract! @user,
               :last_name,
               :email
 json.status @course_membership.status
-json.labels @users_lables[@user], :name
+json.labels @users_labels[@user], :name

--- a/app/views/submissions/_submission_basic.json.jbuilder
+++ b/app/views/submissions/_submission_basic.json.jbuilder
@@ -1,6 +1,6 @@
 json.extract! submission, :created_at, :status, :summary, :accepted, :id
 json.url submission_url(submission, format: :json)
-json.user course_member_url(:course_id => submission.course, :id => submission.user.id, format: :json) if submission.course
+json.user course_member_url(course_id: submission.course, id: submission.user.id, format: :json) if submission.course
 json.has_annotations submission.annotated?
 json.exercise activity_url(submission.exercise, format: :json)
 json.course course_url(submission.course, format: :json) if submission.course

--- a/app/views/submissions/_submission_basic.json.jbuilder
+++ b/app/views/submissions/_submission_basic.json.jbuilder
@@ -1,6 +1,6 @@
 json.extract! submission, :created_at, :status, :summary, :accepted, :id
 json.url submission_url(submission, format: :json)
-json.user course_member_url(submission.course, submission.user, format: :json)
+json.user course_member_url(:course_id => submission.course, :id => submission.user.id, format: :json) if submission.course
 json.has_annotations submission.annotated?
 json.exercise activity_url(submission.exercise, format: :json)
 json.course course_url(submission.course, format: :json) if submission.course

--- a/app/views/submissions/_submission_basic.json.jbuilder
+++ b/app/views/submissions/_submission_basic.json.jbuilder
@@ -1,6 +1,6 @@
 json.extract! submission, :created_at, :status, :summary, :accepted, :id
 json.url submission_url(submission, format: :json)
-json.user user_url(submission.user, format: :json)
+json.user course_member_url(submission.course, submission.user, format: :json)
 json.has_annotations submission.annotated?
 json.exercise activity_url(submission.exercise, format: :json)
 json.course course_url(submission.course, format: :json) if submission.course

--- a/app/views/submissions/_submission_basic.json.jbuilder
+++ b/app/views/submissions/_submission_basic.json.jbuilder
@@ -1,6 +1,10 @@
 json.extract! submission, :created_at, :status, :summary, :accepted, :id
 json.url submission_url(submission, format: :json)
-json.user course_member_url(course_id: submission.course, id: submission.user.id, format: :json) if submission.course
+if submission.course.present?
+    json.user course_member_url(submission.course, submission.user.id, format: :json)
+else
+    json.user user_url(submission.user.id, format: :json)
+end
 json.has_annotations submission.annotated?
 json.exercise activity_url(submission.exercise, format: :json)
 json.course course_url(submission.course, format: :json) if submission.course

--- a/app/views/submissions/_submission_basic.json.jbuilder
+++ b/app/views/submissions/_submission_basic.json.jbuilder
@@ -1,9 +1,9 @@
 json.extract! submission, :created_at, :status, :summary, :accepted, :id
 json.url submission_url(submission, format: :json)
 if submission.course.present?
-    json.user course_member_url(submission.course, submission.user.id, format: :json)
+  json.user course_member_url(submission.course, submission.user.id, format: :json)
 else
-    json.user user_url(submission.user.id, format: :json)
+  json.user user_url(submission.user.id, format: :json)
 end
 json.has_annotations submission.annotated?
 json.exercise activity_url(submission.exercise, format: :json)


### PR DESCRIPTION
This pull request provides the correct user URL in the submissions json. The `user/:id` URL was provided, however, a course admin can only view a user profile via the `courses/:id/members/:id` URL.


<!-- If there are visual changes, add a screenshot -->


Closes #2732.
