### PR TITLE
Make sure redirect from sandbox to default host is allowed

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -96,7 +96,8 @@ class ApplicationController < ActionController::Base
 
   def redirect_to_default_host
     redirect_to host: Rails.configuration.default_host,
-                params: request.query_parameters
+                params: request.query_parameters,
+                allow_other_host: true
   end
 
   def user_not_authorized


### PR DESCRIPTION
Rails 7 introduced protection against open redirects. This is not an open redirect though, it's a redirect to a set known host.
