### PR TITLE
Remove "created" and "last edited"  in activity info

### DIFF
--- a/app/views/activities/info.html.erb
+++ b/app/views/activities/info.html.erb
@@ -66,20 +66,6 @@
                     <%= github_link @repository, @activity.path %>
                     <% end %>
                   </div>
-                  <div class="col-md-12 col-6">
-                    <p title="<%= t '.created' %>">
-                    <i class="mdi mdi-clock-outline mdi-24"></i>
-                    <span title="<%= l @activity.created_at, format: :long %>">
-                    <%= time_ago_in_words(@activity.created_at) %> <%= t '.ago' %>
-                    </span>
-                  </div>
-                  <div class="col-md-12 col-6">
-                    <p title="<%= t '.updated' %>">
-                    <i class="mdi mdi-update mdi-24"></i>
-                    <span title="<%= l @activity.updated_at, format: :long %>">
-                    <%= time_ago_in_words(@activity.updated_at) %> <%= t '.ago' %>
-                    </span>
-                  </div>
                 </div>
               </div>
             </div>

--- a/config/locales/views/activities/en.yml
+++ b/config/locales/views/activities/en.yml
@@ -109,8 +109,6 @@ en:
       judge: Judge
       repository: Repository containing this activity
       repository_path: Path within this repository
-      created: Created
-      updated: Last edited
       ago: ago
       click_here_to_create_one: Click here to create the readme.
       config_set_by: "This value was set by %{file}"

--- a/config/locales/views/activities/nl.yml
+++ b/config/locales/views/activities/nl.yml
@@ -110,8 +110,6 @@ nl:
       judge: Judge
       repository: Repository waar deze leeractiviteit zich in bevindt
       repository_path: Bestandslocatie binnen deze repository
-      created: Aangemaakt
-      updated: Laatst gewijzigd
       ago: geleden
       click_here_to_create_one: Klik hier om de 'readme' informatie aan te maken.
       config_set_by: "Deze waarde werd ingesteld door %{file}"


### PR DESCRIPTION
This pull request removes "created" and "last edited" on the activity info page as they do not have much added value.

<!-- If there are visual changes, add a screenshot -->
before:
![Screenshot from 2021-09-02 11-18-56](https://user-images.githubusercontent.com/53220653/131818145-fdf5a23d-6242-4f29-9068-5a278cfc70a6.png)

after:
![Screenshot from 2021-09-02 11-18-01](https://user-images.githubusercontent.com/53220653/131818200-59168926-41ac-4dc0-8be0-d24155869005.png)



Closes #2374.
