### PR TITLE
Improve UI of summary row on series status overview

### DIFF
--- a/app/views/series/_scoresheet_table.html.erb
+++ b/app/views/series/_scoresheet_table.html.erb
@@ -10,7 +10,7 @@
     </thead>
     <tbody>
     <tr class="summary-row">
-      <td class="user-name ellipsis-overflow"><%= t('series.scoresheet.users', :count => users.length) %></td>
+      <td class="user-name ellipsis-overflow"><%= t('series.scoresheet.users', count: users.length) %></td>
       <% activities.each do |activity| %>
         <% if activity.exercise? %>
           <td class="status">

--- a/app/views/series/_scoresheet_table.html.erb
+++ b/app/views/series/_scoresheet_table.html.erb
@@ -10,15 +10,22 @@
     </thead>
     <tbody>
     <tr class="summary-row">
-      <td class="user-name ellipsis-overflow"><%= users.length %></td>
+      <td class="user-name ellipsis-overflow"><%= t('series.scoresheet.users', :count => users.length) %></td>
       <% activities.each do |activity| %>
         <% if activity.exercise? %>
           <td class="status">
+            <% i = 0 %>
             <% statuses.each do |status| %>
               <% count = submission_counts[[activity.id, status]] %>
               <% if count > 0 %>
-                <%= count %>
-                <%= status_icon(status, 12) %>
+                <% if i > 0 %>
+                  &middot;
+                <% end %>
+                <% i += 1 %>
+                <span data-bs-toggle="tooltip" title="<%= count %> <%= Submission.human_enum_name(:status, status) %>">
+                  <%= count %>
+                  <%= status_icon(status, 12) %>
+                </span>
               <% else %>
               <% end %>
             <% end %>

--- a/config/locales/views/series/en.yml
+++ b/config/locales/views/series/en.yml
@@ -61,6 +61,10 @@ en:
       course_view: Course scoresheet
       select_view: Select view
       status: "Status %{activity}"
+      users:
+        zero: No users
+        one: 1 user
+        other: "%{count} users"
     series_status:
       completed_after_deadline_missed: You completed all learning activities, but unfortunately not before the deadline.
       wrong_after_deadline_missed: You missed the deadline, and there are still incorrect exercises.

--- a/config/locales/views/series/nl.yml
+++ b/config/locales/views/series/nl.yml
@@ -61,6 +61,10 @@ nl:
       course_view: Statusoverzicht van cursus
       select_view: Weergave selecteren
       status: "Status %{activity}"
+      users:
+        zero: Geen gebruikers
+        one: 1 gebruiker
+        other: "%{count} gebruikers"
     overview:
       progress: '%{solved} van de %{count} opgelost'
     series_status:


### PR DESCRIPTION
This pull request improves the UI of the summary row on series status overview.

It adds a mid dot separator:
![image](https://user-images.githubusercontent.com/21177904/164403787-14858bdf-3cec-4632-acc8-10af879c6e53.png)

Tooltips:
![image](https://user-images.githubusercontent.com/21177904/164403877-241f3167-39a3-4db7-ae1c-e66e11cd0159.png)

And adds context to the number in the users collumn:
![image](https://user-images.githubusercontent.com/21177904/164404121-f3364c1d-10af-42d4-8848-4d6fb082f7f9.png)

