### PR TITLE
Add sortbuttons to submissions table

### DIFF
--- a/app/assets/javascripts/components/sort_button.ts
+++ b/app/assets/javascripts/components/sort_button.ts
@@ -1,0 +1,148 @@
+import "search.ts";
+import { css, html, LitElement, TemplateResult } from "lit";
+import { customElement, property } from "lit/decorators.js";
+import { searchQuery } from "search";
+
+export class SortQuery {
+    active_column: string;
+    ascending: boolean;
+    listeners: Array<(c: string, a: boolean) => void> = [];
+
+    constructor() {
+        const sortParams = [...searchQuery.queryParams.params.entries()].filter(
+            ([k, v]) => k.startsWith("order_by_") && (v === "ASC" || v === "DESC")
+        );
+
+        if (sortParams.length > 0) {
+            this.active_column = sortParams[0][0].substring(9);
+            this.ascending = sortParams[0][1] === "ASC";
+            sortParams.slice(1).forEach(([k, _]) => {
+                searchQuery.queryParams.updateParam(k, undefined);
+            });
+        }
+        searchQuery.queryParams.subscribe((k, o, n) => {
+            if (
+                k.startsWith("order_by_") &&
+                !(k === this.getQueryKey() && n === this.getQueryValue()) &&
+                (n === "ASC" || n === "DESC")
+            ) {
+                this.active_column = k.substring(9);
+                this.ascending = n === "ASC";
+                this.notify();
+            }
+        });
+    }
+
+    getQueryKey(): string {
+        return "order_by_" + this.active_column;
+    }
+
+    getQueryValue(): string {
+        return this.ascending ? "ASC" : "DESC";
+    }
+
+    subscribe(listener: (c: string, a: boolean) => void): void {
+        this.listeners.push(listener);
+    }
+
+    notify(): void {
+        this.listeners.forEach(f => f(this.active_column, this.ascending));
+    }
+
+    sortBy(column: string, ascending: boolean): void {
+        if (this.active_column === column && this.ascending === ascending) {
+            return;
+        }
+
+        if (this.active_column !== column) {
+            searchQuery.queryParams.updateParam(this.getQueryKey(), undefined);
+            this.active_column = column;
+        }
+        this.ascending = ascending;
+        this.notify();
+        if (this.active_column) {
+            searchQuery.queryParams.updateParam(this.getQueryKey(), this.getQueryValue());
+        }
+    }
+}
+export const sortQuery = new SortQuery();
+
+@customElement("dodona-sort-button")
+export class SortButton extends LitElement {
+    @property({ type: String })
+    column: string;
+
+    active_column: string;
+    ascending: boolean;
+
+    static styles = css`
+        :host {
+            cursor: pointer;
+        }
+        .mdi::before {
+            display: inline-block;
+            font: normal normal normal 24px/1 "Material Design Icons";
+            text-rendering: auto;
+            box-sizing: border-box;
+            line-height: 18px;
+            font-size: 16px;
+        }
+        .mdi-none::before {
+          display: none;
+        }
+        :host(:hover) .mdi-none::before {
+            opacity: 0.7;
+            display: inline-block;
+            content: "\\F0045";
+        }
+        .mdi-arrow-down::before {
+          content: "\\F0045";
+        }
+        :host(:hover) .mdi-arrow-down::before {
+            opacity: 0.7;
+            content: "\\F005D";
+        }
+        .mdi-arrow-up::before {
+          content: "\\F005D";
+        }
+        :host(:hover) .mdi-arrow-up::before {
+            visibility: hidden;
+        }
+    `;
+
+    isActive(): boolean {
+        return this.column === this.active_column;
+    }
+
+    getSortIcon(): string {
+        return this.isActive() ? this.ascending ? "arrow-down" : "arrow-up" : "none";
+    }
+
+    sort(): void {
+        if (!this.isActive()) {
+            sortQuery.sortBy(this.column, true);
+        } else if (this.ascending) {
+            sortQuery.sortBy(this.column, false);
+        } else {
+            sortQuery.sortBy(undefined, undefined);
+        }
+    }
+
+    constructor() {
+        super();
+        this.ascending = sortQuery.ascending;
+        this.active_column = sortQuery.active_column;
+        sortQuery.subscribe((c, a) => {
+            this.active_column = c;
+            this.ascending = a;
+        });
+        this.addEventListener("click", () => this.sort());
+    }
+
+    render(): TemplateResult {
+        return html`
+            <i class="mdi mdi-${this.getSortIcon()}"></i>
+            <slot></slot>
+        `;
+    }
+}

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -21,6 +21,11 @@ class SubmissionsController < ApplicationController
     end
   end
 
+  has_scope :order_by_user
+  has_scope :order_by_exercise
+  has_scope :order_by_created_at
+  has_scope :order_by_status
+
   content_security_policy only: %i[show] do |policy|
     # allow sandboxed tutor
     policy.frame_src -> { [sandbox_url] }

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -98,6 +98,11 @@ class Submission < ApplicationRecord
     correct.group(:exercise_id, :user_id).least_recent
   }
 
