### PR TITLE
Remove the thick black borders on top of some tables

### DIFF
--- a/app/assets/stylesheets/bootstrap_style_overrides.css.scss
+++ b/app/assets/stylesheets/bootstrap_style_overrides.css.scss
@@ -131,6 +131,10 @@ code {
   tr:last-child td {
     border-bottom: 0;
   }
+
+  :not(:first-child) {
+    border-top: 0;
+  }
 }
 
 .table th {

--- a/app/views/repositories/show.html.erb
+++ b/app/views/repositories/show.html.erb
@@ -78,8 +78,10 @@
             <% if @files.present?%>
                 <table class="table table-index table-resource">
                   <thead>
-                    <td><%= t ".file_name"%></td>
-                    <td><%= t ".file_url" %></td>
+                    <tr>
+                      <th><%= t ".file_name"%></th>
+                      <th><%= t ".file_url" %></th>
+                    </tr>
                   </thead>
                   <tbody>
                     <% @files.each do |file| %>


### PR DESCRIPTION
This pull request removes the tick black borders which are displayed at the top of some tables.

Cause: Bootstrap defines:
```
.table > :not(:first-child) {
    border-top: 2px solid currentColor;
}
```

Which was mostly but not always overwritten by our `th` border bottom.

For example `app/views/courses/_repo_courses_table.html.erb` has `colgroup` as first child and `thead` only as second child.

I also fixed a table that used `td` instead of `th` in `thead`. Which caused it not to have any separator at all anymore between `thead` and `tbody` 

Closes #3390 .
