### PR TITLE
Check the user institution when logging in from a new provider

### DIFF
--- a/app/controllers/auth/omniauth_callbacks_controller.rb
+++ b/app/controllers/auth/omniauth_callbacks_controller.rb
@@ -119,7 +119,7 @@ class Auth::OmniauthCallbacksController < Devise::OmniauthCallbacksController
     identity = Identity.find_by(identifier: auth_uid, provider: provider)
     return [identity, identity.user] if identity.present? && auth_uid.present?
 
-    # No username was provided, try to find the user using the email address.
+    # No username was provided, try to find the user using the email address and institution id.
     user = User.from_email_and_institution(auth_email, provider.institution_id)
     return [nil, nil] if user.blank?
 

--- a/app/controllers/auth/omniauth_callbacks_controller.rb
+++ b/app/controllers/auth/omniauth_callbacks_controller.rb
@@ -120,7 +120,7 @@ class Auth::OmniauthCallbacksController < Devise::OmniauthCallbacksController
     return [identity, identity.user] if identity.present? && auth_uid.present?
 
     # No username was provided, try to find the user using the email address.
-    user = User.from_email(auth_email)
+    user = User.from_email_and_institution(auth_email, provider.institution_id)
     return [nil, nil] if user.blank?
 
     # Find an identity for the user at the current provider.

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -283,10 +283,10 @@ class User < ApplicationRecord
     end
   end
 
-  def self.from_email(email)
-    return nil if email.blank?
+  def self.from_email_and_institution(email, institution_id)
+    return nil if email.blank? || institution_id.nil?
 
-    find_by(email: email)
+    find_by(email: email, institution_id: institution_id)
   end
 
   def set_search

--- a/test/controllers/auth/omniauth_callbacks_controller_test.rb
+++ b/test/controllers/auth/omniauth_callbacks_controller_test.rb
@@ -323,7 +323,7 @@ class OmniauthCallbacksControllerTest < ActionDispatch::IntegrationTest
     OAUTH_PROVIDERS.each do |provider_name|
       # Setup.
       provider = create provider_name
-      user = create :temporary_user
+      user = create :temporary_user, institution: provider.institution
       identity = build :identity, provider: provider, user: user
       username = 'real_username'
       omniauth_mock_identity identity,


### PR DESCRIPTION
This pull request adds an extra check for the user institution when looking for an existing user with a new provider.

Closes #3318 .
