### PR TITLE
End series visualizations on series deadline

### DIFF
--- a/app/assets/javascripts/visualisations/cumulative_timeseries.ts
+++ b/app/assets/javascripts/visualisations/cumulative_timeseries.ts
@@ -184,7 +184,7 @@ export class CTimeseriesGraph extends SeriesGraph {
      * @param {RawData} raw The unprocessed return value of the fetch
      */
     // eslint-disable-next-line camelcase
-    protected override processData({ data, exercises, student_count }: RawData): void {
+    protected override processData({ data, exercises, student_count, deadline }: RawData): void {
         this.data = [];
         // eslint-disable-next-line camelcase
         data as { ex_id: number, ex_data: (string | Date)[] }[];
@@ -196,7 +196,12 @@ export class CTimeseriesGraph extends SeriesGraph {
             ex.ex_data = ex.ex_data.map((d: string) => new Date(d));
         });
 
-        const [minDate, maxDate] = d3.extent(data.flatMap(ex => ex.ex_data)) as Date[];
+        let [minDate, maxDate] = d3.extent(data.flatMap(ex => ex.ex_data)) as Date[];
+
+        if (deadline) {
+            maxDate = deadline;
+        }
+
         this.minDate = this.dateStart ? new Date(this.dateStart) : new Date(minDate);
         this.maxDate = this.dateEnd ? new Date(this.dateEnd) : new Date(maxDate);
 

--- a/app/assets/javascripts/visualisations/timeseries.ts
+++ b/app/assets/javascripts/visualisations/timeseries.ts
@@ -162,7 +162,7 @@ export class TimeseriesGraph extends SeriesExerciseGraph {
      *
      * @param {RawData} raw The unprocessed return value of the fetch
      */
-    protected override processData({ data, exercises }: RawData): void {
+    protected override processData({ data, exercises, deadline }: RawData): void {
         // the type of one datum in the ex_data array
         type Datum = { date: (Date | string); status: string; count: number };
 
@@ -175,10 +175,14 @@ export class TimeseriesGraph extends SeriesExerciseGraph {
             });
         });
 
-        const [minDate, maxDate] = d3.extent(
+        let [minDate, maxDate] = d3.extent(
             data.flatMap(ex => ex.ex_data),
             (d: Datum) => d.date as Date
         );
+
+        if (deadline) {
+            maxDate = deadline;
+        }
 
         this.minDate = this.dateStart ? new Date(this.dateStart) : new Date(minDate);
         this.maxDate = this.dateEnd ? new Date(this.dateEnd) : new Date(maxDate);

--- a/app/controllers/statistics_controller.rb
+++ b/app/controllers/statistics_controller.rb
@@ -49,7 +49,10 @@ class StatisticsController < ApplicationController
       data = series.exercises.map { |ex| { ex_id: ex.id, ex_data: result[:value][ex.id] || [] } }
 
       render json: {
-        data: data, exercises: ex_data, student_count: series.course.enrolled_members.length
+        data: data,
+        exercises: ex_data,
+        student_count: series.course.enrolled_members.length,
+        deadline: series.deadline
       }
     else
       render json: { status: 'not available yet' }, status: :accepted


### PR DESCRIPTION
This pull request sets the default end time of series visualizations to the series deadline if such a deadline is present.

![image](https://user-images.githubusercontent.com/21177904/155683128-8e69225c-6e38-4517-bdd7-d32dc8bb4280.png)
![image](https://user-images.githubusercontent.com/21177904/155683205-de20c312-3de1-4ff1-9f1e-3ba2d7bfc621.png)

Closes #3353 .
