### PR TITLE
Rewrite series graph legends in HTML instead of SVG

### DIFF
--- a/app/assets/javascripts/visualisations/cumulative_timeseries.ts
+++ b/app/assets/javascripts/visualisations/cumulative_timeseries.ts
@@ -287,43 +287,24 @@ export class CTimeseriesGraph extends SeriesGraph {
 
     private legendInit(): void {
         // calculate legend element offsets
-        const exPosition = [];
-        let pos = 0;
-        this.exOrder.forEach(ex => {
-            exPosition.push({ ex_id: ex, pos: pos });
-            // rect size (15) + 5 padding + 20 inter-group padding + text length
-            pos += 40 + this.fontSize / 2 * this.exMap[ex].length;
-        });
-        const legend = this.svg
-            .append("g")
+        const legend = this.container
+            .append("div")
             .attr("class", "legend")
-            .attr(
-                "transform",
-                `translate(${this.width / 2 - pos / 2}, ${this.height - this.margin.bottom / 2})`
-            )
-            .selectAll("g")
-            .data(exPosition)
+            .style("margin-top", "-50px")
+            .selectAll("div")
+            .data(this.exOrder)
             .enter()
-            .append("g")
-            .attr("transform", d => `translate(${d.pos}, 0)`);
-
-        // add legend colors dots
+            .append("div")
+            .attr("class", "legend-item");
         legend
-            .append("rect")
-            .attr("x", 0)
-            .attr("y", 0)
-            .attr("width", 15)
-            .attr("height", 15)
-            .attr("fill", ex => this.color(ex.ex_id) as string);
-
-        // add legend text
+            .append("div")
+            .attr("class", "legend-box")
+            .style("background", exId => this.color(exId));
         legend
-            .append("text")
-            .attr("x", 20)
-            .attr("y", 12)
-            .attr("text-anchor", "start")
-            .text(ex => this.exMap[ex.ex_id])
-            .attr("fill", "currentColor")
+            .append("span")
+            .attr("class", "legend-text")
+            .text(exId => this.exMap[exId])
+            .style("color", "currentColor")
             .style("font-size", `${this.fontSize}px`);
     }
 }

--- a/app/assets/javascripts/visualisations/stacked_status.ts
+++ b/app/assets/javascripts/visualisations/stacked_status.ts
@@ -41,6 +41,7 @@ export class StackedStatusGraph extends SeriesExerciseGraph {
         const legend = this.container
             .append("div")
             .attr("class", "legend")
+            .style("margin-top", "-20px")
             .selectAll("div")
             .data(this.statusOrder)
             .enter()

--- a/app/assets/javascripts/visualisations/stacked_status.ts
+++ b/app/assets/javascripts/visualisations/stacked_status.ts
@@ -37,36 +37,24 @@ export class StackedStatusGraph extends SeriesExerciseGraph {
             .style("opacity", 0)
             .style("z-index", 5);
 
-        // calculate offset for legend elements
-        const { maxPosition, offsets } = this.calculateLegendOffsets();
-
         // Legend
-        const legend = this.svg
-            .append("g")
+        const legend = this.container
+            .append("div")
             .attr("class", "legend")
-            .attr(
-                "transform",
-                `translate(${this.width / 2 - maxPosition / 2}, ${this.height - this.margin.bottom / 2})`
-            )
-            .selectAll("g")
-            .data(offsets)
+            .selectAll("div")
+            .data(this.statusOrder)
             .enter()
-            .append("g")
-            .attr("transform", d => `translate(${d.pos}, 0)`);
+            .append("div")
+            .attr("class", "legend-item");
         legend
-            .append("rect")
-            .attr("x", 0)
-            .attr("y", 0)
-            .attr("width", 15)
-            .attr("height", 15)
-            .attr("fill", s => color(s.status) as string);
+            .append("div")
+            .attr("class", "legend-box")
+            .style("background", status => color(status) as string);
         legend
-            .append("text")
-            .attr("x", 20)
-            .attr("y", 12)
-            .attr("text-anchor", "start")
-            .text(s => I18n.t(`js.status.${s.status.replaceAll(" ", "_")}`))
-            .attr("fill", "currentColor")
+            .append("span")
+            .attr("class", "legend-text")
+            .text(status => I18n.t(`js.status.${status.replaceAll(" ", "_")}`))
+            .style("color", "currentColor")
             .style("font-size", `${this.fontSize}px`);
 
         // Bars
@@ -159,21 +147,5 @@ export class StackedStatusGraph extends SeriesExerciseGraph {
             });
             this.maxSum[ex_id] = sum;
         });
