### PR TITLE
Implement OIDC identity provider

### DIFF
--- a/app/controllers/auth/omniauth_callbacks_controller.rb
+++ b/app/controllers/auth/omniauth_callbacks_controller.rb
@@ -31,6 +31,10 @@ class Auth::OmniauthCallbacksController < Devise::OmniauthCallbacksController
     try_login!
   end
 
+  def oidc
+    try_login!
+  end
+
   def saml
     try_login!
   end

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -22,7 +22,7 @@
 class Provider < ApplicationRecord
   enum mode: { prefer: 0, redirect: 1, link: 2, secondary: 3 }
 
-  PROVIDERS = [Provider::GSuite, Provider::Lti, Provider::Office365, Provider::Saml, Provider::Smartschool].freeze
+  PROVIDERS = [Provider::GSuite, Provider::Lti, Provider::Office365, Provider::Oidc, Provider::Saml, Provider::Smartschool].freeze
 
   belongs_to :institution, inverse_of: :providers
 
@@ -31,6 +31,7 @@ class Provider < ApplicationRecord
   scope :gsuite, -> { where(type: Provider::GSuite.name) }
   scope :lti, -> { where(type: Provider::Lti.name) }
   scope :office365, -> { where(type: Provider::Office365.name) }
+  scope :oidc, -> { where(type: Provider::Oidc.name) }
   scope :saml, -> { where(type: Provider::Saml.name) }
   scope :smartschool, -> { where(type: Provider::Smartschool.name) }
   scope :by_institution, ->(institution) { where(institution_id: institution) }

--- a/app/models/provider/oidc.rb
+++ b/app/models/provider/oidc.rb
@@ -1,0 +1,30 @@
+# == Schema Information
+#
+# Table name: providers
+#
+#  id                :bigint           not null, primary key
+#  type              :string(255)      default("Provider::Saml"), not null
+#  institution_id    :bigint           not null
+#  identifier        :string(255)
+#  certificate       :text(16777215)
+#  entity_id         :string(255)
+#  slo_url           :string(255)
+#  sso_url           :string(255)
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  mode              :integer          default("prefer"), not null
+#  active            :boolean          default(TRUE)
+#  authorization_uri :string(255)
+#  client_id         :string(255)
+#  issuer            :string(255)
+#  jwks_uri          :string(255)
+#
+class Provider::Oidc < Provider
+  validates :certificate, :entity_id, :sso_url, :slo_url, absence: true
+  validates :identifier, absence: true
+  validates :client_id, :issuer, presence: true
+
+  def self.sym
+    :oidc
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -103,7 +103,7 @@ class User < ApplicationRecord
   has_many :annotations, dependent: :restrict_with_error
   has_many :questions, dependent: :restrict_with_error
 
-  devise :omniauthable, omniauth_providers: %i[google_oauth2 lti office365 saml smartschool]
+  devise :omniauthable, omniauth_providers: %i[google_oauth2 lti office365 oidc saml smartschool]
 
   validates :username, uniqueness: { case_sensitive: false, allow_blank: true, scope: :institution }
   validates :email, uniqueness: { case_sensitive: false, allow_blank: true }

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -1,6 +1,9 @@
 ## LTI.
 require_relative '../../lib/LTI/auth.rb'
 
+## OIDC.
+require_relative '../../lib/OIDC/auth.rb'
+
 ## SAML.
 require_relative '../../lib/SAML/strategy.rb'
 require_relative '../../lib/SAML/setup.rb'
@@ -260,6 +263,8 @@ Devise.setup do |config|
   config.omniauth :office365,
                   Rails.application.credentials.office365_client_id,
                   Rails.application.credentials.office365_client_secret
+
+  config.omniauth :oidc, setup: OIDC::Auth::OmniAuth::Setup
 
   config.omniauth :saml, setup: OmniAuth::Strategies::SAML::Setup
 

--- a/lib/LTI/jwk.rb
+++ b/lib/LTI/jwk.rb
@@ -19,13 +19,13 @@ module LTI
 
     def parse_jwks_uri(uri)
       # Download the jwks keyset from the provider.
-      keys = JSON.parse(get_jwsk_content(uri)).with_indifferent_access
+      keys = JSON.parse(get_jwks_content(uri)).with_indifferent_access
 
       # Parse the keys.
       JSON::JWK::Set.new keys[:keys]
     end
 
-    def get_jwsk_content(uri)
+    def get_jwks_content(uri)
       HTTPClient.new.get_content(uri)
     end
 

--- a/lib/OIDC/auth.rb
+++ b/lib/OIDC/auth.rb
@@ -1,0 +1,7 @@
+module OIDC
+  module Auth
+    require_relative 'auth/settings.rb'
+    require_relative 'auth/setup.rb'
+    require_relative 'auth/strategy.rb'
+  end
+end

