### PR TITLE
Fix image captions for exercises

### DIFF
--- a/app/assets/javascripts/exercise.js
+++ b/app/assets/javascripts/exercise.js
@@ -98,6 +98,7 @@ function initLightboxes() {
             content: {
                 elements: images,
                 startAt: index,
+                moreLength: 0,
             }
         });
         return false;

--- a/app/assets/javascripts/exercise.js
+++ b/app/assets/javascripts/exercise.js
@@ -58,7 +58,7 @@ function initLabelsEdit(labels, undeletableLabels) {
 
 function showLightbox(content) {
     const lightbox = new GLightbox(content);
-    lightbox.on("open", () => {
+    lightbox.on("slide_changed", () => {
         // There might have been math in the image captions, so ask
         // MathJax to search for new math (but only in the captions).
         window.MathJax.typeset([".gslide-description"]);


### PR DESCRIPTION
This pull request fixes MathJax compilation for descriptions further in the slideshow, which closes #3271 

It also removes the 'see more' text for long descriptions on mobile, in stead always showing the full description. which closes #3231 

https://github.com/dodona-edu/dodona/issues/3231#issuecomment-1008364358 was not solved, as I could not easily reproduce it. If the problem persists it should probably be made into its own issue.
