### PR TITLE
Fix stray left margin in series dropdown

### DIFF
--- a/app/assets/stylesheets/components/card.css.scss
+++ b/app/assets/stylesheets/components/card.css.scss
@@ -232,6 +232,7 @@ a.card-title-link:hover {
 }
 
 .card-subtitle-actions a.dropdown-item {
+  margin-left: unset;
   color: $text-color;
 }
 


### PR DESCRIPTION
Presumably introduced by #2598.

Closes #3092.