--- a/lib/OIDC/auth/settings.rb
+++ b/lib/OIDC/auth/settings.rb
@@ -1,0 +1,31 @@
+require 'omniauth'
+
+module OIDC
+  module Auth
+    module Settings
+      def base_settings
+        # Support only third-parties that are discoverable.
+        {
+          client_options: {
+            redirect_uri: "https://#{Rails.configuration.default_host}/users/auth/oidc/callback"
+          },
+          discovery: true,
+          response_mode: :form_post,
+          response_type: :id_token,
+          scope: [:openid, :profile]
+        }
+      end
+
+      def provider_settings(provider)
+        raise 'Not an OIDC provider.' unless provider.is_a?(Provider::Oidc)
+
+        {
+          client_options: {
+            identifier: provider.client_id
+          },
+          issuer: provider.issuer
+        }
+      end
+    end
+  end
+end

--- a/lib/OIDC/auth/setup.rb
+++ b/lib/OIDC/auth/setup.rb
@@ -1,0 +1,72 @@
+module OIDC
+  module Auth
+    module OmniAuth
+      class Setup
+        include OIDC::Auth::Settings
+
+        def self.call(env)
+          new(env).setup
+        end
+
+        def initialize(env)
+          @env = env
+        end
+
+        def setup
+          @env['omniauth.params'] ||= {}
+          @env['omniauth.strategy'].options.merge!(base_settings)
+          @env['omniauth.strategy'].options.merge!(configure)
+        end
+
+        private
+
+        def configure
+          # Obtain the openid parameters for the provider.
+          _provider = provider
+          return failure! if _provider.blank?
+
+          provider_settings(_provider)
+        end
+
+        def failure!
+          raise "Invalid or unknown OIDC provider."
+        end
+
+        def params
+          @params ||= Rack::Request.new(@env).params.symbolize_keys
+        end
+
+        def provider
+          # Get the provider from the provider parameter.
+          return Provider::Oidc.find_by(id: params[:provider]) if params[:provider].present?
+
+          # Get the provider from the issuer parameter.
+          return Provider::Oidc.find_by(issuer: params[:iss]) if params[:iss].present?
+
+          # Get the provider from the state parameter.
+          return Provider::Oidc.find_by(id: provider_from_state) if provider_from_state.present?
+
+          # If there is a JWT available, we can parse that to find the issuer.
+          return nil if params[:id_token].blank?
+
+          # Parse the JWT token.
+          jwt_token = JSON::JWT.decode params[:id_token], :skip_verification
+          Provider::Oidc.find_by(issuer: jwt_token[:iss])
+        end
+
+        def provider_from_state
+          # If there is no state, we will not find anything.
+          return nil if params[:state].blank?
+
+          # Attempt to split the state.
+          state = params[:state].split("-", 2)
+          return nil unless state.count == 2
+
+          # Attempt to parse the id as an integer.
+          parsed = state[1].to_i
+          parsed > 0 ? parsed : nil
+        end
+      end
+    end
+  end
+end

--- a/lib/OIDC/auth/strategy.rb
+++ b/lib/OIDC/auth/strategy.rb
@@ -1,0 +1,14 @@
+require 'openid_connect'
+
+# This strategy enables OIDC to be used by Dodona.
+module OmniAuth
+  module Strategies
+    class OIDC < OmniAuth::Strategies::OpenIDConnect
+      include Rails.application.routes.url_helpers
+
+      option :name, 'oidc'
+    end
+  end
+end
+
+OmniAuth.config.add_camelization 'oidc', 'OIDC'


### PR DESCRIPTION
This pull request implements OIDC as an identity provider. The first use case is the Flemish government, documentation is available at https://authenticatie.vlaanderen.be/docs/beveiligen-van-toepassingen/integratie-methoden/oidc/technische-info/discovery-url/.

:exclamation: If you receive an `OpenIDConnect::Discovery::DiscoveryFailed` exception, this can be because of a present or absent trailing slash (`/`) in the issuer value. Some issuers include this, others don't. 

## Setup test
Add a new provider with the following settings:
```
irb(main):001:0> Provider::Oidc.create!(client_id: 'the-client-id', issuer: 'https://authenticatie-ti.vlaanderen.be/op')
```

## Setup production
Add a new provider with the following settings:
```
irb(main):001:0> Provider::Oidc.create!(client_id: 'the-client-id', issuer: 'https://authenticatie.vlaanderen.be/op')
```

## Displaying a provider in the frontend
Similar to `LTI` and `SAML`, the `provider` must be passed along in the request:
```ruby
 <%= link_to omniauth_authorize_path(:user, Provider::Oidc.sym, provider: provider_comes_here) do %>
Sign in!
<% end %>
```

## Testing
To test this, create a provider with the following settings. This issuer has whitelisted the callbacks for both `dodona.localhost:3000`, `mestra.ugent.be`, `naos.ugent.be` and `dodona.ugent.be`.
```ruby
irb(main):001:0> Provider::Oidc.create!(client_id: '4v22yzEh92pcRylWfEsXe1wtMlgQgE9x', issuer: 'https://dodona-oidc-test.eu.auth0.com/')
```

Closes #3022 