### PR TITLE
Make grading debounce independent per score item

### DIFF
--- a/app/assets/javascripts/feedback/score.ts
+++ b/app/assets/javascripts/feedback/score.ts
@@ -1,4 +1,4 @@
-import { fetch, delay } from "util.js";
+import { fetch, createDelayer } from "util.js";
 import FeedbackActions from "feedback/actions";
 
 /**
@@ -59,6 +59,7 @@ export default class ScoreForm {
         this.form.addEventListener("submit", e => {
             e.preventDefault();
         });
+        const delay = createDelayer();
         this.input.addEventListener("change", ev => {
             // If the score is not valid, don't do anything.
             if (!this.input.reportValidity()) {

--- a/app/assets/javascripts/util.js
+++ b/app/assets/javascripts/util.js
@@ -26,13 +26,11 @@ import { isInIframe } from "iframe";
  *  @return {function(TimerHandler, number): void}
  */
 function createDelayer() {
-    return (function () {
-        let timer = 0;
-        return function (callback, ms) {
-            clearTimeout(timer);
-            timer = setTimeout(callback, ms);
-        };
-    })();
+    let timer = 0;
+    return function (callback, ms) {
+        clearTimeout(timer);
+        timer = setTimeout(callback, ms);
+    };
 }
 
 /*

--- a/app/assets/javascripts/util.js
+++ b/app/assets/javascripts/util.js
@@ -2,17 +2,47 @@
 
 import { isInIframe } from "iframe";
 
+/**
+ * Create a function that will delay all subsequent calls on the same timer.
+ * You don't necessarily have to call the delayer with the same function.
+ *
+ * In the first example, the typical usage is illustrated. The second example
+ * illustrates what happens with multiple delayers, each with their own timer.
+ *
+ * There is also a pre-made delayer available with a global timer, see `delay`.
+ * @example
+ *  const delay = createDelayer();
+ *  delay(() => console.log(1), 100);
+ *  delay(() => console.log(2), 100);
+ *  // prints 2, since the first invocation is cancelled
+ *
+ * @example
+ *  const delay1 = createDelayer();
+ *  const delay2 = createDelayer();
+ *  delay1(() => console.log(1), 100);
+ *  delay2(() => console.log(2), 100);
+ *  // prints 1 and then 2, since both have their own timer.
+ *
+ *  @return {function(TimerHandler, number): void}
+ */
+function createDelayer() {
+    return (function () {
+        let timer = 0;
+        return function (callback, ms) {
+            clearTimeout(timer);
+            timer = setTimeout(callback, ms);
+        };
+    })();
+}
+
 /*
  * Function to delay some other function until it isn't
- * called for "ms" ms
+ * called for "ms" ms. This runs on a global timer, meaning
+ * the actual function doesn't matter. If you want a delay
+ * specifically for one function, you need to first create
+ * your own "delayer" with `createDelayer`.
  */
