### PR TITLE
Fix copy courses index method when no user is detected

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -27,8 +27,8 @@ class CoursesController < ApplicationController
     if params[:copy_courses]
       @courses = apply_scopes(@courses)
       @courses = @courses.reorder(featured: :desc, year: :desc, name: :asc)
-      @own_courses = @courses.select { |course| current_user.admin_of?(course) }
-      @other_courses = @courses.reject { |course| current_user.admin_of?(course) }
+      @own_courses = @courses.select { |course| current_user&.admin_of?(course) }
+      @other_courses = @courses.reject { |course| current_user&.admin_of?(course) }
       @courses = @own_courses.concat(@other_courses)
     else
       if current_user && params[:tab] == 'institution'


### PR DESCRIPTION
This pull request fixes the copy courses index method when no user is detected. 

Although the course index method is never called in the current frontend without a user being present, this makes our backend more resilient.

Closes #3434 .
