### PR TITLE
Hide submissions tab at start

### DIFF
--- a/app/assets/javascripts/exercise.js
+++ b/app/assets/javascripts/exercise.js
@@ -349,6 +349,7 @@ function initExerciseShow(exerciseId, programmingLanguage, loggedIn, editorShown
             url += `&course_id=${data.course_id}`;
         }
         $.get(url);
+        $("#activity-submission-link").removeClass("hidden")
         $("#activity-submission-link").tab("show");
     }
 

--- a/app/assets/javascripts/exercise.js
+++ b/app/assets/javascripts/exercise.js
@@ -349,7 +349,7 @@ function initExerciseShow(exerciseId, programmingLanguage, loggedIn, editorShown
             url += `&course_id=${data.course_id}`;
         }
         $.get(url);
-        $("#activity-submission-link").removeClass("hidden")
+        $("#activity-submission-link").removeClass("hidden");
         $("#activity-submission-link").tab("show");
     }
 

--- a/app/views/activities/show.html.erb
+++ b/app/views/activities/show.html.erb
@@ -89,9 +89,11 @@ end %>
           <% if policy(@activity).submit? || !user_signed_in? %>
             <li><a href="#handin" id="activity-handin-link" data-bs-toggle="tab" class="active"><%= t ".handin" %></a></li>
           <% end %>
-          <% if @activity.submissions.count > 0 %>
-            <li><a href="#submissions" data-bs-toggle="tab" id='activity-submission-link' class="<%= 'active' if !(policy(@activity).submit? || !user_signed_in?) %>"><%= t ".solutions" %></a></li>
-          <% end %>
+          <li>
+            <a href="#submissions" data-bs-toggle="tab" id='activity-submission-link' class="<%= 'active' if !(policy(@activity).submit? || !user_signed_in?) %><%= 'hidden' if @activity.submissions.count == 0  %>">
+              <%= t ".solutions" %>
+            </a>
+          </li>
           <li><a href="#feedback" data-bs-toggle="tab" id='activity-feedback-link' class='hidden'><%= t ".feedback" %></a>
           </li>
         </ul>

--- a/app/views/activities/show.html.erb
+++ b/app/views/activities/show.html.erb
@@ -89,8 +89,9 @@ end %>
           <% if policy(@activity).submit? || !user_signed_in? %>
             <li><a href="#handin" id="activity-handin-link" data-bs-toggle="tab" class="active"><%= t ".handin" %></a></li>
           <% end %>
-          <li>
-            <a href="#submissions" data-bs-toggle="tab" id='activity-submission-link' class="<%= 'active' if !(policy(@activity).submit? || !user_signed_in?) %>"><%= t ".solutions" %></a></li>
+          <% if @activity.submissions.count > 0 %>
+            <li><a href="#submissions" data-bs-toggle="tab" id='activity-submission-link' class="<%= 'active' if !(policy(@activity).submit? || !user_signed_in?) %>"><%= t ".solutions" %></a></li>
+          <% end %>
           <li><a href="#feedback" data-bs-toggle="tab" id='activity-feedback-link' class='hidden'><%= t ".feedback" %></a>
           </li>
         </ul>


### PR DESCRIPTION
This pull request makes the difference clear between new and already made exercises.

The number of submission doesn't matter that much, so I didn't add a badge. It doesn't look as clean with a badge too. The "fetch latest submission" feature might be something for the Dodona extension/plugin (https://github.com/thepieterdc/dodona-plugin-vscode/issues/92).

https://user-images.githubusercontent.com/56451049/162568798-03528795-ecdf-4781-a19d-1d9209acd2e6.mp4

*Ignore the internal error and submission link icon in this video.*

Closes #2886.