### PR TITLE
Mark score item as busy before delay, to let page wait until delay finish

### DIFF
--- a/app/assets/javascripts/feedback/score.ts
+++ b/app/assets/javascripts/feedback/score.ts
@@ -15,9 +15,9 @@ export default class ScoreForm {
     private readonly input: HTMLInputElement;
     private readonly expectedScore: HTMLInputElement;
     private readonly spinner: HTMLElement;
-    private readonly deleteButton: HTMLElement;
-    private readonly zeroButton: HTMLElement;
-    private readonly maxButton: HTMLElement;
+    private readonly deleteButton: HTMLButtonElement;
+    private readonly zeroButton: HTMLButtonElement;
+    private readonly maxButton: HTMLButtonElement;
     private readonly maxText: HTMLElement;
     private readonly form: HTMLFormElement;
 
@@ -69,7 +69,7 @@ export default class ScoreForm {
             // If we don't do this, we need a difficult balance between waiting
             // long enough so the delay is useful when using the increment/decrement buttons
             // and the case where we type the value and don't want to wait.
-            this.visualiseUpdating();
+            this.markBusy();
             delay(() => {
                 if (valueOnFocus === (ev.target as HTMLInputElement).value) {
                     return;
@@ -204,18 +204,21 @@ export default class ScoreForm {
     }
 
     private visualiseUpdating(): void {
-        this.parent.registerUpdating(this.scoreItemId);
         this.input.classList.add("in-progress");
         this.maxText.classList.add("in-progress");
         this.spinner.style.visibility = "visible";
     }
 
     public markBusy(): void {
+        this.parent.registerUpdating(this.scoreItemId);
         this.disableInputs();
         this.visualiseUpdating();
     }
 
     public disableInputs(): void {
         this.input.disabled = true;
+        this.deleteButton.disabled = true;
+        this.zeroButton.disabled = true;
+        this.maxButton.disabled = true;
     }
 }

--- a/app/assets/javascripts/feedback/score.ts
+++ b/app/assets/javascripts/feedback/score.ts
@@ -70,7 +70,6 @@ export default class ScoreForm {
             // long enough so the delay is useful when using the increment/decrement buttons
             // and the case where we type the value and don't want to wait.
             this.visualiseUpdating();
-            this.markBusy();
             delay(() => {
                 if (valueOnFocus === (ev.target as HTMLInputElement).value) {
                     return;
@@ -205,13 +204,13 @@ export default class ScoreForm {
     }
 
     private visualiseUpdating(): void {
+        this.parent.registerUpdating(this.scoreItemId);
         this.input.classList.add("in-progress");
         this.maxText.classList.add("in-progress");
         this.spinner.style.visibility = "visible";
     }
 
     public markBusy(): void {
-        this.parent.registerUpdating(this.scoreItemId);
         this.disableInputs();
         this.visualiseUpdating();
     }

--- a/app/assets/javascripts/feedback/score.ts
+++ b/app/assets/javascripts/feedback/score.ts
@@ -70,6 +70,7 @@ export default class ScoreForm {
             // long enough so the delay is useful when using the increment/decrement buttons
             // and the case where we type the value and don't want to wait.
             this.visualiseUpdating();
+            this.markBusy();
             delay(() => {
                 if (valueOnFocus === (ev.target as HTMLInputElement).value) {
                     return;

--- a/app/assets/javascripts/feedback/score.ts
+++ b/app/assets/javascripts/feedback/score.ts
@@ -69,7 +69,7 @@ export default class ScoreForm {
             // If we don't do this, we need a difficult balance between waiting
             // long enough so the delay is useful when using the increment/decrement buttons
             // and the case where we type the value and don't want to wait.
-            this.markBusy();
+            this.visualiseUpdating();
             delay(() => {
                 if (valueOnFocus === (ev.target as HTMLInputElement).value) {
                     return;
@@ -204,13 +204,13 @@ export default class ScoreForm {
     }
 
     private visualiseUpdating(): void {
+        this.parent.registerUpdating(this.scoreItemId);
         this.input.classList.add("in-progress");
         this.maxText.classList.add("in-progress");
         this.spinner.style.visibility = "visible";
     }
 
     public markBusy(): void {
-        this.parent.registerUpdating(this.scoreItemId);
         this.disableInputs();
         this.visualiseUpdating();
     }


### PR DESCRIPTION
This pull request fixes the issue that a user can go to the next exercise before the scores are saved.

I also disabled the max, zero and remove buttons when the input field is already updating. This helps to prohibit concurrent updates.

Closes #3212.
