### PR TITLE
Reduce requested scope when LTI provider is Ufora

### DIFF
--- a/lib/LTI/auth/settings.rb
+++ b/lib/LTI/auth/settings.rb
@@ -23,7 +23,7 @@ module LTI
       def provider_settings(provider)
         raise 'Not an LTI provider.' unless provider.is_a?(Provider::Lti)
 
-        {
+        hash = {
             client_options: {
                 authorization_endpoint: provider.authorization_uri,
                 jwks_uri: provider.jwks_uri,
@@ -31,6 +31,8 @@ module LTI
             },
             issuer: provider.issuer
         }
+        hash[:scope] = [:openid] if (provider.issuer == "https://ufora.ugent.be")
+        hash
       end
     end
   end


### PR DESCRIPTION
Applied this patch to production already, Ufora works again. It's a bit of a hack but 🤷‍♀️

Closes #3082 .
