### PR TITLE
Change sort order for students with teacher rights

### DIFF
--- a/app/controllers/course_members_controller.rb
+++ b/app/controllers/course_members_controller.rb
@@ -17,7 +17,7 @@ class CourseMembersController < ApplicationController
     @course_memberships = apply_scopes(@course.course_memberships)
                           .includes(:course_labels, user: [:institution])
                           .order(status: :asc)
-                          .order(Arel.sql('users.permission ASC'))
+                          .order(Arel.sql('users.permission DESC'))
                           .order(Arel.sql('users.last_name ASC'), Arel.sql('users.first_name ASC'))
                           .where(status: statuses)
                           .paginate(page: parse_pagination_param(params[:page]))

--- a/app/views/course_members/_members_table.html.erb
+++ b/app/views/course_members/_members_table.html.erb
@@ -18,7 +18,7 @@
         <td>
           <% if course_membership.course_admin? %>
             <i class="mdi mdi-school course-mdi-icon mdi-18" title='<%= t "users.users_table.course_admin" %>'></i>
-          <% elsif user.staff? || user.zeus? %>
+          <% elsif user.admin? %>
             <span class="mdi mdi-alert mdi-18" data-bs-toggle="tooltip" data-bs-placement="top" title="<%= t(".teacher_rights") %>"></span>
           <% end %>
           <% if user.username.blank? %>

--- a/app/views/course_members/_members_table.html.erb
+++ b/app/views/course_members/_members_table.html.erb
@@ -18,7 +18,7 @@
         <td>
           <% if course_membership.course_admin? %>
             <i class="mdi mdi-school course-mdi-icon mdi-18" title='<%= t "users.users_table.course_admin" %>'></i>
-          <% elsif user.staff? %>
+          <% elsif user.staff? || user.zeus? %>
             <span class="mdi mdi-alert mdi-18" data-bs-toggle="tooltip" data-bs-placement="top" title="<%= t(".teacher_rights") %>"></span>
           <% end %>
           <% if user.username.blank? %>


### PR DESCRIPTION
This pull request closes #3107.

For reference:
`enum permission: { student: 0, staff: 1, zeus: 2 }`
`enum status: { pending: 0, course_admin: 1, student: 2, unsubscribed: 3 }`

Examples:
![image](https://user-images.githubusercontent.com/56451049/152499771-3e61c243-99ad-4215-b329-684b38ed65af.png)
![image](https://user-images.githubusercontent.com/56451049/152227602-2c34eb45-39d4-47b5-9d43-511b0e1a55fb.png)