### PR TITLE
Color code thumbs up/down in evaluation

### DIFF
--- a/app/assets/stylesheets/components/btn.css.scss
+++ b/app/assets/stylesheets/components/btn.css.scss
@@ -291,3 +291,11 @@ form.button_to {
 .option-btn:hover {
   @include shadow-z4;
 }
+
+.single-zero-button:hover, #zero-button:hover{
+  background-color: $brand-danger;
+}
+
+.single-max-button:hover, #max-button:hover{
+  background-color: $brand-success;
+}


### PR DESCRIPTION
This pull request closes #2715.

I don't have strong opinions on the order of thumbs up or down, but I'm in favor of color coding (thumbs up = green, thumbs down = red) to nudge towards the correct button as @rien suggested. I can switch the order if needed:
https://github.com/dodona-edu/dodona/blob/develop/app/views/feedbacks/_feedback_actions.html.erb
https://github.com/dodona-edu/dodona/blob/develop/app/views/feedbacks/_score_actions.html.erb

![image](https://user-images.githubusercontent.com/56451049/158674135-eaccbe81-cb2f-490e-8773-b28b90eb8ded.png)
![image](https://user-images.githubusercontent.com/56451049/158674215-407c1867-fafa-4554-b4a5-2ac78038557e.png)
![image](https://user-images.githubusercontent.com/56451049/158674676-a20639be-f5dd-4b09-bb5c-a0f7914c7103.png)
![image](https://user-images.githubusercontent.com/56451049/158674720-28687053-b754-43d2-b952-68d38fae3b84.png)