### PR TITLE
Fix rendering of sets with nested structures in python tutor

### DIFF
--- a/public/tutorviz/javascript/pytutor.js
+++ b/public/tutorviz/javascript/pytutor.js
@@ -3389,7 +3389,7 @@ function(objID, stepNum, d3DomElement, isTopLevel) {
             tbl.append('<tr></tr>');
           }
 
-          var curTr = tbl.find('tr:last');
+          var curTr = tbl.children().last();
           curTr.append('<td class="setElt"></td>');
           myViz.renderNestedObject(val, stepNum, curTr.find('td:last'));
         });


### PR DESCRIPTION
Before:
![screenshot_2021-11-29-140037](https://user-images.githubusercontent.com/42220376/143872639-947f7810-c843-4366-b82c-3a308f5eb270.png)

After:
![screenshot_2021-11-29-140009](https://user-images.githubusercontent.com/42220376/143872684-83cfcc03-db58-4736-a6b1-2092d525d4ec.png)

