### PR TITLE
Move ddtrace from tracking a branch to latest beta

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -138,8 +138,7 @@ gem 'memory_profiler', '~> 1.0.0'
 gem 'rack-mini-profiler', '~> 3.0.0'
 gem 'stackprof', '~> 0.2.19'
 
-# Datadog temporarily fixed by git pull https://github.com/DataDog/dd-trace-rb/pull/1830 switch to 0.55.0 when available
-gem 'ddtrace', github: 'kbacha/dd-trace-rb', branch: 'fixes-dalli-server-version'
+gem 'ddtrace', '~> 1.0.0.beta1'
 
 # Make sure filesystem changes only happen at the end of a transaction
 gem 'after_commit_everywhere', '~> 1.1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,3 @@
-GIT
-  remote: https://github.com/kbacha/dd-trace-rb.git
-  revision: b55a7bffe184f8e91d5615affb440575bd2ed6af
-  branch: fixes-dalli-server-version
-  specs:
-    ddtrace (1.0.0.dev)
-      debase-ruby_core_source (<= 0.10.14)
-      msgpack
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -142,6 +133,10 @@ GEM
       railties (>= 6.0.0)
     daemons (1.4.1)
     dalli (3.2.1)
+    ddtrace (1.0.0.beta1)
+      debase-ruby_core_source (<= 0.10.14)
+      libddwaf (~> 1.0.14.2.0.a)
+      msgpack
     debase-ruby_core_source (0.10.14)
     delayed_job (4.1.10)
       activesupport (>= 3.0, < 8.0)
@@ -250,6 +245,8 @@ GEM
       addressable (~> 2.7)
     letter_opener (1.7.0)
       launchy (~> 2.2)
+    libddwaf (1.0.14.2.1.beta1)
+      ffi (~> 1.0)
     listen (3.7.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -530,7 +527,7 @@ DEPENDENCIES
   codecov (~> 0.6.0)
   cssbundling-rails (~> 1.1.0)
   dalli (~> 3.2.1)
-  ddtrace!
+  ddtrace (~> 1.0.0.beta1)
   delayed_job_active_record (~> 4.1.7)
   delayed_job_web (~> 1.4.4)
   devise (~> 4.8.1)

--- a/config/initializers/datadog-tracer.rb
+++ b/config/initializers/datadog-tracer.rb
@@ -1,9 +1,8 @@
 if Rails.env.production? || Rails.env.staging?
   Datadog.configure do |c|
-    c.use :rails, service_name: 'dodona'
-    c.use :delayed_job, analytics_enabled: true
-    c.use :dalli
-    c.analytics_enabled = true
+    c.tracing.instrument :rails, service_name: 'dodona'
+    c.tracing.instrument :delayed_job
+    c.tracing.instrument :dalli
     c.version = Dodona::Application::VERSION
   end
 end


### PR DESCRIPTION
The move to the branch was made necessary by ruby 3.0, but the PR was merged and a release was cut since then.