-    }
-
-    private calculateLegendOffsets(): { maxPosition: number, offsets: { status: string, pos: number }[] } {
-        const statePosition: { status: string, pos: number }[] = [];
-        let pos = 0;
-        this.statusOrder.forEach(status => {
-            statePosition.push({ status: status, pos: pos });
-            const translatedStatus = I18n.t(`js.status.${status.replaceAll(" ", "_")}`);
-
-            pos += 15 + // rect size
-                5 + // padding
-                5 + // inter-group padding
-                (translatedStatus === "wrong" ? 5 : 0) + // extra spacing for wrong
-                this.fontSize / 2 * translatedStatus.length;
-        });
-        return { maxPosition: pos, offsets: statePosition };
     }
 }

--- a/app/assets/stylesheets/components/visualisations.css.scss
+++ b/app/assets/stylesheets/components/visualisations.css.scss
@@ -25,6 +25,7 @@
 
 .stats-container {
   display: flex;
+  flex-direction: column;
 }
 
 .graph_placeholder {
@@ -34,4 +35,29 @@
 .metric-container {
   fill: none;
   stroke-width: 2;
+}
+
+.legend {
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  margin-top: -20px;
+
+  .legend-item {
+    margin-left: 8px;
+    margin-right: 8px;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+
+    .legend-box {
+      width: 15px;
+      height: 15px;
+      border-radius: 5px;
+    }
+
+    .legend-text {
+      margin-left: 4px;
+    }
+  } 
 }

--- a/app/assets/stylesheets/components/visualisations.css.scss
+++ b/app/assets/stylesheets/components/visualisations.css.scss
@@ -41,6 +41,7 @@
   display: flex;
   flex-direction: row;
   justify-content: center;
+  flex-wrap: wrap;
 
   .legend-item {
     margin-left: 8px;
@@ -50,6 +51,7 @@
     align-items: center;
 
     .legend-box {
+      min-width: 15px;
       width: 15px;
       height: 15px;
       border-radius: 5px;

--- a/app/assets/stylesheets/components/visualisations.css.scss
+++ b/app/assets/stylesheets/components/visualisations.css.scss
@@ -41,7 +41,6 @@
   display: flex;
   flex-direction: row;
   justify-content: center;
-  margin-top: -20px;
 
   .legend-item {
     margin-left: 8px;

--- a/app/assets/stylesheets/components/visualisations.css.scss
+++ b/app/assets/stylesheets/components/visualisations.css.scss
@@ -42,6 +42,7 @@
   flex-direction: row;
   justify-content: center;
   flex-wrap: wrap;
+  overflow: hidden;
 
   .legend-item {
     margin-left: 8px;
@@ -51,7 +52,6 @@
     align-items: center;
 
     .legend-box {
-      min-width: 15px;
       width: 15px;
       height: 15px;
       border-radius: 5px;


### PR DESCRIPTION
The visualisation legends have been rewritten into html (instead of svg). Several styling attributes have been moved to the stylesheet. I also used the opportunity to give the colour boxes rounded colours since I feel like it looks a bit better.

![image](https://user-images.githubusercontent.com/32074366/134194250-545a3478-200e-4f2e-9028-8fc698fc439c.png)

![image](https://user-images.githubusercontent.com/32074366/134194494-a3024982-5fec-4ba3-ab1e-536a74f24aec.png)


Closes #3019 .
