### PR TITLE
Fix order on student evaluation overview page

### DIFF
--- a/app/controllers/evaluations_controller.rb
+++ b/app/controllers/evaluations_controller.rb
@@ -161,6 +161,7 @@ class EvaluationsController < ApplicationController
     @feedbacks = Feedback.joins(:evaluation_user)
                          .where(evaluation: @evaluation, evaluation_users: { user: current_user })
                          .includes(:evaluation_exercise, scores: :score_item)
+                         .order('evaluation_exercises.id')
     @feedbacks = policy_scope(@feedbacks)
   end
 

--- a/app/views/evaluations/overview.html.erb
+++ b/app/views/evaluations/overview.html.erb
@@ -22,7 +22,7 @@
           <tbody>
             <% @feedbacks.each do |fb| %>
               <% show_total = policy(fb.evaluation_exercise).show_total? %>
-              <% scores = policy_scope(fb.scores).includes(:score_item) %>
+              <% scores = policy_scope(fb.scores).includes(:score_item).order('score_items.id') %>
               <tr>
                 <%# The last row is normally borderless, but this doesn't work due to the rowspan. %>
                 <td class="align-top <%= "border-bottom-0" if fb === @feedbacks.last %>"


### PR DESCRIPTION
This pull request fixes the order of the exercises and score items on the student evaluation overview page.

Closes #3108.
