### PR TITLE
Sort copy courses list to show own courses first

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -32,8 +32,9 @@ class CoursesController < ApplicationController
       @courses = @courses.where(featured: true)
     elsif params[:copy_courses]
       @courses = @courses.reorder(featured: :desc, year: :desc, name: :asc)
-      # use index to force stable sorting
-      @courses = @courses.sort_by.with_index { |course, i| [current_user.course_admin?(course) ? 0 : 1, i] }
+      @own_courses = @courses.select { |course| current_user.course_admin?(course) }
+      @other_courses = @courses.reject { |course| current_user.course_admin?(course) }
+      @courses = @own_courses + @other_courses
     end
 
     @courses = apply_scopes(@courses)

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -1,3 +1,5 @@
+require 'will_paginate/array'
+
 class CoursesController < ApplicationController
   include SetLtiMessage
 
@@ -30,6 +32,8 @@ class CoursesController < ApplicationController
       @courses = @courses.where(featured: true)
     elsif params[:copy_courses]
       @courses = @courses.reorder(featured: :desc, year: :desc, name: :asc)
+      # use index to force stable sorting
+      @courses = @courses.sort_by.with_index { |course, i| [current_user.course_admin?(course) ? 0 : 1, i] }
     end
 
     @courses = apply_scopes(@courses)

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -1,5 +1,3 @@
-require 'will_paginate/array'
-
 class CoursesController < ApplicationController
   include SetLtiMessage
 
@@ -34,7 +32,7 @@ class CoursesController < ApplicationController
       @courses = @courses.reorder(featured: :desc, year: :desc, name: :asc)
       @own_courses = @courses.select { |course| current_user.course_admin?(course) }
       @other_courses = @courses.reject { |course| current_user.course_admin?(course) }
-      @courses = @own_courses + @other_courses
+      @courses = @own_courses.concat(@other_courses)
     end
 
     @courses = apply_scopes(@courses)

--- a/app/views/courses/_copy_courses_table.html.erb
+++ b/app/views/courses/_copy_courses_table.html.erb
@@ -16,6 +16,9 @@
         </td>
         <td>
           <span>
+            <% if current_user&.admin_of?(course) %>
+              <span title='<%= t "pages.course_card.course-admin" %>'><i class='mdi mdi-18 mdi-school'></i></span>
+            <% end %>
             <% if course.featured %>
               <span title='<%= Course.human_attribute_name("featured") %>'><i class='mdi mdi-18 mdi-star-outline'></i></span>
             <% end %>


### PR DESCRIPTION
This pull request changes the order a user sees the course list when he wants to copy a course. Now their own courses are displayed first. Original order is kept as secondary ordering.

![image](https://user-images.githubusercontent.com/21177904/148767597-e361e178-b539-4283-b9f4-c2c86312ca7f.png)

Closes #1661.
Closes #3049.
