### PR TITLE
Add vertical submission history to submission detail view

### DIFF
--- a/app/assets/javascripts/submission.js
+++ b/app/assets/javascripts/submission.js
@@ -82,4 +82,9 @@ function contextualizeMediaPaths(parentClass, exercisePath, token) {
     });
 }
 
-export { initSubmissionShow };
+function initSubmissionHistory(id) {
+    const element = document.getElementById("history-"+id);
+    element.scrollIntoView({ block: "center", inline: "nearest" });
+}
+
+export { initSubmissionShow, initSubmissionHistory };

--- a/app/assets/stylesheets/components/card.css.scss
+++ b/app/assets/stylesheets/components/card.css.scss
@@ -189,7 +189,7 @@ a.card-title-link:hover {
   .mdi-36::before{
     line-height: 32px
   }
-  .mdi-48::before{
+  .mdi-48::before {
     line-height: 50px
   }
 }

--- a/app/assets/stylesheets/components/card.css.scss
+++ b/app/assets/stylesheets/components/card.css.scss
@@ -189,6 +189,9 @@ a.card-title-link:hover {
   .mdi-36::before{
     line-height: 32px
   }
+  .mdi-48::before{
+    line-height: 50px
+  }
 }
 
 .card-actions {

--- a/app/assets/stylesheets/models/submissions.css.scss
+++ b/app/assets/stylesheets/models/submissions.css.scss
@@ -312,22 +312,22 @@ iframe.file {
   padding-bottom: 10px;
 }
 
-.submission-history{
+.submission-history {
   display: flex;
   max-height: 75px;
   overflow-y: auto;
   margin-bottom: 12px;
 
-  .timestamp-col{
+  .timestamp-col {
     text-align: right;
     margin-right: 0.5em;
   }
 
-  .submission-history-row{
+  .submission-history-row {
     display: inline-block;
   }
 
-  .submission-link{
+  .submission-link {
     min-width: 24px;
     display: inline-block;
     margin-right:6px;

--- a/app/assets/stylesheets/models/submissions.css.scss
+++ b/app/assets/stylesheets/models/submissions.css.scss
@@ -326,4 +326,10 @@ iframe.file {
   .submission-history-row{
     display: inline-block;
   }
+
+  .submission-link{
+    min-width: 24px;
+    display: inline-block;
+    margin-right:6px;
+  }
 }

--- a/app/assets/stylesheets/models/submissions.css.scss
+++ b/app/assets/stylesheets/models/submissions.css.scss
@@ -311,3 +311,19 @@ iframe.file {
 .score-details {
   padding-bottom: 10px;
 }
+
+.submission-history{
+  display: flex;
+  max-height: 75px;
+  overflow-y: auto;
+  margin-bottom: 12px;
+
+  .timestamp-col{
+    text-align: right;
+    margin-right: 0.5em;
+  }
+
+  .submission-history-row{
+    display: inline-block;
+  }
+}

--- a/app/assets/stylesheets/models/submissions.css.scss
+++ b/app/assets/stylesheets/models/submissions.css.scss
@@ -325,6 +325,10 @@ iframe.file {
 
   .submission-history-row {
     display: inline-block;
+
+    &.current-submission {
+      font-weight: bold;
+    }
   }
 
   .submission-link {

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -73,7 +73,7 @@ class SubmissionsController < ApplicationController
     @submissions_time_stamps = []
     prev = nil
     @submissions.each do |s|
-      current = s.created_at.before?(1.day.ago) ? "#{time_ago_in_words(s.created_at)} #{t 'submissions.show.ago'}" : (t "submissions.show.today")
+      current = s.created_at.before?(1.day.ago) ? "#{time_ago_in_words(s.created_at)} #{t 'submissions.show.ago'}" : (t 'submissions.show.today')
       if current == prev
         @submissions_time_stamps.push nil
       else

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -2,7 +2,7 @@ class SubmissionsController < ApplicationController
   include SeriesHelper
 
   before_action :set_submission, only: %i[show download evaluate edit media]
-  before_action :set_submissions, only: %i[index mass_rejudge]
+  before_action :set_submissions, only: %i[index mass_rejudge show]
   before_action :ensure_trailing_slash, only: :show
 
   has_scope :by_filter, as: 'filter' do |controller, scope, value|
@@ -66,6 +66,8 @@ class SubmissionsController < ApplicationController
               else
                 [[@submission.exercise.name, activity_path(@submission.exercise)], [I18n.t('submissions.show.submission'), '#']]
               end
+    @submissions = @submissions.of_exercise(@submission.exercise)
+    @submissions = @submissions.in_course(course) if course.present?
     @feedbacks = policy_scope(@submission.feedbacks).preload(scores: :score_item)
   end
 

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -68,6 +68,7 @@ class SubmissionsController < ApplicationController
                 [[@submission.exercise.name, activity_path(@submission.exercise)], [I18n.t('submissions.show.submission'), '#']]
               end
     @submissions = @submissions.of_exercise(@submission.exercise)
+    @submissions = @submissions.of_user(@submission.user)
     @submissions = @submissions.in_course(course) if course.present?
 
     @submissions_time_stamps = []

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -1,5 +1,6 @@
 class SubmissionsController < ApplicationController
   include SeriesHelper
+  include ActionView::Helpers::DateHelper
 
   before_action :set_submission, only: %i[show download evaluate edit media]
   before_action :set_submissions, only: %i[index mass_rejudge show]
@@ -68,6 +69,19 @@ class SubmissionsController < ApplicationController
               end
     @submissions = @submissions.of_exercise(@submission.exercise)
     @submissions = @submissions.in_course(course) if course.present?
+
+    @submissions_time_stamps = []
+    prev = nil
+    @submissions.each do |s|
+      current = s.created_at.before?(1.day.ago) ? "#{time_ago_in_words(s.created_at)} #{t 'submissions.show.ago'}" : (t "submissions.show.today")
+      if current == prev
+        @submissions_time_stamps.push nil
+      else
+        @submissions_time_stamps.push current
+        prev = current
+      end
+    end
+
     @feedbacks = policy_scope(@submission.feedbacks).preload(scores: :score_item)
   end
 

--- a/app/javascript/packs/submission.js
+++ b/app/javascript/packs/submission.js
@@ -1,4 +1,4 @@
-import { initSubmissionShow } from "submission.js";
+import { initSubmissionShow, initSubmissionHistory } from "submission.js";
 import { initMathJax } from "exercise.js";
 import { CodeListing } from "code_listing/code_listing.ts";
 import { attachClipboard } from "copy";
@@ -7,3 +7,4 @@ window.dodona.initSubmissionShow = initSubmissionShow;
 window.dodona.codeListingClass = CodeListing;
 window.dodona.attachClipboard = attachClipboard;
 window.dodona.initMathJax = initMathJax;
+window.dodona.initSubmissionHistory = initSubmissionHistory;

--- a/app/views/submissions/_description.html.erb
+++ b/app/views/submissions/_description.html.erb
@@ -55,14 +55,21 @@
       </div>
       <div>
         <% @submissions.each_with_index do |s, i| %>
+          <% if s.id == submission.id %>
+            <b>
+          <% end %>
           <%= link_to "##{@submissions.length - i}", submission_path(s), style: 'min-width: 24px; display: inline-block;'  %>
-          <span class='status-icon'><%= submission_status_icon(s, 12) %></span>
+          <span class='status-icon' id="history-<%= s.id%>"><%= submission_status_icon(s, 12) %></span>
           <span>
             <%= Submission.human_enum_name(:status, s.status) %>
             <% if s.summary.present? and s.summary.downcase != Submission.human_enum_name(:status, s.status).downcase %>
               &middot; <span class='text-muted'><%= s.summary %></span>
             <% end %>
           </span>
+
+          <% if s.id == submission.id %>
+            </b>
+          <% end %>
           <br/>
         <% end %>
       </div>
@@ -85,3 +92,7 @@
 <% unless submission.queued? or submission.running? %>
   <%= submission.judge.renderer.new(submission, current_user).parse %>
 <% end %>
+
+<script>
+  window.dodona.initSubmissionHistory(<%= submission.id %>)
+</script>

--- a/app/views/submissions/_description.html.erb
+++ b/app/views/submissions/_description.html.erb
@@ -45,18 +45,18 @@
       <div class="col-md-6 submission-history">
         <div class="timestamp-col">
           <% @submissions_time_stamps.each do |t| %>
-            <span class="text-muted small submission-history-row" style="<%= t.present? ? 'margin-top: 6px;' : '' %>"><%= t %></span>
+            <span class="text-muted small submission-history-row <%= t.present? ? 'mt-1' : '' %>"><%= t %></span>
             <br/>
           <% end %>
         </div>
         <div>
           <% @submissions.each_with_index do |s, i| %>
-            <span class="submission-history-row" style="<%= s.id == submission.id ? 'font-weight: bold;' : '' %> <%= @submissions_time_stamps[i].present? ? ' margin-top: 6px;' : '' %>">
+            <span class="submission-history-row <%= @submissions_time_stamps[i].present? ? 'mt-1' : '' %> <%= s.id == submission.id ? 'current-submission' : '' %>">
               <%= link_to "##{@submissions.length - i}", submission_path(s), class: 'submission-link' %>
               <span class='status-icon' id="history-<%= s.id %>"><%= submission_status_icon(s, 12) %></span>
               <span>
                 <%= Submission.human_enum_name(:status, s.status) %>
-                  <% if s.summary.present? and s.summary.downcase != Submission.human_enum_name(:status, s.status).downcase %>
+                <% if s.summary.present? and s.summary.downcase != Submission.human_enum_name(:status, s.status).downcase %>
                   &middot; <span class='text-muted'><%= s.summary %></span>
                 <% end %>
               </span>

--- a/app/views/submissions/_description.html.erb
+++ b/app/views/submissions/_description.html.erb
@@ -41,46 +41,39 @@
         <span class="text-muted small" title="<%= l submission.created_at, format: :submission %>"><%= time_ago_in_words submission.created_at %> <%= t "submissions.show.ago" %></span>
       </span>
     </div>
-    <div class="col-md-6" style="display: flex; max-height: 75px; overflow-y: scroll">
-      <% prev = nil %>
-      <div style="text-align: right; margin-right: 0.5em">
-        <% @submissions.each do |s| %>
-          <% current = s.created_at.before?(1.day.ago) ? (time_ago_in_words s.created_at) + " " + (t "submissions.show.ago") : (t "submissions.show.today")%>
-          <% if current != prev %>
-            <% prev = current %>
-            <span class="text-muted small" title="<%= l s.created_at, format: :submission %>"><%= current %></span>
+    <% if @feedbacks.blank? %>
+      <div class="col-md-6" style="display: flex; max-height: 75px; overflow-y: auto; margin-bottom: 12px">
+        <div style="text-align: right; margin-right: 0.5em">
+          <% @submissions_time_stamps.each do |t| %>
+            <span class="text-muted small" style="display: inline-block; <%= t.present? ? 'margin-top: 6px;' : '' %>"><%= t %></span>
+            <br/>
           <% end %>
-          <br/>
-        <% end %>
+        </div>
+        <div>
+          <% @submissions.each_with_index do |s, i| %>
+            <span style="display: inline-block; <%= s.id == submission.id ? 'font-weight: bold;' : '' %> <%= @submissions_time_stamps[i].present? ? ' margin-top: 6px;' : '' %>">
+              <%= link_to "##{@submissions.length - i}", submission_path(s), style: 'min-width: 24px; display: inline-block; margin-right:6px;' %>
+              <span class='status-icon' id="history-<%= s.id %>"><%= submission_status_icon(s, 12) %></span>
+              <span>
+                <%= Submission.human_enum_name(:status, s.status) %>
+                  <% if s.summary.present? and s.summary.downcase != Submission.human_enum_name(:status, s.status).downcase %>
+                  &middot; <span class='text-muted'><%= s.summary %></span>
+                <% end %>
+              </span>
+            </span>
+            <br/>
+          <% end %>
+        </div>
       </div>
-      <div>
-        <% @submissions.each_with_index do |s, i| %>
-          <% if s.id == submission.id %>
-            <b>
-          <% end %>
-          <%= link_to "##{@submissions.length - i}", submission_path(s), style: 'min-width: 24px; display: inline-block;'  %>
-          <span class='status-icon' id="history-<%= s.id%>"><%= submission_status_icon(s, 12) %></span>
-          <span>
-            <%= Submission.human_enum_name(:status, s.status) %>
-            <% if s.summary.present? and s.summary.downcase != Submission.human_enum_name(:status, s.status).downcase %>
-              &middot; <span class='text-muted'><%= s.summary %></span>
-            <% end %>
+    <% else %>
+      <div class="col-md-6">
+        <% @feedbacks.each do |feedback| %>
+          <span class="score">
+            <%= render 'feedbacks/score_link', feedback: feedback %>
           </span>
-
-          <% if s.id == submission.id %>
-            </b>
-          <% end %>
-          <br/>
         <% end %>
       </div>
-    </div>
-    <div class="col-md-6">
-      <% @feedbacks.each do |feedback| %>
-        <span class="score">
-          <%= render 'feedbacks/score_link', feedback: feedback %>
-        </span>
-      <% end %>
-    </div>
+    <% end %>
   </div>
 </div>
 <% @feedbacks.each do |feedback | %>

--- a/app/views/submissions/_description.html.erb
+++ b/app/views/submissions/_description.html.erb
@@ -52,7 +52,7 @@
         <div>
           <% @submissions.each_with_index do |s, i| %>
             <span class="submission-history-row" style="<%= s.id == submission.id ? 'font-weight: bold;' : '' %> <%= @submissions_time_stamps[i].present? ? ' margin-top: 6px;' : '' %>">
-              <%= link_to "##{@submissions.length - i}", submission_path(s), style: 'min-width: 24px; display: inline-block; margin-right:6px;' %>
+              <%= link_to "##{@submissions.length - i}", submission_path(s), class: 'submission-link' %>
               <span class='status-icon' id="history-<%= s.id %>"><%= submission_status_icon(s, 12) %></span>
               <span>
                 <%= Submission.human_enum_name(:status, s.status) %>

--- a/app/views/submissions/_description.html.erb
+++ b/app/views/submissions/_description.html.erb
@@ -42,16 +42,16 @@
       </span>
     </div>
     <% if @feedbacks.blank? %>
-      <div class="col-md-6" style="display: flex; max-height: 75px; overflow-y: auto; margin-bottom: 12px">
-        <div style="text-align: right; margin-right: 0.5em">
+      <div class="col-md-6 submission-history">
+        <div class="timestamp-col">
           <% @submissions_time_stamps.each do |t| %>
-            <span class="text-muted small" style="display: inline-block; <%= t.present? ? 'margin-top: 6px;' : '' %>"><%= t %></span>
+            <span class="text-muted small submission-history-row" style="<%= t.present? ? 'margin-top: 6px;' : '' %>"><%= t %></span>
             <br/>
           <% end %>
         </div>
         <div>
           <% @submissions.each_with_index do |s, i| %>
-            <span style="display: inline-block; <%= s.id == submission.id ? 'font-weight: bold;' : '' %> <%= @submissions_time_stamps[i].present? ? ' margin-top: 6px;' : '' %>">
+            <span class="submission-history-row" style="<%= s.id == submission.id ? 'font-weight: bold;' : '' %> <%= @submissions_time_stamps[i].present? ? ' margin-top: 6px;' : '' %>">
               <%= link_to "##{@submissions.length - i}", submission_path(s), style: 'min-width: 24px; display: inline-block; margin-right:6px;' %>
               <span class='status-icon' id="history-<%= s.id %>"><%= submission_status_icon(s, 12) %></span>
               <span>

--- a/app/views/submissions/_description.html.erb
+++ b/app/views/submissions/_description.html.erb
@@ -30,16 +30,42 @@
   </span>
   <div class="row">
     <div class="col-md-6">
-      <span class='status-icon float-start'><%= submission_status_icon(submission, 36) %></span>
+      <span class='status-icon float-start'><%= submission_status_icon(submission, 48) %></span>
       <span class="status-line">
         <%= Submission.human_enum_name(:status, submission.status) %>
         <% if submission.summary.present? and submission.summary.downcase != Submission.human_enum_name(:status, submission.status).downcase %>
-          &middot; <span class='text-muted'><%= submission.summary %></span>
+          <br/><span class='text-muted'><%= submission.summary %></span>
         <% end %>
       </span>
       <span class="by-line">
         <span class="text-muted small" title="<%= l submission.created_at, format: :submission %>"><%= time_ago_in_words submission.created_at %> <%= t "submissions.show.ago" %></span>
       </span>
+    </div>
+    <div class="col-md-6" style="display: flex; max-height: 75px; overflow-y: scroll">
+      <% prev = nil %>
+      <div style="text-align: right; margin-right: 0.5em">
+        <% @submissions.each do |s| %>
+          <% current = s.created_at.before?(1.day.ago) ? (time_ago_in_words s.created_at) + " " + (t "submissions.show.ago") : (t "submissions.show.today")%>
+          <% if current != prev %>
+            <% prev = current %>
+            <span class="text-muted small" title="<%= l s.created_at, format: :submission %>"><%= current %></span>
+          <% end %>
+          <br/>
+        <% end %>
+      </div>
+      <div>
+        <% @submissions.each_with_index do |s, i| %>
+          <%= link_to "##{@submissions.length - i}", submission_path(s), style: 'min-width: 24px; display: inline-block;'  %>
+          <span class='status-icon'><%= submission_status_icon(s, 12) %></span>
+          <span>
+            <%= Submission.human_enum_name(:status, s.status) %>
+            <% if s.summary.present? and s.summary.downcase != Submission.human_enum_name(:status, s.status).downcase %>
+              &middot; <span class='text-muted'><%= s.summary %></span>
+            <% end %>
+          </span>
+          <br/>
+        <% end %>
+      </div>
     </div>
     <div class="col-md-6">
       <% @feedbacks.each do |feedback| %>

--- a/config/locales/views/submissions/en.yml
+++ b/config/locales/views/submissions/en.yml
@@ -33,6 +33,7 @@ en:
       course: Course
       handed_in: Handed in
       ago: ago
+      today: today
       status: Status
       result: Result
       code: Code

--- a/config/locales/views/submissions/nl.yml
+++ b/config/locales/views/submissions/nl.yml
@@ -33,6 +33,7 @@ nl:
       course: Cursus
       handed_in: Ingediend
       ago: geleden
+      today: vandaag
       status: Status
       result: Resultaat
       code: Code


### PR DESCRIPTION
This pull request adds a small submission history table to the submission detail page. This allows for easy navigation to previous submissions. It also gives users a better sense of the progress they are making, visualizing both the total submissions count as well as submission summaries (For example containing diminishing numbers of failing tests).

![Peek 2022-03-11 10-55](https://user-images.githubusercontent.com/21177904/157844484-d2be6306-c8c8-43d1-a25c-38b47cbd9809.gif)

Closes #3469 
Part of #3456 
