### PR TITLE
Add button to clear all scores when giving feedback

### DIFF
--- a/app/assets/javascripts/feedback/actions.ts
+++ b/app/assets/javascripts/feedback/actions.ts
@@ -262,9 +262,6 @@ export default class FeedbackActions {
                     f.data = f.getMax();
                 }
             });
-            if (this.clearAllScoresButton) {
-                this.clearAllScoresButton.disabled = false;
-            }
             const values = this.scoreForms.map(f => f.getDataForNested());
             await this.update({
                 // eslint-disable-next-line camelcase

--- a/app/assets/javascripts/feedback/actions.ts
+++ b/app/assets/javascripts/feedback/actions.ts
@@ -160,7 +160,7 @@ export default class FeedbackActions {
         // Only update the total if we have a total.
         if (this.scoreSumElement) {
             this.scoreSumElement.value = newTotal;
-            
+
             if (this.clearAllScoresButton) {
                 this.clearAllScoresButton.disabled = false;
             }
@@ -267,7 +267,6 @@ export default class FeedbackActions {
                 // eslint-disable-next-line camelcase
                 scores_attributes: values
             });
-            
         });
         this.clearAllScoresButton.addEventListener("click", async e => {
             e.preventDefault();
@@ -277,7 +276,7 @@ export default class FeedbackActions {
                     if (f.data) {
                         f.delete();
                     }
-                })
+                });
             }
         });
     }

--- a/app/assets/javascripts/feedback/score.ts
+++ b/app/assets/javascripts/feedback/score.ts
@@ -165,7 +165,7 @@ export default class ScoreForm {
         this.doRequest(method, data, newFocus);
     }
 
-    private delete(): void {
+    delete(): void {
         this.doRequest("delete", {
             // eslint-disable-next-line camelcase
             expected_score: this.expectedScore.value

--- a/app/views/feedbacks/_feedback_actions.html.erb
+++ b/app/views/feedbacks/_feedback_actions.html.erb
@@ -53,23 +53,16 @@
     <% score_items = @feedback.evaluation_exercise.score_items.order(:id) %>
     <% if score_items.length > 1 %>
       <div class="row">
-        <div class="col-sm-12 d-flex justify-content-between align-items-end mb-1">
+        <div class="col-sm-12">
           <strong><%= t ".total" %></strong>
-          <%= button_tag class: "btn btn-danger btn-sm", id: 'clear-button', title: t(".clear_all"), disabled: @feedback.score.nil? do %>
-            <i class="mdi mdi-delete-outline mdi-12" aria-hidden='true'></i>
-          <% end %>
         </div>
       </div>
       <div class="row row-no-gutters form-row">
         <div class="form-group input">
           <div class="control-wrapper">
             <div class="input-group">
-              <%= button_tag class: "btn btn-secondary btn-sm", type: :button, disabled: true do %>
-                <% if @feedback.completed %>
-                  <i id="completed-button" class="mdi mdi-check mdi-12" aria-hidden='true'></i>
-                <% else %>
-                  <i id="completed-button" class="mdi mdi-circle-slice-3 mdi-12" aria-hidden='true'></i>
-                <% end %>
+              <%= button_tag class: "btn btn-secondary btn-sm", id: 'clear-button', title: t(".clear_all"), disabled: @feedback.score.nil? do %>
+                <i class="mdi mdi-delete-outline mdi-12" aria-hidden='true'></i>
               <% end %>
               <input id="score-sum" class="form-control" disabled="disabled" value="<%= format_score @feedback.score %>">
               <%= button_tag class: "btn btn-secondary max-text", disabled: true, type: :button do %>

--- a/app/views/feedbacks/_feedback_actions.html.erb
+++ b/app/views/feedbacks/_feedback_actions.html.erb
@@ -53,8 +53,11 @@
     <% score_items = @feedback.evaluation_exercise.score_items.order(:id) %>
     <% if score_items.length > 1 %>
       <div class="row">
-        <div class="col-sm-12">
+        <div class="col-sm-12 d-flex justify-content-between align-items-end mb-1">
           <strong><%= t ".total" %></strong>
+          <%= button_tag class: "btn btn-danger btn-sm", id: 'clear-button', title: t(".clear_all"), disabled: @feedback.score.nil? do %>
+            <i class="mdi mdi-delete-outline mdi-12" aria-hidden='true'></i>
+          <% end %>
         </div>
       </div>
       <div class="row row-no-gutters form-row">

--- a/config/locales/views/feedbacks/en.yml
+++ b/config/locales/views/feedbacks/en.yml
@@ -35,6 +35,7 @@ en:
       total: "Total"
       give_max_all: "Assign the maximal score to all score items"
       give_zero_all: "Assign 0 to all score items"
+      clear_all: "Clear all scores"
     progress_row:
       exercise_progress: "%{feedback_count} / %{feedback_total} evaluations completed"
     score_actions:

--- a/config/locales/views/feedbacks/nl.yml
+++ b/config/locales/views/feedbacks/nl.yml
@@ -35,6 +35,7 @@ nl:
       total: "Totaal"
       give_max_all: "Geef de maximumscore aan alle scoreonderdelen"
       give_zero_all: "Geef 0 aan alle scoreonderdelen"
+      clear_all: "Verwijder alle scores"
     progress_row:
       exercise_progress: "%{feedback_count} / %{feedback_total} evaluaties afgewerkt"
     score_actions:

--- a/test/system/feedbacks_test.rb
+++ b/test/system/feedbacks_test.rb
@@ -119,7 +119,7 @@ class FeedbacksTest < ApplicationSystemTestCase
     first_input = find(id: "#{@score_item_first.id}-score-form-wrapper").find('.score-input:not(.in-progress)')
     second_input = find(id: "#{@score_item_second.id}-score-form-wrapper").find('.score-input:not(.in-progress)')
 
-    assert_equal '0', first_input.value
+    assert_equal '6', first_input.value # first input was manually assigned so will be untouched
     assert_equal '0', second_input.value
   end
 
@@ -130,7 +130,7 @@ class FeedbacksTest < ApplicationSystemTestCase
     first_input = find(id: "#{@score_item_first.id}-score-form-wrapper").find('.score-input:not(.in-progress)')
     second_input = find(id: "#{@score_item_second.id}-score-form-wrapper").find('.score-input:not(.in-progress)')
 
-    assert_equal @score_item_first.maximum, BigDecimal(first_input.value)
+    assert_equal '6', first_input.value
     assert_equal @score_item_second.maximum, BigDecimal(second_input.value)
   end
 


### PR DESCRIPTION
This pull request adds a button to the "total"-level to clear all currently given scores.
Also the thumbs up/down buttons at the "total"-level now only fills up empty scores and leaves manually assigned scores untouched.

<!-- If there are visual changes, add a screenshot -->
![Screenshot from 2021-08-26 16-57-23](https://user-images.githubusercontent.com/53220653/130986546-10e9d04d-f2dc-4aff-88c8-c9e9e00838fe.png)

Closes #2716.