+  scope :order_by_user, ->(direction) { includes(:user).reorder 'users.first_name': direction, 'users.last_name': direction, id: :desc }
+  scope :order_by_exercise, ->(direction) { includes(:exercise).reorder "activities.name_#{I18n.locale}": direction, id: :desc }
+  scope :order_by_created_at, ->(direction) { reorder created_at: direction, id: :desc }
+  scope :order_by_status, ->(direction) { reorder status: direction, id: :desc }
+
   def initialize(params)
     raise 'please explicitly tell whether you want to evaluate this submission' unless params.key? :evaluate
 

--- a/app/views/submissions/_submissions_table.html.erb
+++ b/app/views/submissions/_submissions_table.html.erb
@@ -5,13 +5,13 @@
       <th class="status-column"></th>
       <th></th>
       <% if user.nil? && (current_user.admin? || current_user.administrating_courses.any?) %>
-        <th><%= t ".user" %></th>
+        <th><dodona-sort-button column="user"><%= t ".user" %></dodona-sort-button></th>
       <% end %>
       <% unless exercise.present? %>
-        <th><%= t ".exercise" %></th>
+        <th><dodona-sort-button column="exercise"><%= t ".exercise" %></dodona-sort-button></th>
       <% end %>
-      <th><%= t ".time" %></th>
-      <th><%= t ".status" %></th>
+      <th><dodona-sort-button column="created_at"><%= t ".time" %></dodona-sort-button></th>
+      <th><dodona-sort-button column="status"><%= t ".status" %></dodona-sort-button></th>
       <th><%= t ".summary" %></th>
       <th></th>
     </tr>

--- a/test/models/submission_test.rb
+++ b/test/models/submission_test.rb
@@ -325,6 +325,54 @@ class SubmissionTest < ActiveSupport::TestCase
     end
   end
 
+  test 'Should be able to order submissions by user' do
+    first = create :submission, user: create(:user, first_name: 'Antoon', last_name: 'Adams')
+    third = create :submission, user: create(:user, first_name: 'Bart', last_name: 'Adams')
+    second = create :submission, user: create(:user, first_name: 'Antoon', last_name: 'Bettens')
+
+    assert_equal second.id, Submission.first&.id
+    assert_equal first.id, Submission.order_by_user('ASC').first&.id
+    assert_equal third.id, Submission.order_by_user('DESC').first&.id
+  end
+
+  test 'Should be able to order submissions by exercise' do
+    first = create :submission, exercise: create(:exercise, name_nl: 'Oefening A', name_en: 'Activity C')
+    third = create :submission, exercise: create(:exercise, name_nl: 'Oefening C', name_en: 'Activity A')
+    second = create :submission, exercise: create(:exercise, name_nl: 'Oefening B', name_en: 'Activity B')
+
+    I18n.with_locale :nl do
+      assert_equal second.id, Submission.first&.id
+      assert_equal first.id, Submission.order_by_exercise('ASC').first&.id
+      assert_equal third.id, Submission.order_by_exercise('DESC').first&.id
+    end
+
+    I18n.with_locale :en do
+      assert_equal second.id, Submission.first&.id
+      assert_equal third.id, Submission.order_by_exercise('ASC').first&.id
+      assert_equal first.id, Submission.order_by_exercise('DESC').first&.id
+    end
+  end
+
+  test 'Should be able to order submissions by created_at' do
+    first = create :submission, created_at: 3.days.ago
+    third = create :submission, created_at: 1.day.ago
+    second = create :submission, created_at: 2.days.ago
+
+    assert_equal second.id, Submission.first&.id
+    assert_equal first.id, Submission.order_by_created_at('ASC').first&.id
+    assert_equal third.id, Submission.order_by_created_at('DESC').first&.id
+  end
+
+  test 'Should be able to order submissions by status' do
+    first = create :submission, status: :correct
+    third = create :submission, status: :running
+    second = create :submission, status: :wrong
+
+    assert_equal second.id, Submission.first&.id
+    assert_equal first.id, Submission.order_by_status('ASC').first&.id
+    assert_equal third.id, Submission.order_by_status('DESC').first&.id
+  end
+
   class StatisticsTest < ActiveSupport::TestCase
     setup do
       @date = DateTime.new(1302, 7, 11, 13, 37, 42)


### PR DESCRIPTION
# Sort buttons
Interacting with this new system I made a new component that represents a sort button that can be used in table headers.
All buttons interact with a single state class `SortQuery`, which make sure only one sort column and direction is active any time and which itself interacts with  `SearchQuery` to provide the relevant sort param.

These sort params are handled in the backend by scopes defined in the controller and the model.

This pr only contains such scopes for submissions as an example, leaving further additions of such sort scopes to other models for a future pr. (This pr is already overloaded as is).

- [x] Added tests for sorting

https://user-images.githubusercontent.com/21177904/165749398-acfb1ef3-788a-4f01-90d3-2a8e47b9b4af.mp4

Closes # .
