### PR TITLE
Check if python judge should be used when seeding the database

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ If you want to help with development, issues tagged with the [student label](htt
     ...
     GRANT ALL ON dodona_test-3.* TO 'dodona';
     ```
-4. Create and seed the database with `rails db:setup`. (If something goes wrong with the database, you can use `rails db:reset` to drop, rebuild and reseed the database.)
+4. Create and seed the database with `rails db:setup`. (If something goes wrong with the database, you can use `rails db:reset` to drop, rebuild and reseed the database.)   
+If the error "Could not initialize python judge" arises, use `SKIP_PYTHON_JUDGE=true rails db:setup`
 5. [Start the server](#starting-the-server). The simplest way is with `rails s`. Dodona [will be available on a subdomain of localhost](#localhost-subdomain): http://dodona.localhost:3000.
 6. Because CAS authentication does not work in development, you can log in by going to these pages (only works with the seed database form step 4)
    - `http://dodona.localhost:3000/nl/users/1/token/zeus`

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -146,7 +146,11 @@ if Rails.env.development?
 
   puts "Create & clone judge (#{Time.now - start})"
 
-  python_judge = Judge.create name: 'python', image: 'dodona/dodona-python', remote: 'git@github.com:dodona-edu/judge-pythia.git', renderer: PythiaRenderer
+  if ENV["SKIP_PYTHON_JUDGE"] == 'true' do
+    python_judge = Judge.create name: 'python', image: 'dodona/dodona-python', remote: 'git@github.com:dodona-edu/judge-java12.git', renderer: PythiaRenderer
+  else
+    python_judge = Judge.create name: 'python', image: 'dodona/dodona-python', remote: 'git@github.com:dodona-edu/judge-pythia.git', renderer: PythiaRenderer
+  end
 
   # Other judges
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -146,11 +146,14 @@ if Rails.env.development?
 
   puts "Create & clone judge (#{Time.now - start})"
 
-  if ENV["SKIP_PYTHON_JUDGE"] == 'true' do
+  if ENV["SKIP_PYTHON_JUDGE"] == 'true'
     python_judge = Judge.create name: 'python', image: 'dodona/dodona-python', remote: 'git@github.com:dodona-edu/judge-java12.git', renderer: PythiaRenderer
   else
     python_judge = Judge.create name: 'python', image: 'dodona/dodona-python', remote: 'git@github.com:dodona-edu/judge-pythia.git', renderer: PythiaRenderer
   end
+
+  raise "Could not initialize python judge, try again or use 'SKIP_PYTHON_JUDGE=true rails db:setup'" if python_judge.nil?
+    
 
   # Other judges
 


### PR DESCRIPTION
This pull request adds an if-statement to check which python judge should be used when seeding the database. A public python judge is used in case the ENV variable `SKIP_PYTHON_JUDGE` is set to `true`. Also, an error arises if the python judge is not initialized.

<!-- If there are visual changes, add a screenshot -->

Closes #2593.
