### PR TITLE
Include exercises without any submissions in series analytics

### DIFF
--- a/app/assets/javascripts/visualisations/cumulative_timeseries.ts
+++ b/app/assets/javascripts/visualisations/cumulative_timeseries.ts
@@ -207,13 +207,12 @@ export class CTimeseriesGraph extends SeriesGraph {
         this.minDate = allignedStart;
         this.maxDate = new Date(this.binTicks[this.binTicks.length - 1]);
 
-        if (!this.dateStart) {
-            this.setPickerDates(this.minDate, this.maxDate);
-        }
-
-
         if (this.binTicks.length < 2) {
             return;
+        }
+
+        if (!this.dateStart) {
+            this.setPickerDates(this.minDate, this.maxDate);
         }
 
         // eslint-disable-next-line camelcase

--- a/app/assets/javascripts/visualisations/violin.ts
+++ b/app/assets/javascripts/visualisations/violin.ts
@@ -196,7 +196,7 @@ export class ViolinGraph extends SeriesExerciseGraph {
             // largest x-value
             this.maxFreq = Math.max(this.maxFreq, d3.max(ex.freq, bin => bin.length));
 
-            ex.average = d3.mean(ex.counts);
+            ex.average = d3.mean(ex.counts) || 0;
         });
     }
 

--- a/app/controllers/statistics_controller.rb
+++ b/app/controllers/statistics_controller.rb
@@ -46,8 +46,8 @@ class StatisticsController < ApplicationController
     result = Submission.send(visualisation, series: series)
     if result.present?
       ex_data = series.exercises.map { |ex| [ex.id, ex.name] }
-      data = result[:value].map { |k, v| { ex_id: k, ex_data: v } }
-      # intitial: used by cumulative graph to set the value for first tick (everthing that came before)
+      data = series.exercises.map { |ex| { ex_id: ex.id, ex_data: result[:value][ex.id] || [] } }
+
       render json: {
         data: data, exercises: ex_data, student_count: series.course.enrolled_members.length
       }

--- a/test/controllers/statistics_controller_test.rb
+++ b/test/controllers/statistics_controller_test.rb
@@ -1,0 +1,40 @@
+require 'test_helper'
+
+class StatisticsControllerTest < ActionDispatch::IntegrationTest
+
+  def setup
+    @course = create :course
+
+    @course_admin = users(:staff)
+    @course_admin.administrating_courses << @course
+    sign_in @course_admin
+  end
+
+  test 'Exercises without submissions are included in data' do
+    e1 = create :exercise
+    e2 = create :exercise, submission_count: 5
+    series = create :series, exercises: [e1, e2], course: @course
+
+    # violin
+    get violin_path format: :json, params: {series_id: series.id}
+    results = JSON.parse response.body
+    assert_equal 2, results["data"].count
+
+    # stacked
+    get stacked_status_path format: :json, params: {series_id: series.id}
+    results = JSON.parse response.body
+    assert_equal 2, results["data"].count
+
+    # time series
+    get timeseries_path format: :json, params: {series_id: series.id}
+    results = JSON.parse response.body
+    assert_equal 2, results["data"].count
+
+    # ctimeseries
+    get cumulative_timeseries_path format: :json, params: {series_id: series.id}
+    results = JSON.parse response.body
+    assert_equal 2, results["data"].count
+  end
+
+end
+

--- a/test/controllers/statistics_controller_test.rb
+++ b/test/controllers/statistics_controller_test.rb
@@ -1,7 +1,6 @@
 require 'test_helper'
 
 class StatisticsControllerTest < ActionDispatch::IntegrationTest
-
   def setup
     @course = create :course
 
@@ -16,25 +15,23 @@ class StatisticsControllerTest < ActionDispatch::IntegrationTest
     series = create :series, exercises: [e1, e2], course: @course
 
     # violin
-    get violin_path format: :json, params: {series_id: series.id}
+    get violin_path format: :json, params: { series_id: series.id }
     results = JSON.parse response.body
-    assert_equal 2, results["data"].count
+    assert_equal 2, results['data'].count
 
     # stacked
-    get stacked_status_path format: :json, params: {series_id: series.id}
+    get stacked_status_path format: :json, params: { series_id: series.id }
     results = JSON.parse response.body
-    assert_equal 2, results["data"].count
+    assert_equal 2, results['data'].count
 
     # time series
-    get timeseries_path format: :json, params: {series_id: series.id}
+    get timeseries_path format: :json, params: { series_id: series.id }
     results = JSON.parse response.body
-    assert_equal 2, results["data"].count
+    assert_equal 2, results['data'].count
 
     # ctimeseries
-    get cumulative_timeseries_path format: :json, params: {series_id: series.id}
+    get cumulative_timeseries_path format: :json, params: { series_id: series.id }
     results = JSON.parse response.body
-    assert_equal 2, results["data"].count
+    assert_equal 2, results['data'].count
   end
-
 end
-


### PR DESCRIPTION
This pull request adds exercises without submission to the series analytics.

Single exercise without submissions:
![Peek 2022-02-21 15-50](https://user-images.githubusercontent.com/21177904/154978454-46411028-5f35-4018-92a2-e80db40763e3.gif)

All exercises without submissions:
![Peek 2022-02-21 15-49](https://user-images.githubusercontent.com/21177904/154978456-fcc08447-4c47-4240-a873-ee2e4057d30f.gif)


- [x] Tests were added

Closes #3392 .
