### PR TITLE
Add visual confirmation that a score has been saved when grading

### DIFF
--- a/app/assets/javascripts/feedback/score.ts
+++ b/app/assets/javascripts/feedback/score.ts
@@ -63,6 +63,7 @@ export default class ScoreForm {
         this.input.addEventListener("change", ev => {
             // If the score is not valid, don't do anything.
             if (!this.input.reportValidity()) {
+                this.input.classList.add("is-invalid");
                 return;
             }
             // Mark as busy to show we are aware an update should happen.

--- a/app/assets/javascripts/feedback/score.ts
+++ b/app/assets/javascripts/feedback/score.ts
@@ -14,7 +14,7 @@ import FeedbackActions from "feedback/actions";
 export default class ScoreForm {
     private readonly input: HTMLInputElement;
     private readonly expectedScore: HTMLInputElement;
-    private readonly spinner: HTMLElement;
+    private readonly scoreState: HTMLElement;
     private readonly deleteButton: HTMLElement;
     private readonly zeroButton: HTMLElement;
     private readonly maxButton: HTMLElement;
@@ -32,7 +32,7 @@ export default class ScoreForm {
 
         this.form = element.querySelector(".score-form") as HTMLFormElement;
         this.input = this.form.querySelector("input.score-input");
-        this.spinner = this.form.querySelector(".dodona-progress");
+        this.scoreState= this.form.querySelector(".score-state");
         this.expectedScore = this.form.querySelector(".score-form input.expected-score");
         this.deleteButton = this.form.parentElement.querySelector(".delete-button");
         this.zeroButton = this.form.parentElement.querySelector(".single-zero-button");
@@ -61,9 +61,13 @@ export default class ScoreForm {
         });
         const delay = createDelayer();
         this.input.addEventListener("change", ev => {
-            // If the score is not valid, don't do anything.
+            // If the score is not valid, show warning.
             if (!this.input.reportValidity()) {
-                this.input.classList.add("is-invalid");
+                this.scoreState.innerHTML =
+                    "<i " +
+                        "class=\"mdi mdi-alert-circle-outline mdi-18 colored-wrong\" " +
+                        "aria-hidden='true'" +
+                    "></i>";
                 return;
             }
             // Mark as busy to show we are aware an update should happen.
@@ -207,7 +211,11 @@ export default class ScoreForm {
     private visualiseUpdating(): void {
         this.input.classList.add("in-progress");
         this.maxText.classList.add("in-progress");
-        this.spinner.style.visibility = "visible";
+        this.scoreState.innerHTML =
+            "<span " +
+                "class=\"spinner-border spinner-border-sm colored-warning\" " +
+                "aria-hidden=\"true\"" +
+            "></span>";
     }
 
     public markBusy(): void {

--- a/app/assets/javascripts/feedback/score.ts
+++ b/app/assets/javascripts/feedback/score.ts
@@ -63,11 +63,10 @@ export default class ScoreForm {
         this.input.addEventListener("change", ev => {
             // If the score is not valid, show warning.
             if (!this.input.reportValidity()) {
-                this.scoreState.innerHTML =
-                    "<i " +
-                        "class=\"mdi mdi-alert-circle-outline mdi-18 colored-wrong\" " +
-                        "aria-hidden='true'" +
-                    "></i>";
+                const icon = document.createElement("i");
+                icon.classList.add("mdi", "mdi-alert-circle-outline", "mdi-18", "colored-wrong");
+                icon.setAttribute("aria-hidden", "true");
+                this.scoreState.replaceChildren(icon);
                 return;
             }
             // Mark as busy to show we are aware an update should happen.
@@ -211,11 +210,11 @@ export default class ScoreForm {
     private visualiseUpdating(): void {
         this.input.classList.add("in-progress");
         this.maxText.classList.add("in-progress");
-        this.scoreState.innerHTML =
-            "<span " +
-                "class=\"spinner-border spinner-border-sm colored-warning\" " +
-                "aria-hidden=\"true\"" +
-            "></span>";
+
+        const span = document.createElement("span");
+        span.classList.add("spinner-border", "spinner-border-sm", "colored-warning");
+        span.setAttribute("aria-hidden", "true");
+        this.scoreState.replaceChildren(span);
     }
 
     public markBusy(): void {

--- a/app/assets/javascripts/feedback/score.ts
+++ b/app/assets/javascripts/feedback/score.ts
@@ -32,7 +32,7 @@ export default class ScoreForm {
 
         this.form = element.querySelector(".score-form") as HTMLFormElement;
         this.input = this.form.querySelector("input.score-input");
-        this.scoreState= this.form.querySelector(".score-state");
+        this.scoreState = this.form.querySelector(".score-state");
         this.expectedScore = this.form.querySelector(".score-form input.expected-score");
         this.deleteButton = this.form.parentElement.querySelector(".delete-button");
         this.zeroButton = this.form.parentElement.querySelector(".single-zero-button");

--- a/app/assets/stylesheets/base.css.scss
+++ b/app/assets/stylesheets/base.css.scss
@@ -52,7 +52,7 @@
 @import "../../../node_modules/bootstrap/scss/tooltip";
 @import "../../../node_modules/bootstrap/scss/popover";
 //@import "../../../node_modules/bootstrap/scss/carousel";
-//@import "../../../node_modules/bootstrap/scss/spinners";
+@import "../../../node_modules/bootstrap/scss/spinners";
 //@import "../../../node_modules/bootstrap/scss/offcanvas";
 @import "../../../node_modules/bootstrap/scss/helpers";
 @import "../../../node_modules/bootstrap/scss/utilities/api";

--- a/app/assets/stylesheets/components/evaluations.css.scss
+++ b/app/assets/stylesheets/components/evaluations.css.scss
@@ -85,6 +85,10 @@
         border-bottom-right-radius: 0;
       }
 
+      .score-input{
+        border-color: $border-color;
+      }
+
       .dodona-progress .bar {
         border-bottom-left-radius: 6px;
         border-bottom-right-radius: 6px;

--- a/app/assets/stylesheets/components/evaluations.css.scss
+++ b/app/assets/stylesheets/components/evaluations.css.scss
@@ -85,7 +85,7 @@
         border-bottom-right-radius: 0;
       }
 
-      .score-input{
+      .score-input.is-valid, .score-input.is-invalid{
         border-color: $border-color;
       }
 

--- a/app/assets/stylesheets/components/evaluations.css.scss
+++ b/app/assets/stylesheets/components/evaluations.css.scss
@@ -75,7 +75,7 @@
         color: $text-color;
         text-align: center;
         background-color: $input-group-addon-bg;
-        border: 1px solid $input-group-addon-border-color;
+        border: 1px solid $border-color;
         opacity: 1;
         cursor: auto;
       }
@@ -85,8 +85,17 @@
         border-bottom-right-radius: 0;
       }
 
-      .score-input.is-valid, .score-input.is-invalid{
+      .score-input{
+        border-right: none;
         border-color: $border-color;
+        margin-right: -28px;
+        padding-right: 28px;
+      }
+      .score-state{
+        border-left: none;
+        width: 28px;
+        background-color: $input-bg;
+        padding: 0;
       }
 
       .dodona-progress .bar {

--- a/app/views/feedbacks/_score_actions.html.erb
+++ b/app/views/feedbacks/_score_actions.html.erb
@@ -11,7 +11,7 @@
             <i class="mdi mdi-delete-outline mdi-12" aria-hidden='true'></i>
           <% end %>
           <%= f.number_field :score,
-                             class: "form-control score-input ",
+                             class: "form-control score-input",
                              step: 0.25,
                              tabindex: index + 1,
                              min: 0,

--- a/app/views/feedbacks/_score_actions.html.erb
+++ b/app/views/feedbacks/_score_actions.html.erb
@@ -4,19 +4,23 @@
                namespace: score_item.id,
                html: { class: "form-inline score-form col-12", data: { url: url, new: score.persisted? } } do |f| %>
     <%= f.hidden_field :expected_score, value: score.score, class: "expected-score" %>
-    <div class="form-group input <%= 'has-warning' if @warning.present? && @warning == score&.id&.to_s %>">
+    <div class="form-group input <%= 'has-warning' if @warning.present? && @warning == score&.id&.to_s %> has-feedback">
       <div class="control-wrapper">
         <div class="input-group">
           <%= button_tag class: "btn btn-secondary btn-sm delete-button", type: :button, disabled: !@score_map.key?(score_item.id) do %>
             <i class="mdi mdi-delete-outline mdi-12" aria-hidden='true'></i>
           <% end %>
           <%= f.number_field :score,
-                             class: "form-control score-input",
+                             class: "form-control score-input " + (score.score.nil? ? ' is-invalid' : ' is-valid') ,
                              step: 0.25,
                              tabindex: index + 1,
                              min: 0,
                              max: score_item.maximum,
-                             value: format_score(f.object.score, lang='en', numeric_only=true) %>
+                             value: format_score(f.object.score, lang='en', numeric_only=true) do %>
+          <%end %>
+          <%#= button_tag class: "btn btn-secondary", type: :button, disabled: true do %>
+<!--            <i class="mdi mdi-circle-small mdi-12 valid <%#= score.score.nil? ? ' colored-secondary' : ' colored-info' %>"  aria-hidden='true'></i>-->
+          <%# end %>
           <%= button_tag class: "btn btn-secondary max-text", disabled: true, type: :button, data: { max: format_score(score_item.maximum, lang='en', numeric_only=true) } do %>
             / <%= format_score(score_item.maximum) %>
           <% end %>

--- a/app/views/feedbacks/_score_actions.html.erb
+++ b/app/views/feedbacks/_score_actions.html.erb
@@ -16,8 +16,7 @@
                              tabindex: index + 1,
                              min: 0,
                              max: score_item.maximum,
-                             value: format_score(f.object.score, lang='en', numeric_only=true) do %>
-          <%end %>
+                             value: format_score(f.object.score, lang='en', numeric_only=true) %>
           <%= button_tag class: "btn btn-secondary max-text", disabled: true, type: :button, data: { max: format_score(score_item.maximum, lang='en', numeric_only=true) } do %>
             / <%= format_score(score_item.maximum) %>
           <% end %>

--- a/app/views/feedbacks/_score_actions.html.erb
+++ b/app/views/feedbacks/_score_actions.html.erb
@@ -11,16 +11,13 @@
             <i class="mdi mdi-delete-outline mdi-12" aria-hidden='true'></i>
           <% end %>
           <%= f.number_field :score,
-                             class: "form-control score-input " + (score.score.nil? ? ' is-invalid' : ' is-valid') ,
+                             class: "form-control score-input " + (score.score.nil? ? '' : ' is-valid') ,
                              step: 0.25,
                              tabindex: index + 1,
                              min: 0,
                              max: score_item.maximum,
                              value: format_score(f.object.score, lang='en', numeric_only=true) do %>
           <%end %>
-          <%#= button_tag class: "btn btn-secondary", type: :button, disabled: true do %>
-<!--            <i class="mdi mdi-circle-small mdi-12 valid <%#= score.score.nil? ? ' colored-secondary' : ' colored-info' %>"  aria-hidden='true'></i>-->
-          <%# end %>
           <%= button_tag class: "btn btn-secondary max-text", disabled: true, type: :button, data: { max: format_score(score_item.maximum, lang='en', numeric_only=true) } do %>
             / <%= format_score(score_item.maximum) %>
           <% end %>

--- a/app/views/feedbacks/_score_actions.html.erb
+++ b/app/views/feedbacks/_score_actions.html.erb
@@ -11,12 +11,18 @@
             <i class="mdi mdi-delete-outline mdi-12" aria-hidden='true'></i>
           <% end %>
           <%= f.number_field :score,
-                             class: "form-control score-input " + (score.score.nil? ? '' : ' is-valid') ,
+                             class: "form-control score-input ",
                              step: 0.25,
                              tabindex: index + 1,
                              min: 0,
                              max: score_item.maximum,
                              value: format_score(f.object.score, lang='en', numeric_only=true) %>
+
+          <%= button_tag class: "btn btn-secondary score-state", disabled: true, type: :button do %>
+            <% unless score.score.nil? %>
+              <i class="mdi mdi-check mdi-18 colored-info" aria-hidden='true'></i>
+            <% end %>
+          <% end %>
           <%= button_tag class: "btn btn-secondary max-text", disabled: true, type: :button, data: { max: format_score(score_item.maximum, lang='en', numeric_only=true) } do %>
             / <%= format_score(score_item.maximum) %>
           <% end %>
@@ -26,11 +32,6 @@
           <%= button_tag class: "btn btn-secondary btn-sm single-max-button", type: :button, title: t('.give_max_one', score: format_score(score_item.maximum)) do %>
             <i class="mdi mdi-thumb-up-outline mdi-12" aria-hidden='true'></i>
           <% end %>
-        </div>
-        <div class="dodona-progress dodona-progress-indeterminate">
-          <div class="progressbar bar bar1" style="width: 0;"></div>
-          <div class="bufferbar bar bar2" style="width: 100%;"></div>
-          <div class="auxbar bar bar3" style="width: 0;"></div>
         </div>
       </div>
     </div>

--- a/app/views/feedbacks/_score_actions.html.erb
+++ b/app/views/feedbacks/_score_actions.html.erb
@@ -4,7 +4,7 @@
                namespace: score_item.id,
                html: { class: "form-inline score-form col-12", data: { url: url, new: score.persisted? } } do |f| %>
     <%= f.hidden_field :expected_score, value: score.score, class: "expected-score" %>
-    <div class="form-group input <%= 'has-warning' if @warning.present? && @warning == score&.id&.to_s %> has-feedback">
+    <div class="form-group input <%= 'has-warning' if @warning.present? && @warning == score&.id&.to_s %>">
       <div class="control-wrapper">
         <div class="input-group">
           <%= button_tag class: "btn btn-secondary btn-sm delete-button", type: :button, disabled: !@score_map.key?(score_item.id) do %>


### PR DESCRIPTION
This pull request adds visual confirmation if a score has been saved succesfully.

![Peek 2022-01-12 11-57](https://user-images.githubusercontent.com/21177904/149127825-b029adf7-d6c8-421b-b10f-affd2181699f.gif)
![Peek 2022-01-12 11-58](https://user-images.githubusercontent.com/21177904/149127830-533878b6-0344-415b-ad21-a4f7bd4ed4c9.gif)


Closes #2822 .
