### PR TITLE
Make sure institutions get merged even if there are users with no email

### DIFF
--- a/app/models/institution.rb
+++ b/app/models/institution.rb
@@ -56,8 +56,6 @@ class Institution < ApplicationRecord
     errors.add(:merge, 'has link provider') if providers.any?(&:link?)
     return false if errors.any?
 
-    courses.each { |c| c.update(institution: other) }
-    users.each { |u| u.update(institution: other) }
     providers.each do |p|
       if p.prefer?
         p.update(institution: other, mode: :secondary)
@@ -65,6 +63,8 @@ class Institution < ApplicationRecord
         p.update(institution: other)
       end
     end
+    courses.each { |c| c.update(institution: other) }
+    users.each { |u| u.update(institution: other) }
     reload
     destroy
   end

--- a/test/models/institution_test.rb
+++ b/test/models/institution_test.rb
@@ -68,6 +68,18 @@ class InstitutionTest < ActiveSupport::TestCase
     assert provider3.redirect?
   end
 
+  test 'should merge if there are smartschool users with no email' do
+    institution_to_merge = create :institution
+    provider = create(:smartschool_provider, institution: institution_to_merge, mode: :prefer)
+    user = create :user, email: nil, institution: institution_to_merge
+    create :identity, provider: provider, user: user
+    institution = create :institution
+    create :provider, institution: institution, mode: :prefer
+    institution_to_merge.merge_into(institution)
+    assert institution_to_merge.destroyed?
+    assert_equal user.reload.institution_id, institution.id
+  end
+
   test 'merge should update users' do
     institution_to_merge = create :institution
     users = create_list :user, 4, institution: institution_to_merge


### PR DESCRIPTION
By reordering the updates, we can be sure that the new institution allows users with no email.

- [x] Tests were added

Closes #3040.
