### PR TITLE
List own courses first when copying a course

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -29,7 +29,10 @@ class CoursesController < ApplicationController
     elsif params[:tab] == 'featured'
       @courses = @courses.where(featured: true)
     elsif params[:copy_courses]
-      @courses = @courses.reorder(featured: :desc, year: :desc, name: :asc)
+      @own_courses = @courses.joins("INNER JOIN course_memberships ON courses.id = course_memberships.course_id AND course_memberships.user_id = #{@current_user.id} AND course_memberships.status = 1")
+                             .reorder(featured: :desc, year: :desc, name: :asc)
+      @other_courses = @courses.joins("INNER JOIN course_memberships ON courses.id = course_memberships.course_id AND course_memberships.user_id = #{@current_user.id} AND course_memberships.status != 1")
+                               .reorder(featured: :desc, year: :desc, name: :asc)
     end
 
     @courses = apply_scopes(@courses)

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -29,10 +29,13 @@ class CoursesController < ApplicationController
     elsif params[:tab] == 'featured'
       @courses = @courses.where(featured: true)
     elsif params[:copy_courses]
-      @own_courses = @courses.joins("INNER JOIN course_memberships ON courses.id = course_memberships.course_id AND course_memberships.user_id = #{@current_user.id} AND course_memberships.status = 1")
-                             .reorder(featured: :desc, year: :desc, name: :asc)
-      @other_courses = @courses.joins("INNER JOIN course_memberships ON courses.id = course_memberships.course_id AND course_memberships.user_id = #{@current_user.id} AND course_memberships.status != 1")
-                               .reorder(featured: :desc, year: :desc, name: :asc)
+      @featured_courses = @courses.where(featured: true)
+      @own_courses = @courses.where(featured: false)
+                             .reorder(year: :desc, name: :asc)
+                             .select { |course| current_user.course_admin?(course) }
+      @other_courses = @courses.where(featured: false)
+                               .reorder(year: :desc, name: :asc)
+                               .reject { |course| current_user.course_admin?(course) }
     end
 
     @courses = apply_scopes(@courses)

--- a/app/views/courses/_copy_courses_table.html.erb
+++ b/app/views/courses/_copy_courses_table.html.erb
@@ -9,7 +9,30 @@
     </tr>
     </thead>
     <tbody>
-    <% courses.each do |course| %>
+    <% @own_courses.each do |course| %>
+      <tr class="copy-course-row" data-course_id="<%= course.id %>" data-answer="<%= course.name %>">
+        <td>
+          <input type="radio" name="course-select" class="form-check-input">
+        </td>
+        <td>
+          <span>
+            <% if course.featured %>
+              <span title='<%= Course.human_attribute_name("featured") %>'><i class='mdi mdi-18 mdi-star-outline'></i></span>
+            <% end %>
+            <%= course.name %> <span class="text-muted">(<%= course.formatted_year %>)</span>
+          </span>
+          <br/>
+          <small class="text-muted"><%= [course.teacher, course.institution&.name].select(&:present?).join(" - ") %></small>
+        </td>
+        <td><%= course.subscribed_members_count %></td>
+        <td class="actions">
+          <%= link_to course_path(course), target: '_blank', class: 'btn btn-sm btn-secondary nested-link' do %>
+            <i class="mdi mdi-open-in-new mdi-18"></i>
+          <% end %>
+        </td>
+      </tr>
+    <% end %>
+    <% @other_courses.each do |course| %>
       <tr class="copy-course-row" data-course_id="<%= course.id %>" data-answer="<%= course.name %>">
         <td>
           <input type="radio" name="course-select" class="form-check-input">

--- a/app/views/courses/_copy_courses_table.html.erb
+++ b/app/views/courses/_copy_courses_table.html.erb
@@ -9,6 +9,29 @@
     </tr>
     </thead>
     <tbody>
+    <% @featured_courses.each do |course| %>
+      <tr class="copy-course-row" data-course_id="<%= course.id %>" data-answer="<%= course.name %>">
+        <td>
+          <input type="radio" name="course-select" class="form-check-input">
+        </td>
+        <td>
+          <span>
+            <% if course.featured %>
+              <span title='<%= Course.human_attribute_name("featured") %>'><i class='mdi mdi-18 mdi-star-outline'></i></span>
+            <% end %>
+            <%= course.name %> <span class="text-muted">(<%= course.formatted_year %>)</span>
+          </span>
+          <br/>
+          <small class="text-muted"><%= [course.teacher, course.institution&.name].select(&:present?).join(" - ") %></small>
+        </td>
+        <td><%= course.subscribed_members_count %></td>
+        <td class="actions">
+          <%= link_to course_path(course), target: '_blank', class: 'btn btn-sm btn-secondary nested-link' do %>
+            <i class="mdi mdi-open-in-new mdi-18"></i>
+          <% end %>
+        </td>
+      </tr>
+    <% end %>
     <% @own_courses.each do |course| %>
       <tr class="copy-course-row" data-course_id="<%= course.id %>" data-answer="<%= course.name %>">
         <td>


### PR DESCRIPTION
This pull request lists the user's own courses (course admin) first in the course table when copying a course. To accomplish this, I split up the courses into 2 sets, one where the user is course admin of the courses and one where the user is not course admin.

<!-- If there are visual changes, add a screenshot -->

Closes #1661.
