### PR TITLE
Improve R syntax highlighting

### DIFF
--- a/app/assets/stylesheets/theme/rouge-light.css.scss
+++ b/app/assets/stylesheets/theme/rouge-light.css.scss
@@ -149,6 +149,11 @@
     color: #BA2121 !important
   }
 
+  /* Name */
+  .highlighter-rouge .n {
+    color: #19177C !important
+  }
+
   /* Name.Attribute */
   .highlighter-rouge .na {
     color: #7D9029 !important


### PR DESCRIPTION
This pull request gives a color to the general `highlighter-rouge .n` class in light theme. I've chosen the same color as `Name.variable` (dark blue).

<!-- If there are visual changes, add a screenshot -->
before:
![Screenshot from 2021-09-02 17-04-40](https://user-images.githubusercontent.com/53220653/131868884-e0cc9c90-032a-4e80-baac-1a81304713f5.png)
after:
![Screenshot from 2021-09-02 17-04-17](https://user-images.githubusercontent.com/53220653/131868906-a7a5add3-a1cc-4c98-83a5-c872101647a9.png)



Closes #2193.
