### PR TITLE
Sort activity read states by id

### DIFF
--- a/app/models/activity_read_state.rb
+++ b/app/models/activity_read_state.rb
@@ -19,6 +19,7 @@ class ActivityReadState < ApplicationRecord
 
   after_save :invalidate_caches
 
+  default_scope { order(id: :desc) }
   scope :of_content_page, ->(activity) { where activity_id: activity.id }
   scope :in_course, ->(course) { where course_id: course.id }
   scope :in_series, ->(series) { where(course_id: series.course.id).where(activity: series.content_pages) }


### PR DESCRIPTION
This pull request sorts the activity read states such that the most recent appears first.

Closes #3346  .
