### PR TITLE
Add copy to clipboard button for submission link

### DIFF
--- a/app/views/submissions/_description.html.erb
+++ b/app/views/submissions/_description.html.erb
@@ -30,7 +30,11 @@
   </span>
   <div class="row">
     <div class="col-md-6">
-      <span class='status-icon float-start'><%= submission_status_icon(submission, 36) %></span>
+      <span class='status-icon float-start'>
+        <button class="btn btn-icon" data-clipboard-text="<%= submission.id %>" title="Copy submission link to clipboard.">
+          <%= submission_status_icon(submission, 36) %>
+        </button>
+      </span>
       <span class="status-line">
         <%= Submission.human_enum_name(:status, submission.status) %>
         <% if submission.summary.present? and submission.summary.downcase != Submission.human_enum_name(:status, submission.status).downcase %>

--- a/app/views/submissions/_description.html.erb
+++ b/app/views/submissions/_description.html.erb
@@ -31,7 +31,7 @@
   <div class="row">
     <div class="col-md-6">
       <span class='status-icon float-start'>
-        <button class="btn btn-icon" data-clipboard-text="<%= submission.id %>" title="Copy submission link to clipboard.">
+        <button class="btn btn-icon" data-clipboard-text="<%= submission.id %>" title="<%= t "submissions.show.copy_submission_link" %>">
           <%= submission_status_icon(submission, 36) %>
         </button>
       </span>

--- a/app/views/submissions/_description.html.erb
+++ b/app/views/submissions/_description.html.erb
@@ -31,7 +31,7 @@
   <div class="row">
     <div class="col-md-6">
       <span class='status-icon float-start'>
-        <button class="btn btn-icon" data-clipboard-text="<%= 'https://' + request.domain + submission_path %>" title="<%= t "submissions.show.copy_submission_link" %>">
+        <button class="btn btn-icon" data-clipboard-text="<%= 'https://' + request.domain + submission_path(submission.id) %>" title="<%= t "submissions.show.copy_submission_link" %>">
           <%= submission_status_icon(submission, 36) %>
         </button>
       </span>

--- a/app/views/submissions/_description.html.erb
+++ b/app/views/submissions/_description.html.erb
@@ -31,7 +31,7 @@
   <div class="row">
     <div class="col-md-6">
       <span class='status-icon float-start'>
-        <button class="btn btn-icon" data-clipboard-text="<%= submission.id %>" title="<%= t "submissions.show.copy_submission_link" %>">
+        <button class="btn btn-icon" data-clipboard-text="<%= 'https://' + request.domain + submission_path %>" title="<%= t "submissions.show.copy_submission_link" %>">
           <%= submission_status_icon(submission, 36) %>
         </button>
       </span>

--- a/app/views/submissions/_description.html.erb
+++ b/app/views/submissions/_description.html.erb
@@ -31,7 +31,7 @@
   <div class="row">
     <div class="col-md-6">
       <span class='status-icon float-start'>
-        <button class="btn btn-icon" data-clipboard-text="<%= 'https://' + request.domain.to_s + submission_path(submission.id).to_s %>" title="<%= t "submissions.show.copy_submission_link" %>">
+        <button class="btn btn-icon" data-clipboard-text="<%= submission_url(submission) %>" title="<%= t "submissions.show.copy_submission_link" %>">
           <%= submission_status_icon(submission, 36) %>
         </button>
       </span>

--- a/app/views/submissions/_description.html.erb
+++ b/app/views/submissions/_description.html.erb
@@ -10,6 +10,9 @@
 
 <div class="submission-summary clearfix">
   <span class="description">
+    <button class="btn btn-icon" data-clipboard-text="<%= submission_url(submission) %>" title="<%= t 'submissions.show.copy_submission_link' %>">
+      <i class="mdi mdi-36 mdi-link float-start"></i>
+    </button>
     <%= t "submissions.show.submission_for" %>
     <% if submission.course.nil? %>
       <%= link_to submission.exercise.name, activity_path(submission.exercise) %>
@@ -30,11 +33,7 @@
   </span>
   <div class="row">
     <div class="col-md-6">
-      <span class='status-icon float-start'>
-        <button class="btn btn-icon" data-clipboard-text="<%= submission_url(submission) %>" title="<%= t "submissions.show.copy_submission_link" %>">
-          <%= submission_status_icon(submission, 36) %>
-        </button>
-      </span>
+      <span class='status-icon float-start'><%= submission_status_icon(submission, 36) %></span>
       <span class="status-line">
         <%= Submission.human_enum_name(:status, submission.status) %>
         <% if submission.summary.present? and submission.summary.downcase != Submission.human_enum_name(:status, submission.status).downcase %>

--- a/app/views/submissions/_description.html.erb
+++ b/app/views/submissions/_description.html.erb
@@ -31,7 +31,7 @@
   <div class="row">
     <div class="col-md-6">
       <span class='status-icon float-start'>
-        <button class="btn btn-icon" data-clipboard-text="<%= 'https://' + request.domain + submission_path(submission.id) %>" title="<%= t "submissions.show.copy_submission_link" %>">
+        <button class="btn btn-icon" data-clipboard-text="<%= 'https://' + request.domain.to_s + submission_path(submission.id).to_s %>" title="<%= t "submissions.show.copy_submission_link" %>">
           <%= submission_status_icon(submission, 36) %>
         </button>
       </span>

--- a/config/locales/views/submissions/en.yml
+++ b/config/locales/views/submissions/en.yml
@@ -43,6 +43,7 @@ en:
       in: "in"
       by: "by"
       submission_for: "Submission for"
+      copy_submission_link : "Copy submission link to clipboard."
       output: Output
       correct_tests: Correct tests
       diff:

--- a/config/locales/views/submissions/nl.yml
+++ b/config/locales/views/submissions/nl.yml
@@ -43,6 +43,7 @@ nl:
       in: "in"
       by: "door"
       submission_for: "Oplossing voor"
+      copy_submission_link : "Kopieer indieningslink naar het klembord."
       output: Uitvoer
       correct_tests: Correcte testen
       diff:


### PR DESCRIPTION
Default:
![image](https://user-images.githubusercontent.com/56451049/142828947-927a97c8-2102-4a8a-a01e-9f090b985d5b.png)
On hover:
![image](https://user-images.githubusercontent.com/56451049/142829062-1f2c9eeb-0f11-49f9-94fb-327977b3e0f7.png)

I chose this lay-out because the link refers to the submission and aligns with the other symbol.

- [ ] Documentation update can be found at dodona-edu/dodona-edu.github.io#

Closes #2213.
