### PR TITLE
Fix pagination of the copy course list

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -1,3 +1,5 @@
+require 'will_paginate/array'
+
 class CoursesController < ApplicationController
   include SetLtiMessage
 


### PR DESCRIPTION
This pull request fixes the copy courses pagination. 

The issue was created in #3277 where the introduced `@courses.select` and `@courses.reject` statements return an array instead of an `ActiveRecordRelation`. 


