### PR TITLE
Visualisation y-axis range toggle

### DIFF
--- a/app/assets/javascripts/visualisations/cumulative_timeseries.ts
+++ b/app/assets/javascripts/visualisations/cumulative_timeseries.ts
@@ -111,16 +111,15 @@ export class CTimeseriesGraph extends SeriesGraph {
 
         // y range toggle functionality
         // add a rect behind y-axis for bigger clickable area
-        const yBackground = this.graph.append("rect")
+        this.graph.append("rect")
             .attr("width", 50)
             .attr("height", this.innerHeight+10)
             .attr("x", -50)
             .attr("y", -10)
             .attr("fill", "none")
-            .attr("pointer-events", "all");
-        yBackground
-            .on("click", () => this.yRangeToggle())
-            .on("mouseover", () => yBackground.style("cursor", "pointer"));
+            .attr("pointer-events", "all")
+            .style("cursor", "pointer")
+            .on("click", () => this.yRangeToggle());
 
         this.drawUpdate(animation);
     }
@@ -159,9 +158,6 @@ export class CTimeseriesGraph extends SeriesGraph {
         this.graph.selectAll(".line")
             .data(this.data, ex => ex.ex_id )
             .join("path")
-            // .attr("class", "line")
-            // .style("stroke", ex => this.color(ex.ex_id) as string)
-            // .style("fill", "none")
             .transition().duration(animation ? 500: 0)
             .attr("d", ex => d3.line()
                 .x(d => this.x(d.bin["x0"]))

--- a/app/assets/javascripts/visualisations/cumulative_timeseries.ts
+++ b/app/assets/javascripts/visualisations/cumulative_timeseries.ts
@@ -187,9 +187,6 @@ export class CTimeseriesGraph extends SeriesGraph {
             ex.ex_data = ex.ex_data.map((d: string) => new Date(d));
         });
 
-
-        this.insertFakeData(data, student_count);
-
         let [minDate, maxDate] = d3.extent(data.flatMap(ex => ex.ex_data)) as Date[];
         minDate = d3.timeDay.offset(new Date(minDate), -1); // start 1 day earlier from 0
         maxDate = new Date(maxDate);

--- a/app/assets/javascripts/visualisations/cumulative_timeseries.ts
+++ b/app/assets/javascripts/visualisations/cumulative_timeseries.ts
@@ -104,10 +104,23 @@ export class CTimeseriesGraph extends SeriesGraph {
                 .curve(d3.curveMonotoneX)(ex.ex_data)
             );
 
+        // tooltip functionality
         this.svg.on("mouseover", e => this.tooltipOver(e));
         this.svg.on("mousemove", e => this.tooltipMove(e));
         this.svg.on("mouseleave", () => this.tooltipOut());
-        this.svg.on("click", () => this.yRangeToggle());
+
+        // y range toggle functionality
+        // add a rect behind y-axis for bigger clickable area
+        const yBackground = this.graph.append("rect")
+            .attr("width", 50)
+            .attr("height", this.innerHeight+10)
+            .attr("x", -50)
+            .attr("y", -10)
+            .attr("fill", "none")
+            .attr("pointer-events", "all");
+        yBackground
+            .on("click", () => this.yRangeToggle())
+            .on("mouseover", () => yBackground.style("cursor", "pointer"));
 
         this.drawUpdate(animation);
     }

--- a/app/assets/javascripts/visualisations/cumulative_timeseries.ts
+++ b/app/assets/javascripts/visualisations/cumulative_timeseries.ts
@@ -35,7 +35,7 @@ export class CTimeseriesGraph extends SeriesGraph {
     private studentCount: number; // amount of subscribed students
     private maxSum = 0; // largest y-value == max value
     private dateArray: Date[]; // an array of dates from minDate -> maxDate (in days)
-    private y100 = true; // Whether y range goes to 100% (true) of max of the data (false)
+    private y100 = false; // Whether y range goes to 100% (true) of max of the data (false)
 
     /**
     * Draws the graph's svg (and other) elements that never change on the screen


### PR DESCRIPTION
This pull request add the functionality for the cumulative timeseries graph to toggle between a max y range of 100% and max of the data.
At the moment I'm a bit unsure of how to communicate the existence of this feature to the users, since a clickable axis is something easily overlooked.
![image](https://user-images.githubusercontent.com/32074366/134814838-ad68ba42-cef0-484d-8b99-97daf931d9db.png)
![image](https://user-images.githubusercontent.com/32074366/134814852-8c1d7fc5-91ff-4b52-9c26-c9bd63d71a2e.png)


Closes  #3018 .
