### PR TITLE
Merge usernames which match case insensitively when merging institutions

### DIFF
--- a/lib/tasks/merge_institutions.rb
+++ b/lib/tasks/merge_institutions.rb
@@ -51,7 +51,7 @@ class MergeInstitutions
         return unless c == 'y'
 
         i1.users.where(username: i2.users.pluck(:username)).each do |u1|
-          u2 = i2.users.find { |u| u.username == u1.username }
+          u2 = i2.users.find { |u| u.username.downcase == u1.username.downcase }
           next if u2.nil?
 
           @output.puts ''

--- a/test/tasks/merge_institutions_test.rb
+++ b/test/tasks/merge_institutions_test.rb
@@ -239,4 +239,20 @@ class MergeInstitutionsTest < ActiveSupport::TestCase
     assert Institution.exists?(i2.id)
     assert s.on_filesystem?
   end
+
+  test 'The script should also merge case insensitive equal usernames' do
+    i1 = create :institution
+    i2 = create :institution
+    u1 = create :user, username: 'test', institution: i1
+    u2 = create :user, username: 'Test', institution: i2
+
+    merge_institutions_interactive i1.id, i2.id, 'y', 'y', 'y'
+
+    assert_not Institution.exists?(i1.id)
+    assert Institution.exists?(i2.id)
+    assert_not User.exists?(u1.id)
+    assert User.exists?(u2.id)
+    u2.reload
+    assert_equal i2, u2.institution
+  end
 end


### PR DESCRIPTION
This pull request merges users with usernames which match case insensitively when merging institutions.

Fixes bug created in #3331 

- [x] Tests are added
