### PR TITLE
Rights request: Show correct error message when motivation is not filled out

### DIFF
--- a/app/views/rights_requests/_form.html.erb
+++ b/app/views/rights_requests/_form.html.erb
@@ -16,7 +16,9 @@
     </div>
 
     <div class="field form-group row">
-      <%= f.label :context, class: 'col-sm-3 col-form-label' %>
+      <div class="col-sm-3 col-form-label">
+        <%= f.label :context %>
+      </div>
       <div class="col-sm-9">
         <%= f.text_area :context, class: 'form-control', placeholder: t(".context_explanation") %>
       </div>

--- a/app/views/rights_requests/new.html.erb
+++ b/app/views/rights_requests/new.html.erb
@@ -3,14 +3,14 @@
     <div class="card">
       <div class="card-title card-title-colored">
         <h2 class="card-title-text"><%= t ".title" %></h2>
-        <% if policy(RightsRequest).create? or current_user&.rights_request.errors.any?%>
+        <% if policy(RightsRequest).create? or @rights_request.errors.any? %>
           <div class="card-title-fab">
             <%= render 'fab_button', form: 'new_rights_request', icon: 'send' %>
           </div>
         <% end %>
       </div>
       <div class="card-supporting-text">
-        <% if policy(RightsRequest).create?  or current_user&.rights_request.errors.any?%>
+        <% if policy(RightsRequest).create?  or @rights_request.errors.any? %>
           <%= render 'form', rights_request: @rights_request %>
         <% else %>
           <div class="callout callout-info"><p>

--- a/app/views/rights_requests/new.html.erb
+++ b/app/views/rights_requests/new.html.erb
@@ -3,14 +3,14 @@
     <div class="card">
       <div class="card-title card-title-colored">
         <h2 class="card-title-text"><%= t ".title" %></h2>
-        <% if policy(RightsRequest).create? %>
+        <% if policy(RightsRequest).create? or current_user&.rights_request.errors.any?%>
           <div class="card-title-fab">
             <%= render 'fab_button', form: 'new_rights_request', icon: 'send' %>
           </div>
         <% end %>
       </div>
       <div class="card-supporting-text">
-        <% if policy(RightsRequest).create? %>
+        <% if policy(RightsRequest).create?  or current_user&.rights_request.errors.any?%>
           <%= render 'form', rights_request: @rights_request %>
         <% else %>
           <div class="callout callout-info"><p>

--- a/app/views/rights_requests/new.html.erb
+++ b/app/views/rights_requests/new.html.erb
@@ -3,14 +3,14 @@
     <div class="card">
       <div class="card-title card-title-colored">
         <h2 class="card-title-text"><%= t ".title" %></h2>
-        <% if policy(RightsRequest).create? or @rights_request.errors.any? %>
+        <% if policy(RightsRequest).create? || @rights_request.errors.any? %>
           <div class="card-title-fab">
             <%= render 'fab_button', form: 'new_rights_request', icon: 'send' %>
           </div>
         <% end %>
       </div>
       <div class="card-supporting-text">
-        <% if policy(RightsRequest).create?  or @rights_request.errors.any? %>
+        <% if policy(RightsRequest).create? || @rights_request.errors.any? %>
           <%= render 'form', rights_request: @rights_request %>
         <% else %>
           <div class="callout callout-info"><p>


### PR DESCRIPTION
This pull request fixes a bug where the user was shown misleading information when he hadn't filled out a motivation message.

Right now the following message is shown:
![image](https://user-images.githubusercontent.com/21177904/148251156-774c405d-4cac-4e36-8323-8af2dcb24c58.png)

The error message saying you already applied still appears when it should:
![image](https://user-images.githubusercontent.com/21177904/148251732-3dbb16e5-453f-49f8-9d58-871274278828.png)

Closes #3124 .
