### PR TITLE
Catch some bad API usage that should not result in internal error

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,6 +6,8 @@ class ApplicationController < ActionController::Base
   MAX_STORED_URL_LENGTH = 1024
 
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
+  rescue_from ActionDispatch::Http::Parameters::ParseError, with: :bad_request
+  rescue_from ActionController::ParameterMissing, with: :bad_request
 
   protect_from_forgery with: :null_session
 
@@ -118,6 +120,12 @@ class ApplicationController < ActionController::Base
         redirect_to(root_path)
       end
     end
+  end
+
+  def bad_request
+    # rubocop:disable Rails/RenderInline
+    render status: :bad_request, inline: 'Bad request'
+    # rubocop:enable Rails/RenderInline
   end
 
   def set_locale

--- a/test/controllers/submissions_controller_test.rb
+++ b/test/controllers/submissions_controller_test.rb
@@ -135,11 +135,16 @@ class SubmissionsControllerTest < ActionDispatch::IntegrationTest
     assert_response :unprocessable_entity
   end
 
-  test 'create submission should respond bad_request without an exercise' do
+  test 'create submission should respond unprocessable_entity without an exercise' do
     attrs = generate_attr_hash
     attrs.delete(:exercise_id)
     create_request(attr_hash: attrs)
     assert_response :unprocessable_entity
+  end
+
+  test 'create submission should respond bad_request without a hash' do
+    post submissions_url
+    assert_response :bad_request
   end
 
   test 'create submission within course' do


### PR DESCRIPTION
- [x] Tests were added

Could not test the ParseError, since the testing framework refuses to post to bad URIs.
