### PR TITLE
Replace use of ActiveRecord::Associations::Preloader by includes

### DIFF
--- a/app/controllers/score_items_controller.rb
+++ b/app/controllers/score_items_controller.rb
@@ -93,6 +93,6 @@ class ScoreItemsController < ApplicationController
     # Reload the evaluation, since one of the items changed.
     @evaluation.score_items.reload
     # Preload the stuff for one exercise and an existing instance.
-    EvaluationExercise.includes({score_items: :scores}).find(item.evaluation_exercise.id)
+    EvaluationExercise.includes({ score_items: :scores }).find(item.evaluation_exercise.id)
   end
 end

--- a/app/controllers/score_items_controller.rb
+++ b/app/controllers/score_items_controller.rb
@@ -93,7 +93,6 @@ class ScoreItemsController < ApplicationController
     # Reload the evaluation, since one of the items changed.
     @evaluation.score_items.reload
     # Preload the stuff for one exercise and an existing instance.
-    ActiveRecord::Associations::Preloader.new(records: item.evaluation_exercise, associations: [score_items: :scores])
-    item.evaluation_exercise
+    EvaluationExercise.includes({score_items: :scores}).find(item.evaluation_exercise.id)
   end
 end


### PR DESCRIPTION
This pull request replaces the usage of ActiveRecord::Associations::Preloader by includes.

It was introduced in https://github.com/dodona-edu/dodona/commit/e2cfa5f8120157fff147c3a1d933dc5acb031ec4 but the API of preloader is not guaranteed (as we noticed with a recent api change see #3369). 

Our expected usage is also supported by the default rails api, example see here: https://stackoverflow.com/questions/38749960/rails-eager-load-deep-associations-on-an-instance

Closes #3369 .
