### PR TITLE
Automate annotations 

### DIFF
--- a/app/models/institution.rb
+++ b/app/models/institution.rb
@@ -9,7 +9,7 @@
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
 #  generated_name :boolean          default(TRUE), not null
-#  category       :integer          default("secondary")
+#  category       :integer          default("secondary"), not null
 #
 
 class Institution < ApplicationRecord

--- a/lib/tasks/auto_annotate_models.rake
+++ b/lib/tasks/auto_annotate_models.rake
@@ -1,0 +1,59 @@
+# NOTE: only doing this in development as some production environments (Heroku)
+# NOTE: are sensitive to local FS writes, and besides -- it's just not proper
+# NOTE: to have a dev-mode tool do its thing in production.
+if Rails.env.development?
+  require 'annotate'
+  task :set_annotation_options do
+    # You can override any of these by setting an environment variable of the
+    # same name.
+    Annotate.set_defaults(
+      'active_admin'                => 'false',
+      'additional_file_patterns'    => [],
+      'routes'                      => 'false',
+      'models'                      => 'true',
+      'position_in_routes'          => 'before',
+      'position_in_class'           => 'before',
+      'position_in_test'            => 'before',
+      'position_in_fixture'         => 'before',
+      'position_in_factory'         => 'before',
+      'position_in_serializer'      => 'before',
+      'show_foreign_keys'           => 'false',
+      'show_complete_foreign_keys'  => 'false',
+      'show_indexes'                => 'false',
+      'simple_indexes'              => 'false',
+      'model_dir'                   => 'app/models',
+      'root_dir'                    => '',
+      'include_version'             => 'false',
+      'require'                     => '',
+      'exclude_tests'               => 'false',
+      'exclude_fixtures'            => 'false',
+      'exclude_factories'           => 'false',
+      'exclude_serializers'         => 'false',
+      'exclude_scaffolds'           => 'true',
+      'exclude_controllers'         => 'true',
+      'exclude_helpers'             => 'true',
+      'exclude_sti_subclasses'      => 'false',
+      'ignore_model_sub_dir'        => 'false',
+      'ignore_columns'              => nil,
+      'ignore_routes'               => nil,
+      'ignore_unknown_models'       => 'false',
+      'hide_limit_column_types'     => 'integer,bigint,boolean',
+      'hide_default_column_types'   => 'json,jsonb,hstore',
+      'skip_on_db_migrate'          => 'false',
+      'format_bare'                 => 'true',
+      'format_rdoc'                 => 'false',
+      'format_yard'                 => 'false',
+      'format_markdown'             => 'false',
+      'sort'                        => 'false',
+      'force'                       => 'false',
+      'frozen'                      => 'false',
+      'classified_sort'             => 'false',
+      'trace'                       => 'false',
+      'wrapper_open'                => nil,
+      'wrapper_close'               => nil,
+      'with_comment'                => 'false'
+    )
+  end
+
+  Annotate.load_tasks
+end

--- a/test/factories/institutions.rb
+++ b/test/factories/institutions.rb
@@ -9,7 +9,7 @@
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
 #  generated_name :boolean          default(TRUE), not null
-#  category       :integer          default("secondary")
+#  category       :integer          default("secondary"), not null
 #
 
 FactoryBot.define do

--- a/test/fixtures/institutions.yml
+++ b/test/fixtures/institutions.yml
@@ -9,7 +9,7 @@
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
 #  generated_name :boolean          default(TRUE), not null
-#  category       :integer          default("secondary")
+#  category       :integer          default("secondary"), not null
 #
 
 ugent:

--- a/test/models/institution_test.rb
+++ b/test/models/institution_test.rb
@@ -9,7 +9,7 @@
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
 #  generated_name :boolean          default(TRUE), not null
-#  category       :integer          default("secondary")
+#  category       :integer          default("secondary"), not null
 #
 
 require 'test_helper'


### PR DESCRIPTION
This pull request automates the annotations that are on top of relevant ruby files.

It is no longer required to run `bundle exec annotate --models` after database changes. The annotations will automatically be adjusted after each run of `rails db:migrate`.

The config can be updated if more/other information is required in the annotations in the future.
