### PR TITLE
Make sure inputServiceWorker.js can be served in production

### DIFF
--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -2,6 +2,8 @@ class ActivitiesController < ApplicationController
   include SeriesHelper
   include SetLtiMessage
 
+  INPUT_SERVICE_WORKER = 'inputServiceWorker.js'.freeze
+
   before_action :set_activity, only: %i[show description edit update media info]
   before_action :set_course, only: %i[show edit update media info]
   before_action :set_series, only: %i[show edit update info]
@@ -204,7 +206,8 @@ class ActivitiesController < ApplicationController
   # Asset has been preprocessed and built internally
   # Redirecting to the asset is not possible due to browser security policy
   def input_service_worker
-    send_file(Rails.application.assets['inputServiceWorker.js'].filename,
+    assets = Rails.application.assets || Rails.application.assets_manifest.assets
+    send_file(assets[INPUT_SERVICE_WORKER].filename,
               filename: 'inputServiceWorker.js',
               type: 'text/javascript')
   end

--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -2,8 +2,6 @@ class ActivitiesController < ApplicationController
   include SeriesHelper
   include SetLtiMessage
 
-  INPUT_SERVICE_WORKER = 'inputServiceWorker.js'.freeze
-
   before_action :set_activity, only: %i[show description edit update media info]
   before_action :set_course, only: %i[show edit update media info]
   before_action :set_series, only: %i[show edit update info]
@@ -207,7 +205,7 @@ class ActivitiesController < ApplicationController
   # Redirecting to the asset is not possible due to browser security policy
   def input_service_worker
     assets = Rails.application.assets || Rails.application.assets_manifest.assets
-    send_file(assets[INPUT_SERVICE_WORKER].filename,
+    send_file(assets['inputServiceWorker.js'].filename,
               filename: 'inputServiceWorker.js',
               type: 'text/javascript')
   end


### PR DESCRIPTION
This pull request tries to fix the asset resolution problem for the input service worker by choosing the correct assets in any environment.
