### PR TITLE
Don't fetch first and last submission for timeseries if none are present

### DIFF
--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -429,8 +429,8 @@ class Submission < ApplicationRecord
     submissions = submissions.judged
     submissions = submissions.from_students(options[:series].course)
 
-    first_sub = submissions.least_recent.first.created_at
-    last_sub = submissions.most_recent.first.created_at
+    first_sub = submissions.present? ? submissions.least_recent.first.created_at : nil
+    last_sub = submissions.present? ? submissions.most_recent.first.created_at : nil
 
     submissions = submissions.in_time_range(options[:start], options[:end]) if options[:end].present?
 

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -429,8 +429,8 @@ class Submission < ApplicationRecord
     submissions = submissions.judged
     submissions = submissions.from_students(options[:series].course)
 
-    first_sub = submissions.present? ? submissions.least_recent.first.created_at : nil
-    last_sub = submissions.present? ? submissions.most_recent.first.created_at : nil
+    first_sub = submissions.any? ? submissions.least_recent.first.created_at : nil
+    last_sub = submissions.any? ? submissions.most_recent.first.created_at : nil
 
     submissions = submissions.in_time_range(options[:start], options[:end]) if options[:end].present?
 

--- a/test/models/submission_test.rb
+++ b/test/models/submission_test.rb
@@ -364,7 +364,7 @@ class SubmissionTest < ActiveSupport::TestCase
       assert_equal result.values[0], [@date, @date, @date] # timestamp for each first correct submission (one for each user)
     end
 
-    test 'visualisation work return empty list on empty series' do
+    test 'visualisation return empty list on empty series' do
       exercise = create :exercise
       series = create :series, exercises: [exercise], course: @course
 

--- a/test/models/submission_test.rb
+++ b/test/models/submission_test.rb
@@ -363,5 +363,26 @@ class SubmissionTest < ActiveSupport::TestCase
       assert_equal result.length, 1 # one key: 1 exercise
       assert_equal result.values[0], [@date, @date, @date] # timestamp for each first correct submission (one for each user)
     end
+
+    test 'visualisation work return empty list on empty series' do
+      exercise = create :exercise
+      series = create :series, exercises: [exercise], course: @course
+
+      # violin
+      result = Submission.violin_matrix(course: @course, series: series)[:value]
+      assert_equal result.length, 0
+
+      # stacked
+      result = Submission.stacked_status_matrix(course: @course, series: series)[:value]
+      assert_equal result.length, 0
+
+      # time series
+      result = Submission.timeseries_matrix(course: @course, series: series)[:value]
+      assert_equal result.length, 0
+
+      # ctimeseries
+      result = Submission.cumulative_timeseries_matrix(course: @course, series: series)[:value]
+      assert_equal result.length, 0
+    end
   end
 end


### PR DESCRIPTION
This pull request fixes a bug when timeseries tried to fetch the first and last submission when none are present.

Now a message is shown explaining that no data is availlable:
![image](https://user-images.githubusercontent.com/21177904/154279189-6e306ee8-06a0-4856-8e32-1bb267618006.png)

Closes #3367 .
