### PR TITLE
add line blur on hover

### DIFF
--- a/app/assets/javascripts/visualisations/cumulative_timeseries.ts
+++ b/app/assets/javascripts/visualisations/cumulative_timeseries.ts
@@ -171,8 +171,7 @@ export class CTimeseriesGraph extends SeriesGraph {
                 .x(d => this.x(d.x1))
                 .y(d => this.y(d.cSum / this.studentCount))
                 .curve(d3.curveMonotoneX)(ex.ex_data)
-            )
-            .attr("data-index", ex => ex.ex_id);
+            );
     }
 
     /**
@@ -392,12 +391,11 @@ export class CTimeseriesGraph extends SeriesGraph {
             .data(this.exOrder)
             .enter()
             .append("div")
-            .attr("data-index", exId => exId)
             .attr("class", "legend-item")
-            .on("mouseover", e => {
-                const lines = this.graph
-                    .selectAll(`.line:not([data-index='${e.target.dataset.index}'])`);
-                lines.style("opacity", 0.2);
+            .on("mouseover", (_, legendId) => {
+                this.graph
+                    .selectAll(".line")
+                    .style("opacity", lineEx => legendId !== lineEx.ex_id ? .2 : 1);
             })
             .on("mouseout", () => {
                 this.graph

--- a/app/assets/javascripts/visualisations/cumulative_timeseries.ts
+++ b/app/assets/javascripts/visualisations/cumulative_timeseries.ts
@@ -171,7 +171,8 @@ export class CTimeseriesGraph extends SeriesGraph {
                 .x(d => this.x(d.x1))
                 .y(d => this.y(d.cSum / this.studentCount))
                 .curve(d3.curveMonotoneX)(ex.ex_data)
-            );
+            )
+            .attr("data-index", ex => ex.ex_id);
     }
 
     /**
@@ -391,16 +392,29 @@ export class CTimeseriesGraph extends SeriesGraph {
             .data(this.exOrder)
             .enter()
             .append("div")
-            .attr("class", "legend-item");
+            .attr("data-index", exId => exId)
+            .attr("class", "legend-item")
+            .on("mouseover", e => {
+                const lines = this.graph
+                    .selectAll(`.line:not([data-index='${e.target.dataset.index}'])`);
+                lines.style("opacity", 0.2);
+            })
+            .on("mouseout", () => {
+                this.graph
+                    .selectAll(".line")
+                    .style("opacity", 1);
+            });
         legend
             .append("div")
             .attr("class", "legend-box")
-            .style("background", exId => this.color(exId));
+            .style("background", exId => this.color(exId))
+            .style("pointer-events", "none");
         legend
             .append("span")
             .attr("class", "legend-text")
             .text(exId => this.exMap[exId])
             .style("color", "currentColor")
-            .style("font-size", `${this.fontSize}px`);
+            .style("font-size", `${this.fontSize}px`)
+            .style("pointer-events", "none");
     }
 }


### PR DESCRIPTION
When hovering over a legend item, every line except the one corresponding to the item will be blurred.
This should greatly assist in identifying the correct line for each exercise.


![Peek 2022-01-16 01-26](https://user-images.githubusercontent.com/32074366/149642530-583bc40c-7072-4aa4-ba0b-a0d6bf9eb7f2.gif)



