### PR TITLE
Improve color scheme of dark mode for the  cumulative time series and heatmap

### DIFF
--- a/app/assets/javascripts/heatmap.ts
+++ b/app/assets/javascripts/heatmap.ts
@@ -64,7 +64,7 @@ function initHeatmap(url: string, oldestFirst: boolean, year: string | undefined
 function drawHeatmap(data: [moment.Moment, number][], oldestFirst: boolean, year: string | undefined): void {
     const darkMode = window.dodona.darkMode;
     const emptyColor = darkMode ? "#37474F" : "white";
-    const lowColor = darkMode ? "#01579B" : "#E3F2FD";
+    const lowColor = darkMode ? "#364953" : "#E3F2FD";
     const highColor = darkMode ? "#039BE5" : "#0D47A1";
 
     const longMonthNames = monthKeys.map(k => I18n.t(`js.months.long.${k}`));

--- a/app/assets/javascripts/visualisations/timeseries.ts
+++ b/app/assets/javascripts/visualisations/timeseries.ts
@@ -49,7 +49,7 @@ export class TimeseriesGraph extends SeriesExerciseGraph {
         // no data in cell
         const emptyColor = this.darkMode ? "#37474F" : "white";
         // almost no data in cell
-        const lowColor = this.darkMode ? "#01579B" : "#E3F2FD";
+        const lowColor = this.darkMode ? "#364953" : "#E3F2FD";
         // a lot of data in cell
         const highColor = this.darkMode ? "#039BE5" : "#0D47A1";
 


### PR DESCRIPTION
This pull request improves the color scheme of dark mode for the cumulative time series and heatmap.

I made this change because in the old color scheme I could not intuitively see which values where highest.

New:
![image](https://user-images.githubusercontent.com/21177904/154991728-ca6aa4b5-ca3f-4850-a85c-433b3189741d.png)
![image](https://user-images.githubusercontent.com/21177904/155096561-0be67257-922e-4cd8-891a-03502c13bbf9.png)

Old:
![image](https://user-images.githubusercontent.com/21177904/154991962-9c6af86a-29fd-4eee-b4d7-6c508b4313b9.png)
![image](https://user-images.githubusercontent.com/21177904/155096598-3661253c-ea14-4b6b-a3aa-d9a3fea250a7.png)

Light mode:
![image](https://user-images.githubusercontent.com/21177904/154991844-19f98b34-793c-46d1-b28d-fffc93cb3069.png)
![image](https://user-images.githubusercontent.com/21177904/155096579-2b87bf77-d88b-4a11-a304-5a3a9d343c02.png)
