### PR TITLE
Fix babel 'loose' warning

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -44,7 +44,7 @@ module.exports = function (api) {
       ["@babel/plugin-proposal-class-properties", { loose: true }],
       ["@babel/plugin-proposal-private-methods", { loose: true }],
       ["@babel/plugin-proposal-object-rest-spread", { useBuiltIns: true }],
-      ["@babel/plugin-proposal-private-property-in-object", { "loose": true }],
+      ["@babel/plugin-proposal-private-property-in-object", { loose: true }],
       ["@babel/plugin-transform-runtime", {
         helpers: false,
         regenerator: true,

--- a/babel.config.js
+++ b/babel.config.js
@@ -44,6 +44,7 @@ module.exports = function (api) {
       ["@babel/plugin-proposal-class-properties", { loose: true }],
       ["@babel/plugin-proposal-private-methods", { loose: true }],
       ["@babel/plugin-proposal-object-rest-spread", { useBuiltIns: true }],
+      ["@babel/plugin-proposal-private-property-in-object", { "loose": true }],
       ["@babel/plugin-transform-runtime", {
         helpers: false,
         regenerator: true,


### PR DESCRIPTION
This pull request explicitly adds `@babel/plugin-proposal-private-property-in-object` to `babel.config.js` 
We already used it implicitly.

Adding it explicitly allows us to specify the `loose: true` setting. Again this setting was already used because other `babel` plugins had this setting. 
It solves the warning following warning:
```
Though the "loose" option was set to "false" in your @babel/preset-env config, it will not be used for @babel/plugin-proposal-private-property-in-object since the "loose" mode option was set to "true" for @babel/plugin-proposal-private-methods.
The "loose" option must be the same for @babel/plugin-proposal-class-properties, @babel/plugin-proposal-private-methods and @babel/plugin-proposal-private-property-in-object (when they are enabled): you can silence this warning by explicitly adding
        ["@babel/plugin-proposal-private-property-in-object", { "loose": true }]
to the "plugins" section of your Babel config.
```


Closes #3142 .
