### PR TITLE
Improve toast accessibility

### DIFF
--- a/app/assets/javascripts/toast.ts
+++ b/app/assets/javascripts/toast.ts
@@ -35,7 +35,7 @@ export class Toast {
 
     private generateToastHTML(content: string, loading: boolean): Element {
         const element = this.htmlToElement(
-            `<div class='toast toast-show'>${content}</div>`
+            `<output role='status' class='toast toast-show'>${content}</output>`
         );
         if (loading) {
             element.appendChild(this.htmlToElement("<div class='spinner'></div>"));

--- a/app/assets/stylesheets/components/toast.css.scss
+++ b/app/assets/stylesheets/components/toast.css.scss
@@ -3,6 +3,7 @@
   left: 24px;
   position: fixed;
   z-index: 1000;
+  pointer-events: none;
 }
 
 .toasts .toast {

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -86,7 +86,7 @@
     <%= render 'layouts/drawer' %>
   <% end %>
   <%= render 'layouts/main_container' %>
-  <div class="toasts"></div>
+  <section class="toasts"></section>
   <%= render 'layouts/footer' %>
 </div>
 <script>

--- a/app/views/layouts/lti.html.erb
+++ b/app/views/layouts/lti.html.erb
@@ -40,7 +40,7 @@
 </head>
 <body>
 <%= render 'layouts/main_container' %>
-<div class="toasts"></div>
+<section class="toasts"></section>
 <script>
     I18n = I18n || {};
     I18n.locale = "<%= I18n.locale %>";

--- a/test/javascript/toast.test.ts
+++ b/test/javascript/toast.test.ts
@@ -2,7 +2,7 @@ import { Toast } from "../../app/assets/javascripts/toast";
 
 beforeEach(() => {
     jest.useFakeTimers();
-    document.body.innerHTML = "<div class='toasts'></div>";
+    document.body.innerHTML = "<section class='toasts'></section>";
 });
 
 test("create toast with default settings", () => {


### PR DESCRIPTION
This pull request improves the accessibility of toast messages based on the tips in https://web.dev/building-a-toast-component/

Changes:
- use a `section` instead of a `div` as toast container
- use `output` instead of `div` for individual toasts
- add status role
- disable pointer events for the container to prevent (accidental) text selection
