### PR TITLE
Fix the amount of pixels of total score input on the grading page

### DIFF
--- a/app/assets/stylesheets/components/evaluations.css.scss
+++ b/app/assets/stylesheets/components/evaluations.css.scss
@@ -85,9 +85,13 @@
         border-bottom-right-radius: 0;
       }
 
+      .form-control{
+        border-color: $border-color;
+        line-height: initial;
+      }
+
       .score-input{
         border-right: none;
-        border-color: $border-color;
         margin-right: -28px;
         padding-right: 28px;
       }


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/21177904/149336010-3bc06089-ece3-449b-8e4b-bd5c8e033105.png)

After:
![image](https://user-images.githubusercontent.com/21177904/149336039-f110b678-1807-4c3a-b814-1b890ae26e03.png)


Issue only happened on specific zoom levels because the input field had height `33.33px` while the surrounding button-tags had height `33px`  