-const delay = (function () {
-    let timer = 0;
-    return function (callback, ms) {
-        clearTimeout(timer);
-        timer = setTimeout(callback, ms);
-    };
-})();
+const delay = createDelayer();
 
 function updateURLParameter(_url, param, paramVal) {
     const url = new URL(_url, window.location.origin);
@@ -143,6 +173,7 @@ function setDocumentTitle(title) {
 }
 
 export {
+    createDelayer,
     delay,
     fetch,
     updateURLParameter,

--- a/test/javascript/util.test.js
+++ b/test/javascript/util.test.js
@@ -1,73 +1,95 @@
-import { updateArrayURLParameter, updateURLParameter, getURLParameter, getArrayURLParameter } from "../../app/assets/javascripts/util";
+import {
+    updateArrayURLParameter, updateURLParameter, getURLParameter, getArrayURLParameter,
+    delay, createDelayer
+} from "../../app/assets/javascripts/util";
 
-let relativePath;
-let relativePathParameter;
-let noParameterURL;
-let oneParameterURL;
-let twoParameterURL;
-let multipleValueUrl;
+jest.useFakeTimers();
 
-beforeEach(() => {
-    relativePath = "/test_functions";
-    relativePathParameter = "/test_functions?param=paramVal"
-    noParameterURL = "https://example.com/test_functions";
-    oneParameterURL = "https://example.com/test_functions?param1=paramVal1";
-    twoParameterURL = "https://example.com/test_functions?param1=paramVal1&param2=paramVal2";
+describe("Url functions", () => {
+    const relativePath = "/test_functions";
+    const relativePathParameter = "/test_functions?param=paramVal";
+    const noParameterURL = "https://example.com/test_functions";
+    const oneParameterURL = "https://example.com/test_functions?param1=paramVal1";
+    const twoParameterURL = "https://example.com/test_functions?param1=paramVal1&param2=paramVal2";
     // "[]" is converted to "%5B%5D" in a URL
-    multipleValueUrl = "https://example.com/test_functions?param%5B%5D=paramVal1&param%5B%5D=paramVal2&param%5B%5D=paramVal3";
+    // eslint-disable-next-line max-len
+    const multipleValueUrl = "https://example.com/test_functions?param%5B%5D=paramVal1&param%5B%5D=paramVal2&param%5B%5D=paramVal3";
+
+    test("return correct parameter value", () => {
+        expect(getURLParameter("param", relativePathParameter)).toBe("paramVal");
+        expect(getURLParameter("param1", oneParameterURL)).toBe("paramVal1");
+        expect(getURLParameter("param2", twoParameterURL)).toBe("paramVal2");
+
+        expect(getURLParameter("param", relativePath)).toBe(null);
+        expect(getURLParameter("param", noParameterURL)).toBe(null);
+        expect(getURLParameter("wrongParam", oneParameterURL)).toBe(null);
+    });
+
+    test("return correct array parameter value if present", () => {
+        expect(getArrayURLParameter("param", multipleValueUrl))
+            .toEqual(["paramVal1", "paramVal2", "paramVal3"]);
+        expect(getArrayURLParameter("param", relativePath)).toEqual([]);
+        expect(getArrayURLParameter("param", noParameterURL)).toEqual([]);
+        expect(getArrayURLParameter("wrongParam", twoParameterURL)).toEqual([]);
+    });
+
+    test("update URL parameter", () => {
+        let updatedURL = updateURLParameter(relativePath, "param", "paramval");
+        expect(updatedURL).toEqual(`${window.location.origin}${relativePath}?param=paramval`);
+
+        updatedURL = updateURLParameter(noParameterURL, "param", "paramVal");
+        expect(updatedURL).toEqual(`${noParameterURL}?param=paramVal`);
+
+        updatedURL = updateURLParameter(oneParameterURL, "param1", "newParamVal1");
+        expect(updatedURL).toEqual(`${noParameterURL}?param1=newParamVal1`);
+
+        updatedURL = updateURLParameter(twoParameterURL, "param3", "paramVal3");
+        expect(updatedURL).toEqual(`${twoParameterURL}&param3=paramVal3`);
+
+        updatedURL = updateURLParameter(oneParameterURL, "param1");
+        expect(updatedURL).toEqual(noParameterURL);
+    });
+
+    test("update array URL parameter", () => {
+        let updatedURL = updateArrayURLParameter(relativePath, "param",
+            ["paramVal1", "paramVal1", "paramVal2"]);
+        // eslint-disable-next-line max-len
+        expect(updatedURL).toEqual(`${window.location.origin}${relativePath}?param%5B%5D=paramVal1&param%5B%5D=paramVal2`);
+
+        updatedURL = updateArrayURLParameter(noParameterURL, "param",
+            ["paramVal1", "paramVal1", "paramVal2", "paramVal3"]);
+        // eslint-disable-next-line max-len
+        expect(updatedURL).toEqual(`${noParameterURL}?param%5B%5D=paramVal1&param%5B%5D=paramVal2&param%5B%5D=paramVal3`);
+
+        updatedURL = updateArrayURLParameter(oneParameterURL, "param2", ["paramVal2"]);
+        expect(updatedURL).toEqual(`${oneParameterURL}&param2%5B%5D=paramVal2`);
+
+        updatedURL = updateArrayURLParameter(multipleValueUrl, "param", ["paramVal1", "paramVal2"]);
+        expect(updatedURL).toEqual(`${noParameterURL}?param%5B%5D=paramVal1&param%5B%5D=paramVal2`);
+    });
 });
 
-test("return correct parameter value", () => {
-    expect(getURLParameter("param", relativePathParameter)).toBe("paramVal");
-    expect(getURLParameter("param1", oneParameterURL)).toBe("paramVal1");
-    expect(getURLParameter("param2", twoParameterURL)).toBe("paramVal2");
+describe("Delay tests", () => {
+    test("delay debounces result", () => {
+        const callback = jest.fn(() => {
+        });
+        delay(callback, 100);
+        delay(callback, 100);
+        // Fast forward until everything is run.
+        jest.advanceTimersByTime(200);
+        expect(callback.mock.calls.length).toBe(1);
+    });
 
-    expect(getURLParameter("param", relativePath)).toBe(null);
-    expect(getURLParameter("param", noParameterURL)).toBe(null);
-    expect(getURLParameter("wrongParam", oneParameterURL)).toBe(null);
+    test("different delayers are independent", () => {
+        const callback = jest.fn(() => {
+        });
+        const delay1 = createDelayer();
+        const delay2 = createDelayer();
+        delay(callback, 100);
+        delay1(callback, 100);
+        delay2(callback, 100);
+        // Fast forward until everything is run.
+        jest.advanceTimersByTime(200);
+        expect(callback.mock.calls.length).toBe(3);
+    });
 });
-
-test("return correct array parameter value if present", () => {
-    expect(getArrayURLParameter("param", multipleValueUrl)).toEqual(["paramVal1", "paramVal2", "paramVal3"]);
-
-    expect(getArrayURLParameter("param", relativePath)).toEqual([]);
-    expect(getArrayURLParameter("param", noParameterURL)).toEqual([]);
-    expect(getArrayURLParameter("wrongParam", twoParameterURL)).toEqual([]);
-});
-
-test("update URL parameter", () => {
-    let updatedURL;
-
-    // test updateURLParameter
-    updatedURL = updateURLParameter(relativePath, "param", "paramval")
-    expect(updatedURL).toEqual(`${window.location.origin}${relativePath}?param=paramval`);
-
-    updatedURL = updateURLParameter(noParameterURL, "param", "paramVal");
-    expect(updatedURL).toEqual(`${noParameterURL}?param=paramVal`);
-
-    updatedURL = updateURLParameter(oneParameterURL, "param1", "newParamVal1");
-    expect(updatedURL).toEqual(`${noParameterURL}?param1=newParamVal1`);
-
-    updatedURL = updateURLParameter(twoParameterURL, "param3", "paramVal3");
-    expect(updatedURL).toEqual(`${twoParameterURL}&param3=paramVal3`);
-
-    updatedURL = updateURLParameter(oneParameterURL, "param1");
-    expect(updatedURL).toEqual(noParameterURL);
-});
-
-test("Update array URL parameter", () => {
-    let updatedURL;
-
-    // test updateArrayURLParameter
-    updatedURL = updateArrayURLParameter(relativePath, "param", ["paramVal1", "paramVal1", "paramVal2"]);
-    expect(updatedURL).toEqual(`${window.location.origin}${relativePath}?param%5B%5D=paramVal1&param%5B%5D=paramVal2`)
-
-    updatedURL = updateArrayURLParameter(noParameterURL, "param", ["paramVal1", "paramVal1", "paramVal2", "paramVal3"]);
-    expect(updatedURL).toEqual(`${noParameterURL}?param%5B%5D=paramVal1&param%5B%5D=paramVal2&param%5B%5D=paramVal3`);
-
-    updatedURL = updateArrayURLParameter(oneParameterURL, "param2", ["paramVal2"]);
-    expect(updatedURL).toEqual(`${oneParameterURL}&param2%5B%5D=paramVal2`);
-
-    updatedURL = updateArrayURLParameter(multipleValueUrl, "param", ["paramVal1", "paramVal2"]);
-    expect(updatedURL).toEqual(`${noParameterURL}?param%5B%5D=paramVal1&param%5B%5D=paramVal2`);
-})


### PR DESCRIPTION
This pull request fixes #3072.

The existing `delay` function uses a global timer for the delaying, regardless of what function you call. This is why only the last score was being saved (since the previous calls are cancelled when the next score saving function is called). I have now introduced a `createDelayer` function, which allows you to create multiple `delay`s that are independent.

- [x] Tests were added, and the test file was cleaned up a bit.