### PR TITLE
 Improve labeling of time periods on cumulative plot

### DIFF
--- a/app/assets/javascripts/visualisations/cumulative_timeseries.ts
+++ b/app/assets/javascripts/visualisations/cumulative_timeseries.ts
@@ -362,6 +362,7 @@ export class CTimeseriesGraph extends SeriesGraph {
             message += `<br><span style="color: ${this.color(e)}">&FilledSmallSquare;</span> ${d3.format(".1%")(ex.ex_data[i].cSum / this.studentCount)}
                     (${ex.ex_data[i].cSum}/${this.studentCount})`;
         });
+        message += "</b>";
         return message;
     }
 

--- a/app/assets/javascripts/visualisations/cumulative_timeseries.ts
+++ b/app/assets/javascripts/visualisations/cumulative_timeseries.ts
@@ -345,7 +345,7 @@ export class CTimeseriesGraph extends SeriesGraph {
     private tooltipText(i: number): string {
         const date = this.binTicks[i];
         const capitalize = (s: string): string => s.charAt(0).toUpperCase() + s.slice(1);
-        let message = "<b>";
+        let message = "";
 
         if (this.binStep < 24) {
             const on = I18n.t("js.date_on");
@@ -362,8 +362,8 @@ export class CTimeseriesGraph extends SeriesGraph {
             message += `<br><span style="color: ${this.color(e)}">&FilledSmallSquare;</span> ${d3.format(".1%")(ex.ex_data[i].cSum / this.studentCount)}
                     (${ex.ex_data[i].cSum}/${this.studentCount})`;
         });
-        message += "</b>";
-        return message;
+
+        return "<b>" + message + "</b>";
     }
 
     private yRangeToggle(): void {

--- a/app/assets/javascripts/visualisations/cumulative_timeseries.ts
+++ b/app/assets/javascripts/visualisations/cumulative_timeseries.ts
@@ -344,7 +344,6 @@ export class CTimeseriesGraph extends SeriesGraph {
 
     private tooltipText(i: number): string {
         const date = this.binTicks[i];
-        const capitalize = (s: string): string => s.charAt(0).toUpperCase() + s.slice(1);
         let message = "";
 
         if (this.binStep < 24) {
@@ -355,7 +354,7 @@ export class CTimeseriesGraph extends SeriesGraph {
         }
 
         const weekDay = d3.timeFormat(I18n.t("date.formats.weekday_long"));
-        message += capitalize(weekDay(date));
+        message += weekDay(date);
 
         this.exOrder.forEach(e => {
             const ex = this.data.find(ex => ex.ex_id === e);

--- a/app/assets/javascripts/visualisations/timeseries.ts
+++ b/app/assets/javascripts/visualisations/timeseries.ts
@@ -249,7 +249,6 @@ export class TimeseriesGraph extends SeriesExerciseGraph {
             .duration(200)
             .style("opacity", .9);
         let message = "";
-        const capitalize = (s: string): string => s.charAt(0).toUpperCase() + s.slice(1);
         if (this.binStep < 24) {
             const on = I18n.t("js.date_on");
             const timeFormat = d3.timeFormat(I18n.t("time.formats.plain_time"));
@@ -260,18 +259,18 @@ export class TimeseriesGraph extends SeriesExerciseGraph {
             `;
         } else if (this.binStep === 24) { // binning per day
             const format = d3.timeFormat(I18n.t("date.formats.weekday_long"));
-            message = `${capitalize(format(d.date))}:<br>`;
+            message = `${format(d.date)}:<br>`;
         } else if (this.binStep < 168) { // binning per multiple days
             const format = d3.timeFormat(I18n.t("date.formats.weekday_long"));
             message = `
-                <b>${capitalize(format(d.date))} - ${format(new Date(d.date - this.binStep * 3600000))}:</b>
+                <b>${format(d.date)} - ${format(new Date(d.date - this.binStep * 3600000))}:</b>
                 <br>
             `;
         } else { // binning per week(s)
             const weekDay = d3.timeFormat(I18n.t("date.formats.weekday_long"));
             const monthDay = d3.timeFormat(I18n.t("date.formats.monthday_long"));
             message = `
-                <b>${capitalize(weekDay(d.date))} - ${monthDay(new Date(d.date - this.binStep * 3600000))}:</b>
+                <b>${weekDay(d.date)} - ${monthDay(new Date(d.date - this.binStep * 3600000))}:</b>
                 <br>
             `;
         }


### PR DESCRIPTION
This pull request removes the start time from the tooltip of the cumulative plot as it incorrectly indicates some kind of binning behavior, which is not what the graph represents.

The capitalization of dates in the tooltip has also changed to follow behavior as specified by I18n.

![image](https://user-images.githubusercontent.com/21177904/154923200-b99ea52f-df74-4aa3-b17a-8fde0d75785e.png)
![image](https://user-images.githubusercontent.com/21177904/154923175-75da7ff4-66db-4cc5-a101-f6b32e64e1f9.png)

I also fixed a bug that scaling is reset when the date range is changed.

Closes #3348 .
