### PR TITLE
Prevent closing Papyros when pressing Escape

### DIFF
--- a/app/views/activities/_coding_scratchpad.html.erb
+++ b/app/views/activities/_coding_scratchpad.html.erb
@@ -6,7 +6,7 @@
 data-bs-target="#scratchpad-offcanvas" aria-controls="scratchpad-offcanvas" id="scratchpad-offcanvas-show-btn">
     <%= t '.start_coding' %>
 </button>
-<div class="offcanvas offcanvas-end" tabindex="-1" id="scratchpad-offcanvas">
+<div class="offcanvas offcanvas-end" tabindex="-1" id="scratchpad-offcanvas" data-bs-keyboard="false">
     <div class="scratchpad-header">
         <h4>
             <%= activity_icon(@activity, 24) %>


### PR DESCRIPTION
This pull request prevents the offcanvas component from being closed when the user presses Escape. This ensures pressing Escape when trying to hide autocompletion results will not annoy the user.

Closes https://github.com/dodona-edu/papyros/issues/161 .
