### PR TITLE
Give same height to all elements in status table

### DIFF
--- a/app/assets/stylesheets/components/table.css.scss
+++ b/app/assets/stylesheets/components/table.css.scss
@@ -34,7 +34,7 @@
       height: auto;
       top: auto;
     }
-    .user-name:not(.sticky-column) {
+    td:not(.sticky-column) {
       height: 42px;
     }
     thead .user-name {
@@ -112,6 +112,6 @@ tr.gu-mirror {
   }
 }
 
-#scoresheet-table-wrapper .user-name {
-  height: 35px;
+#scoresheet-table-wrapper td {
+  height: 37px;
 }


### PR DESCRIPTION
This pull request makes sure the first column (user name) always has the same height as the other columns.

Before:
![image](https://user-images.githubusercontent.com/21177904/149786325-7222e52b-734b-42b5-b102-e62665817d0b.png)
![image](https://user-images.githubusercontent.com/21177904/149786343-788ffdf9-e787-4e0f-aee8-523682c45c11.png)

After:
![image](https://user-images.githubusercontent.com/21177904/149786381-bf5479dc-2f38-4d10-a55c-c65d76beb56c.png)
![image](https://user-images.githubusercontent.com/21177904/149786395-7ba2631b-ec2a-4132-ac9b-1167378d9e3e.png)


Closes #3109  .
