### PR TITLE
Remove Cross-Origin headers to fix loading of external resources in exercise descriptions

### DIFF
--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -113,26 +113,10 @@ class ActivitiesController < ApplicationController
 
     @title = @activity.name
     @crumbs << [@activity.name, '#']
-
-    return unless @activity.exercise?
-
-    # Enable SharedArrayBuffers on exercise pages
-    response.set_header 'Cross-Origin-Opener-Policy', 'same-origin'
-    response.set_header 'Cross-Origin-Embedder-Policy', 'require-corp'
   end
 
   def description
     raise Pundit::NotAuthorizedError, 'Not allowed' unless @activity.access_token == params[:token]
-
-    if @activity.exercise?
-      # CORP, allow sandbox to fetch from dodona
-      response.set_header 'Cross-Origin-Resource-Policy', 'cross-origin'
-      # COEP, allow sandbox to work with Papyros present
-      response.set_header 'Cross-Origin-Embedder-Policy', 'require-corp'
-      # Potential future improvement for iframes? https://github.com/camillelamy/explainers/blob/main/anonymous_iframes.md
-      # Limit allowed origins to prevent abuse of CORP header
-      response.set_header 'Access-Control-Allow-Origin', "#{Rails.configuration.sandbox_host} #{Rails.configuration.default_host}"
-    end
 
     render layout: 'frame'
   end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,22 +1,5 @@
 require "active_support/core_ext/integer/time"
 
-# Middleware to add required headers to assets
-class AssetHeaders
-  # Source: https://gist.github.com/ryanb/4157256
-  def initialize(app)
-    @app = app
-  end
-
-  def call(env)
-    request = Rack::Request.new(env)
-    response = @app.call(env)
-    if request.path =~ /^\/assets\//
-      response[1]['Cross-Origin-Resource-Policy'] = 'cross-origin'
-    end
-    response
-  end
-end
-
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
@@ -118,9 +101,6 @@ Rails.application.configure do
 
   # Annotate rendered view with file names.
   # config.action_view.annotate_rendered_view_with_filenames = true
-
-  # Use correct headers on /assets
-  config.middleware.use AssetHeaders
 
   # Regenerate js translation files
   config.middleware.use I18n::JS::Middleware


### PR DESCRIPTION
This pull request removes the headers that enabled SharedArrayBuffers on exercise pages, as they interfere with already existing functionality. This means Papyros will always use the service worker to handle input.

Closes #3572 .
