### PR TITLE
Update readme to improve setup script for new users

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ If the error "Could not initialize python judge" arises, use `SKIP_PYTHON_JUDGE=
 These steps are not required to run the server, but you need docker to actually evaluate exercises.
 
 1. Install and start `docker`.
-2. run `docker pull dodona/dodona-python`
+2. Run `docker pull dodona/dodona-python`
 
 If you want to build the docker images yourself:
 1. Clone the [docker-images repository](https://github.com/dodona-edu/docker-images).

--- a/README.md
+++ b/README.md
@@ -36,11 +36,6 @@ If you want to help with development, issues tagged with the [student label](htt
     ```
 3. Create a `dodona` user with access to the `dodona` and `dodona_test-N` databases. You will need as much test databases as hou have CPU threads.
     ```sql
-    CREATE DATABASE dodona;
-    CREATE DATABASE dodona_test;
-    CREATE DATABASE `dodona_test-0`;
-    ...
-    CREATE DATABASE `dodona_test-N`;
     CREATE USER 'dodona'@'localhost' IDENTIFIED BY 'dodona';
     GRANT ALL ON dodona.* TO 'dodona'@'localhost';
     GRANT ALL ON dodona_test.* TO 'dodona'@'localhost';
@@ -48,7 +43,7 @@ If you want to help with development, issues tagged with the [student label](htt
     ...
     GRANT ALL ON `dodona_test-N`.* TO 'dodona'@'localhost';
     ```
-4. Install the correct `ruby` version using [RVM](https://rvm.io/) and install `rails`
+4. Install the correct `ruby` version using [RVM](https://rvm.io/)
 5. Install the correct `node` version using `nvm` and [yarn](https://yarnpkg.com/)
 6. Run `bundle install` and `yarn install`
 7. Create and seed the database with `rails db:setup`. (If something goes wrong with the database, you can use `rails db:reset` to drop, rebuild and reseed the database.)

--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ If you want to help with development, issues tagged with the [student label](htt
     ...
     GRANT ALL ON `dodona_test-N`.* TO 'dodona'@'localhost';
     ```
-4. Install correct `ruby` version using [RVM](https://rvm.io/) and install `rails`
-5. install correct `node` version using `nvm` and [yarn](https://yarnpkg.com/)
+4. Install the correct `ruby` version using [RVM](https://rvm.io/) and install `rails`
+5. Install the correct `node` version using `nvm` and [yarn](https://yarnpkg.com/)
 6. Run `bundle install` and `yarn install`
 7. Create and seed the database with `rails db:setup`. (If something goes wrong with the database, you can use `rails db:reset` to drop, rebuild and reseed the database.)
 If the error "Could not initialize python judge" arises, use `SKIP_PYTHON_JUDGE=true rails db:setup`

--- a/README.md
+++ b/README.md
@@ -36,17 +36,25 @@ If you want to help with development, issues tagged with the [student label](htt
     ```
 3. Create a `dodona` user with access to the `dodona` and `dodona_test-N` databases. You will need as much test databases as hou have CPU threads.
     ```sql
-    CREATE USER 'dodona'@'localhost' IDENTIFIED BY 'dodona';
-    GRANT ALL ON dodona.* TO 'dodona';
-    GRANT ALL ON dodona_test.* TO 'dodona';
-    GRANT ALL ON dodona_test-0.* TO 'dodona';
+    CREATE DATABASE dodona;
+    CREATE DATABASE dodona_test;
+    CREATE DATABASE `dodona_test-0`;
     ...
-    GRANT ALL ON dodona_test-3.* TO 'dodona';
+    CREATE DATABASE `dodona_test-N`;
+    CREATE USER 'dodona'@'localhost' IDENTIFIED BY 'dodona';
+    GRANT ALL ON dodona.* TO 'dodona'@'localhost';
+    GRANT ALL ON dodona_test.* TO 'dodona'@'localhost';
+    GRANT ALL ON `dodona_test-0`.* TO 'dodona'@'localhost';
+    ...
+    GRANT ALL ON `dodona_test-N`.* TO 'dodona'@'localhost';
     ```
-4. Create and seed the database with `rails db:setup`. (If something goes wrong with the database, you can use `rails db:reset` to drop, rebuild and reseed the database.)
+4. Install correct `ruby` version using [RVM](https://rvm.io/) and install `rails`
+5. install correct `node` version using `nvm` and [yarn](https://yarnpkg.com/)
+6. Run `bundle install` and `yarn install`
+7. Create and seed the database with `rails db:setup`. (If something goes wrong with the database, you can use `rails db:reset` to drop, rebuild and reseed the database.)
 If the error "Could not initialize python judge" arises, use `SKIP_PYTHON_JUDGE=true rails db:setup`
-5. [Start the server](#starting-the-server). The simplest way is with `rails s`. Dodona [will be available on a subdomain of localhost](#localhost-subdomain): http://dodona.localhost:3000.
-6. Because CAS authentication does not work in development, you can log in by going to these pages (only works with the seed database from step 4)
+8. [Start the server](#starting-the-server). The simplest way is with `rails s`. Dodona [will be available on a subdomain of localhost](#localhost-subdomain): http://dodona.localhost:3000.
+9. Because CAS authentication does not work in development, you can log in by going to these pages (only works with the seed database from step 4)
    - `http://dodona.localhost:3000/nl/users/1/token/zeus`
    - `http://dodona.localhost:3000/nl/users/2/token/staff`
    - `http://dodona.localhost:3000/nl/users/3/token/student`
@@ -55,8 +63,11 @@ If the error "Could not initialize python judge" arises, use `SKIP_PYTHON_JUDGE=
 These steps are not required to run the server, but you need docker to actually evaluate exercises.
 
 1. Install and start `docker`.
-2. Clone the [docker-images repository](https://github.com/dodona-edu/docker-images).
-3. Build a docker image. The `build.sh` scripts builds all images. But with the initial data, only `dodona-python` is needed. You can build this image with `docker build --pull --force-rm -t "dodona-python" -f "dodona-python.dockerfile" .`.
+2. run `docker pull dodona/dodona-python`
+
+If you want to build the docker images yourself:
+1. Clone the [docker-images repository](https://github.com/dodona-edu/docker-images).
+2. Build a docker image. The `build.sh` scripts builds all images. But with the initial data, only `dodona-python` is needed. You can build this image with `docker build --pull --force-rm -t "dodona-python" -f "dodona-python.dockerfile" .`.
 
 #### Loading visualisations locally
 These steps are not required to run the server, but are needed to let the visualisations load.


### PR DESCRIPTION
This pull request edits the readme file.

The changes reflect the information I lacked to setup dodona.

This includes explicitly specifying some basic requirements such as `yarn`, `ruby` and `node`

I also updated the part on `Evaluating exercises locally`