### PR TITLE
Remove first-input-delay package

### DIFF
--- a/app/assets/javascripts/application_old.js
+++ b/app/assets/javascripts/application_old.js
@@ -20,5 +20,3 @@
 
 //= require bootstrap-tokenfield
 //= require typeahead.js/dist/typeahead.bundle.js
-
-//= require first-input-delay/dist/first-input-delay.min.js

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "core-js": "^3.22.3",
     "d3": "^7.4.4",
     "dragula": "^3.7.3",
-    "first-input-delay": "^0.1.3",
     "flatpickr": "^4.6.13",
     "glightbox": "^3.2.0",
     "glob": "^8.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3688,11 +3688,6 @@ find-up@^4.0.0, find-up@^4.1.0:
     locate-path "^5.0.0"
     path-exists "^4.0.0"
 
-first-input-delay@^0.1.3:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/first-input-delay/-/first-input-delay-0.1.3.tgz#5506fb95a9537ba9706096b9c159bfd3f38f6f62"
-  integrity sha512-hZ1mI+BWYIBr8jlp2bDPnRvnmSICBxpZRwdc0nhiQn2uyMxSKZEBbkO8V0/s26AMeX8p/AD4g09+liRrhXvKKQ==
-
 flat-cache@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-3.0.4.tgz#61b0338302b2fe9f957dcc32fc2a87f1c3048b11"


### PR DESCRIPTION
This pull request removes the first-input-delay npm package. It was added for firebase performance measuring which was removed a long time ago.