### PR TITLE
Convert HTML and markdown to plain text in structured course data

### DIFF
--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -170,6 +170,6 @@
         "name": "<%= escape_javascript(@course.teacher) %>"
       },
     <% end %>
-    "description": "<%= escape_javascript(@course.description) %>"
+    "description": "<%= raw escape_javascript(strip_tags markdown(@course.description)) %>"
   }
 </script>


### PR DESCRIPTION
This pull request converts the course description HTML and markdown text to plain text in the structured course data.

<!-- If there are visual changes, add a screenshot -->

Closes #3038.
