### PR TITLE
Show stats about questions on statistics page

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -171,6 +171,9 @@ class CoursesController < ApplicationController
   def statistics
     @title = I18n.t('courses.statistics.statistics')
     @crumbs = [[@course.name, course_path(@course)], [I18n.t('courses.statistics.statistics'), '#']]
+    @unanswered = @course.unanswered_questions.count
+    @in_progress = @course.in_progress_questions.count
+    @answered = @course.answered_questions.count
   end
 
   def scoresheet

--- a/app/views/courses/statistics.html.erb
+++ b/app/views/courses/statistics.html.erb
@@ -29,6 +29,32 @@
           <% end %>
         </div>
       </div>
+      <div class="row">
+        <div class="col-12 col-sm-3 admin-card-stat">
+          <%= link_to questions_course_path(@course), class: 'card-title-link' do %>
+            <h1><%= number_with_delimiter @unanswered + @in_progress + @answered, delimiter: " " %></h1>
+            <%= t "courses.statistics.total_questions" %>
+          <% end %>
+        </div>
+        <div class="col-12 col-sm-3 admin-card-stat">
+          <%= link_to questions_course_path(@course), class: 'card-title-link' do %>
+            <h1><%= number_with_delimiter @unanswered, delimiter: " " %></h1>
+            <%= t "courses.statistics.unanswered_questions" %>
+          <% end %>
+        </div>
+        <div class="col-12 col-sm-3 admin-card-stat">
+          <%= link_to questions_course_path(@course), class: 'card-title-link' do %>
+            <h1><%= number_with_delimiter @in_progress, delimiter: " " %></h1>
+            <%= t "courses.statistics.in_progress_questions" %>
+          <% end %>
+        </div>
+        <div class="col-12 col-sm-3 admin-card-stat">
+          <%= link_to questions_course_path(@course), class: 'card-title-link' do %>
+            <h1><%= number_with_delimiter @answered, delimiter: " " %></h1>
+            <%= t "courses.statistics.answered_questions" %>
+          <% end %>
+        </div>
+      </div>
 
       <%= render partial: 'visualizations/punchcard', locals: {course: @course} %>
 

--- a/config/locales/views/courses/en.yml
+++ b/config/locales/views/courses/en.yml
@@ -165,6 +165,10 @@ en:
       failed: "Failed unfavoriting course"
     statistics:
       statistics: "Statistics"
+      total_questions: "Total number of questions"
+      unanswered_questions: "Unanswered questions"
+      in_progress_questions: "Questions in progress"
+      answered_questions: "Answered questions"
     user_stats:
       subscribed_users: Registered users
       submitted_solutions: Submitted solutions

--- a/config/locales/views/courses/nl.yml
+++ b/config/locales/views/courses/nl.yml
@@ -161,6 +161,10 @@ nl:
       failed: "Cursus uit favorieten verwijderen mislukt"
     statistics:
       statistics: "Statistieken"
+      total_questions: "Totaal aantal vragen"
+      unanswered_questions: "Onbeantwoorde vragen"
+      in_progress_questions: "Vragen in behandeling"
+      answered_questions: "Beantwoorde vragen"
     user_stats:
       subscribed_users: Geregistreerde gebruikers
       exercise_count: Oefeningen


### PR DESCRIPTION
This pull request shows the total number of questions on the statistics page as well as the number of unanswered, answered and in-progress questions.

<!-- If there are visual changes, add a screenshot -->
![Screenshot from 2021-08-31 11-30-03](https://user-images.githubusercontent.com/53220653/131479324-773bbcc2-3d85-408e-9195-5d0e8bc91a56.png)


Closes #2453.
