### PR TITLE
Move delete series button down

### DIFF
--- a/app/views/series/_series.html.erb
+++ b/app/views/series/_series.html.erb
@@ -54,19 +54,6 @@
                 <% end %>
               </li>
             <% end %>
-            <% if policy(series).destroy? %>
-              <li>
-                <%
-                    confirm = t('series.delete.confirm')
-                    if series.evaluation.present?
-                      confirm += " " + t('series.delete.confirm_evaluation')
-                    end
-                 %>
-                <%= link_to series_path(series), method: :delete, data: {confirm: confirm}, class: "dropdown-item" do %>
-                  <i class='mdi mdi-delete mdi-18'></i> <%= t("series.delete.title") %>
-                <% end %>
-              </li>
-            <% end %>
             <% if policy(series).create_evaluation? %>
               <li>
                 <% if series.evaluation.present? %>
@@ -106,6 +93,19 @@
               <li>
                 <%= link_to mass_rejudge_series_path(series), method: :post, remote: true, data: {confirm: t("submissions.index.confirm_reevaluate_submissions")}, class: "dropdown-item" do %>
                   <i class='mdi mdi-replay mdi-18'></i> <%= t("submissions.index.reevaluate_submissions") %>
+                <% end %>
+              </li>
+            <% end %>
+            <% if policy(series).destroy? %>
+              <li>
+                <%
+                    confirm = t('series.delete.confirm')
+                    if series.evaluation.present?
+                      confirm += " " + t('series.delete.confirm_evaluation')
+                    end
+                 %>
+                <%= link_to series_path(series), method: :delete, data: {confirm: confirm}, class: "dropdown-item" do %>
+                  <i class='mdi mdi-delete mdi-18'></i> <%= t("series.delete.title") %>
                 <% end %>
               </li>
             <% end %>


### PR DESCRIPTION
`Delete series` is the second button next to two important buttons: `Edit series` and `Show evaluation`. This is prone to accidental clicking. Deleting a series doesn't happen that often and is irreversible (after a warning), so I would argue it can be moved down in the list. In most GUI's the delete button is near the bottom in the list of options.

Before:
![image](https://user-images.githubusercontent.com/56451049/151033986-3bed9e79-a922-450a-8418-402fb82f023d.png)
After:
![image](https://user-images.githubusercontent.com/56451049/151034168-ae3a18a3-fe36-4206-b387-570dfeae4f8b.png)


Was a part of #2809.
