### PR TITLE
Store last seen and last sign in in the database

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -27,6 +27,8 @@ class ApplicationController < ActionController::Base
 
   around_action :user_time_zone, if: :current_user
 
+  after_action :set_user_seen_at, if: :current_user
+
   before_action :set_time_zone_offset
 
   before_action :set_notifications, if: :user_signed_in?
@@ -59,6 +61,7 @@ class ApplicationController < ActionController::Base
       raise "User with id #{user.id} should not have a blank email " \
             'if the provider is not LTI, OIDC or Smartschool'
     end
+    user.touch(:sign_in_at)
   end
 
   Warden::Manager.after_set_user do |user, _auth, _opts|
@@ -194,5 +197,9 @@ class ApplicationController < ActionController::Base
     # This variable counts for which services the dot in the favicon should be shown.
     # On most pages this will be empty or contain :notifications
     @dot_icon = @unread_notifications.any? ? %i[notifications] : []
+  end
+
+  def set_user_seen_at
+    current_user.touch(:seen_at)
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -27,7 +27,7 @@ class ApplicationController < ActionController::Base
 
   around_action :user_time_zone, if: :current_user
 
-  after_action :set_user_seen_at, if: :current_user
+  after_action :set_user_seen_at, if: -> { current_user && !js_request? }
 
   before_action :set_time_zone_offset
 
@@ -80,6 +80,10 @@ class ApplicationController < ActionController::Base
 
   def remote_request?
     request.format.js? || request.format.json?
+  end
+
+  def js_request?
+    request.format.js?
   end
 
   def parse_pagination_param(page)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -95,7 +95,10 @@ class UsersController < ApplicationController
 
   def token_sign_in
     token = params[:token]
-    sign_in(@user) if token.present? && token == @user.token
+    if token.present? && token == @user.token
+      sign_in(@user)
+      @user.touch(:sign_in_at)
+    end
     redirect_to root_path
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,6 +15,8 @@
 #  time_zone      :string(255)      default("Brussels")
 #  institution_id :bigint
 #  search         :string(4096)
+#  seen_at        :datetime
+#  sign_in_at     :datetime
 #
 
 require 'securerandom'

--- a/db/migrate/20220124145914_add_seen_at_to_users.rb
+++ b/db/migrate/20220124145914_add_seen_at_to_users.rb
@@ -1,0 +1,5 @@
+class AddSeenAtToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :seen_at, :datetime
+  end
+end

--- a/db/migrate/20220124145930_add_sign_in_at_to_users.rb
+++ b/db/migrate/20220124145930_add_sign_in_at_to_users.rb
@@ -1,0 +1,5 @@
+class AddSignInAtToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :sign_in_at, :datetime
+  end
+end

--- a/db/migrate/20220125082726_add_index_to_users.rb
+++ b/db/migrate/20220125082726_add_index_to_users.rb
@@ -1,0 +1,5 @@
+class AddIndexToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_index :users, :seen_at
+  end
+end

--- a/db/migrate/20220125082726_add_index_to_users.rb
+++ b/db/migrate/20220125082726_add_index_to_users.rb
@@ -1,5 +1,0 @@
-class AddIndexToUsers < ActiveRecord::Migration[6.1]
-  def change
-    add_index :users, :seen_at
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_24_145930) do
+ActiveRecord::Schema.define(version: 2022_01_25_082726) do
 
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
@@ -473,6 +473,7 @@ ActiveRecord::Schema.define(version: 2022_01_24_145930) do
     t.datetime "sign_in_at"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["institution_id"], name: "index_users_on_institution_id"
+    t.index ["seen_at"], name: "index_users_on_seen_at"
     t.index ["token"], name: "index_users_on_token"
     t.index ["username", "institution_id"], name: "index_users_on_username_and_institution_id", unique: true
     t.index ["username"], name: "index_users_on_username"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_20_102810) do
+ActiveRecord::Schema.define(version: 2022_01_24_145930) do
 
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
@@ -469,6 +469,8 @@ ActiveRecord::Schema.define(version: 2022_01_20_102810) do
     t.string "time_zone", default: "Brussels"
     t.bigint "institution_id"
     t.string "search", limit: 4096
+    t.datetime "seen_at"
+    t.datetime "sign_in_at"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["institution_id"], name: "index_users_on_institution_id"
     t.index ["token"], name: "index_users_on_token"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_25_082726) do
+ActiveRecord::Schema.define(version: 2022_01_24_145930) do
 
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
@@ -473,7 +473,6 @@ ActiveRecord::Schema.define(version: 2022_01_25_082726) do
     t.datetime "sign_in_at"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["institution_id"], name: "index_users_on_institution_id"
-    t.index ["seen_at"], name: "index_users_on_seen_at"
     t.index ["token"], name: "index_users_on_token"
     t.index ["username", "institution_id"], name: "index_users_on_username_and_institution_id", unique: true
     t.index ["username"], name: "index_users_on_username"

--- a/test/factories/users.rb
+++ b/test/factories/users.rb
@@ -15,6 +15,8 @@
 #  time_zone      :string(255)      default("Brussels")
 #  institution_id :bigint
 #  search         :string(4096)
+#  seen_at        :datetime
+#  sign_in_at     :datetime
 #
 
 FactoryBot.define do

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -1,3 +1,4 @@
+# == Schema Information
 #
 # Table name: users
 #
@@ -14,6 +15,8 @@
 #  time_zone      :string(255)      default("Brussels")
 #  institution_id :bigint
 #  search         :string(4096)
+#  seen_at        :datetime
+#  sign_in_at     :datetime
 #
 
 zeus:

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -15,6 +15,8 @@
 #  time_zone      :string(255)      default("Brussels")
 #  institution_id :bigint
 #  search         :string(4096)
+#  seen_at        :datetime
+#  sign_in_at     :datetime
 #
 
 require 'test_helper'


### PR DESCRIPTION
This pull request adds two database fields to `users`: `seen_at` and `sign_in_at`. These are updated on page load and sign in respectively.

Closes #3296  .
