### PR TITLE
Fix deadline warning not showing up

### DIFF
--- a/app/assets/javascripts/exercise.js
+++ b/app/assets/javascripts/exercise.js
@@ -389,17 +389,17 @@ function initExerciseShow(exerciseId, programmingLanguage, loggedIn, editorShown
         if (!_deadline) {
             return;
         }
-        const $deadlineWarning = $("#deadline-warning");
-        const $deadlineInfo = $("#deadline-info");
+        const deadlineWarningElement = document.getElementById("deadline-warning");
+        const deadlineInfoElement = document.getElementById("deadline-info");
         const deadline = new Date(_deadline);
         const infoDeadline = new Date(deadline - (5 * 60 * 1000));
 
         function showDeadlineAlerts() {
             if (deadline < new Date()) {
-                $deadlineInfo.hide();
-                $deadlineWarning.show();
+                deadlineInfoElement.hidden = true;
+                deadlineWarningElement.hidden = false;
             } else if (infoDeadline < new Date()) {
-                $deadlineInfo.show();
+                deadlineInfoElement.hidden = false;
                 setTimeout(showDeadlineAlerts, Math.min(
                     Math.max(10, (deadline - new Date()) / 10),
                     10 * 60 * 1000));


### PR DESCRIPTION
Since Bootstrap 5, the CSS for `[hidden]` has been changed to `display: none !important`. jQuery's [show](https://api.jquery.com/show/) can't override this, so the `show` and `hide` in the code was useless. Since we're slowly moving away from jQuery anyway, this pull request replaces the jQuery usage with `removeAttribute` and `setAttribute` where appropriate.

I verified locally that the message shows up again. Writing time-based tests seemed like more effort than I was willing to put into it, so I didn't do it.

Closes #3342.
