### PR TITLE
Fix the link in the popup notice to set series activities visible

### DIFF
--- a/app/views/series/_series.html.erb
+++ b/app/views/series/_series.html.erb
@@ -151,7 +151,7 @@
   <% if current_user&.course_admin?(series.course) && !series.activities_visible %>
     <div class="alert alert-info hidden-print">
       <%= t "series.show.activities_not_visible" %>
-      <%= t('series.show.make_visible_html', series_url: series_path(series, series: {visibility: :open}), method: :patch) %>
+      <%= t('series.show.make_visible_html', series_url: series_path(series, series: {activities_visible: true}), method: :patch) %>
     </div>
   <% end %>
   <div class="tab-content">


### PR DESCRIPTION
This pull request fixes the link in the popup notice which sets the activities of a series visible to students.

Closes #3389 .
