### PR TITLE
Move minitest from development to test gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -143,9 +143,6 @@ group :development, :test do
   # test template rendering
   gem 'rails-controller-testing', '~> 1.0.5'
 
-  # I18N default locale & better test reporter
-  gem 'minitest-utils', '~> 0.4.6'
-
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', '~> 11.1.3', platforms: %i[mri mingw x64_mingw]
 
@@ -163,6 +160,9 @@ group :test do
 
   # Mocking HTTP requests to third parties.
   gem 'webmock'
+
+  # I18N default locale & better test reporter
+  gem 'minitest-utils', '~> 0.4.6'
 end
 
 group :development do


### PR DESCRIPTION
This pull request moves minitest to the test group in the gemfile. This solves the webmock issue as mintest loads webmock as one of its dependencies. 

I have not found any reason why minitest is needed in development as this is clearly a testing library. @bmesuere or @chvp can you confirm or deny this?

Closes #3167 .
