### PR TITLE
Add series navigation on course member page

### DIFF
--- a/app/assets/javascripts/course.js
+++ b/app/assets/javascripts/course.js
@@ -133,7 +133,7 @@ function initCourseShow() {
         const nav = document.getElementById("scrollspy-nav");
         if (nav) {
             new ScrollSpy(nav, {
-                sectionSelector: ".series .anchor",
+                sectionSelector: ".series .anchor, .profile .anchor",
                 offset: 90,
             }).activate();
         }

--- a/app/views/course_members/show.html.erb
+++ b/app/views/course_members/show.html.erb
@@ -102,6 +102,16 @@
     </div>
 
   </div>
+
+  <nav id="scrollspy-nav" class="col-md-1 d-none d-md-block hidden-print series-sidebar">
+    <ul class="nav" data-offset-bottom="80">
+      <li class="header ellipsis-overflow"><%= t "courses.show.exercise_series" %></li>
+      <li><%= link_to t(".statistics"), "#", class: 'ellipsis-overflow nav-link', title: t(".statistics") %> </li>
+      <% @series.each do |series| %>
+        <li><%= link_to series.name, "#" + series.anchor, class: 'ellipsis-overflow nav-link', title: series.name %> </li>
+      <% end %>
+    </ul>
+  </nav>
 </div>
 
 <script type="text/javascript">

--- a/app/views/course_members/show.html.erb
+++ b/app/views/course_members/show.html.erb
@@ -7,6 +7,7 @@
     <div class="card profile">
       <div class="card-supporting-text">
         <div>
+          <a class="anchor" id="statistics" name="statistics"></a>
           <span class="user-icon float-start"><i class="mdi mdi-36 <%= @course_membership.course_admin? ? "mdi-school" : "mdi-account" %>">
           </i></span>
           <span class="profile-line">
@@ -106,7 +107,7 @@
   <nav id="scrollspy-nav" class="col-md-1 d-none d-md-block hidden-print series-sidebar">
     <ul class="nav" data-offset-bottom="80">
       <li class="header ellipsis-overflow"><%= t "courses.show.exercise_series" %></li>
-      <li><%= link_to t(".statistics"), "#", class: 'ellipsis-overflow nav-link', title: t(".statistics") %> </li>
+      <li><%= link_to t(".statistics"), "#statistics", class: 'ellipsis-overflow nav-link', title: t(".statistics") %> </li>
       <% @series.each do |series| %>
         <li><%= link_to series.name, "#" + series.anchor, class: 'ellipsis-overflow nav-link', title: series.name %> </li>
       <% end %>

--- a/config/locales/views/course_members/en.yml
+++ b/config/locales/views/course_members/en.yml
@@ -7,6 +7,7 @@ en:
       close: "Close"
       save: "Save"
       course_overview: "Course overview for "
+      statistics: "Statistics"
     form:
       course_labels: "Labels"
       labels_delimiter: "Use a comma to delimit labels"

--- a/config/locales/views/course_members/nl.yml
+++ b/config/locales/views/course_members/nl.yml
@@ -7,6 +7,7 @@ nl:
       close: "Sluiten"
       save: "Opslaan"
       course_overview: "Cursusoverzicht voor "
+      statistics: "Statistieken"
     form:
       course_labels: "Labels"
       labels_delimiter: "Gebruik een komma om labels te scheiden"


### PR DESCRIPTION
This pull request adds the series navigation in the right margin of the course member page. Before, this series navigation was only shown on the course page and not on the course member page.

<!-- If there are visual changes, add a screenshot -->
![Screenshot from 2021-08-25 11-49-42](https://user-images.githubusercontent.com/53220653/130769104-3e54583c-e66f-41a1-ba79-363b411434a3.png)


Closes #2436.
