### PR TITLE
Run CI actions on pull request instead of on push

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,13 @@
 name: Lint
 
-on: [push]
+on:
+  push:
+    branches:
+      - master
+      - develop
+    tags:
+      - '*'
+  pull_request:
 
 jobs:
   ruby:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,13 @@
 name: Test
 
-on: [push]
+on:
+  push:
+    branches:
+      - master
+      - develop
+    tags:
+      - '*'
+  pull_request:
 
 jobs:
   ruby:


### PR DESCRIPTION
This should fix the CI actions not being run for external pull
requests. They are still run on pushes to develop, master and
tags (which should only happen on merges or new releases).

Closes #3190.
