### PR TITLE
Fix height of series card after showing "not enough data"

### DIFF
--- a/app/assets/javascripts/visualisations/series_graph.ts
+++ b/app/assets/javascripts/visualisations/series_graph.ts
@@ -169,8 +169,8 @@ export abstract class SeriesGraph {
     */
     protected drawNoData(): void {
         this.container
-            .style("height", "50px")
             .append("div")
+            .style("height", "50px")
             .text(I18n.t("js.no_data"))
             .attr("class", "graph_placeholder");
     }


### PR DESCRIPTION
Fixes faulty visualisation container height after one of them returns a 'not enough data'

Closes #3110 .

