### PR TITLE
Add summary row to course scoresheets

### DIFF
--- a/app/assets/javascripts/components/histogram.ts
+++ b/app/assets/javascripts/components/histogram.ts
@@ -12,11 +12,12 @@ export class Histogram extends LitElement {
             align-items: flex-end;
             height: 100%;
             width: 100%;
+            border-bottom: 1px solid var(--dod-histo-axis, lightgray);
         }
         .bar {
             display: inline-block;
-            background: var(--bs-blue);
             width: 100%;
+            background: var(--dod-histo-bar, steelblue);
         }
     `;
 

--- a/app/assets/javascripts/components/histogram.ts
+++ b/app/assets/javascripts/components/histogram.ts
@@ -1,0 +1,39 @@
+import { css, html, LitElement, TemplateResult } from "lit";
+import { customElement, property } from "lit/decorators.js";
+
+@customElement("dodona-histogram")
+export class Histogram extends LitElement {
+    @property({ type: Array })
+    values: number[];
+
+    static styles = css`
+        :host {
+            display: flex;
+            align-items: flex-end;
+            height: 100%;
+            width: 100%;
+        }
+        .bar {
+            display: inline-block;
+            background: var(--bs-blue);
+            width: 100%;
+        }
+    `;
+
+    getHeight(value: number): number {
+        const max = Math.max(...this.values);
+        return 100 * value / max;
+    }
+
+    renderRow(value: number, index: number): TemplateResult {
+        return html`<div
+            class="bar"
+            style="height: ${this.getHeight(value)}%"
+            title="${index}: ${value}">
+            </div>`;
+    }
+
+    render(): TemplateResult[] {
+        return this.values.map((v, i) => this.renderRow(v, i));
+    }
+}

--- a/app/assets/stylesheets/components.css.scss
+++ b/app/assets/stylesheets/components.css.scss
@@ -6,6 +6,7 @@
 @import "components/evaluations.css.scss";
 @import "components/favorite.css.scss";
 @import "components/heatmap.css.scss";
+@import "components/histogram.css.scss";
 @import "components/img.css.scss";
 @import "components/link.css.scss";
 @import "components/modal.css.scss";

--- a/app/assets/stylesheets/components/histogram.css.scss
+++ b/app/assets/stylesheets/components/histogram.css.scss
@@ -1,0 +1,4 @@
+dodona-histogram {
+  --dod-histo-axis: #{$hairlinegray};
+  --dod-histo-bar: #{$primary-700};
+}

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -221,6 +221,11 @@ class CoursesController < ApplicationController
       @users = apply_scopes(scores[:users])
       @series = scores[:series]
       @hash = scores[:hash]
+
+      @total = Hash.new(0)
+      @hash.each_with_object(@total) do |(key, val), total|
+        total[key[1]] += val[:accepted]
+      end
     end
 
     respond_to do |format|

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -220,11 +220,14 @@ class CoursesController < ApplicationController
       scores = @course.scoresheet
       @users = apply_scopes(scores[:users])
       @series = scores[:series]
+
+      # this maps a [user_id, series_id] tuple to an object containing the number of accepted and started exercises
       @hash = scores[:hash]
 
-      @total = Hash.new(0)
-      @hash.each_with_object(@total) do |(key, val), total|
-        total[key[1]] += val[:accepted]
+      @histogram = {}
+      @series.each { |s| @histogram[s.id] = Array.new(s.activity_count + 1, 0) }
+      @hash.each do |(_, series_id), val|
+        @histogram[series_id][val[:accepted]] += 1
       end
     end
 

--- a/app/javascript/packs/scoresheet.js
+++ b/app/javascript/packs/scoresheet.js
@@ -1,3 +1,5 @@
 import { initScoresheetLinks } from "scoresheet";
 
+import "components/histogram.ts";
+
 window.dodona.initScoresheetLinks = initScoresheetLinks;

--- a/app/views/courses/_scoresheet_table.html.erb
+++ b/app/views/courses/_scoresheet_table.html.erb
@@ -11,6 +11,12 @@
     </tr>
     </thead>
     <tbody>
+    <tr class="summary-row">
+      <td class="user-name ellipsis-overflow"><%= t('series.scoresheet.users', count: users.length) %></td>
+      <% series.each do |s| %>
+        <td class="status" ><%= total[s.id] %></td>
+      <% end %>
+    </tr>
     <% users.each do |student| %>
       <tr>
         <td class="user-name ellipsis-overflow"><%= link_to student.full_name, course_member_path(course, student), title: student.full_name, class: "ellipsis-overflow" %></td>

--- a/app/views/courses/_scoresheet_table.html.erb
+++ b/app/views/courses/_scoresheet_table.html.erb
@@ -14,7 +14,7 @@
     <tr class="summary-row">
       <td class="user-name ellipsis-overflow"><%= t('series.scoresheet.users', count: users.length) %></td>
       <% series.each do |s| %>
-        <td class="status" ><%= total[s.id] %></td>
+        <td class="status" ><dodona-histogram values="<%= histogram[s.id] %>"></dodona-histogram></td>
       <% end %>
     </tr>
     <% users.each do |student| %>

--- a/app/views/courses/scoresheet.js.erb
+++ b/app/views/courses/scoresheet.js.erb
@@ -1,1 +1,1 @@
-$("#scoresheet-table-wrapper").html("<%= escape_javascript(render partial: 'scoresheet_table', locals: {course: @course, series: @series, users: @users, hash: @hash, total: @total}) %>")
+$("#scoresheet-table-wrapper").html("<%= escape_javascript(render partial: 'scoresheet_table', locals: {course: @course, series: @series, users: @users, hash: @hash, histogram: @histogram}) %>")

--- a/app/views/courses/scoresheet.js.erb
+++ b/app/views/courses/scoresheet.js.erb
@@ -1,1 +1,1 @@
-$("#scoresheet-table-wrapper").html("<%= escape_javascript(render partial: 'scoresheet_table', locals: {course: @course, series: @series, users: @users, hash: @hash}) %>")
+$("#scoresheet-table-wrapper").html("<%= escape_javascript(render partial: 'scoresheet_table', locals: {course: @course, series: @series, users: @users, hash: @hash, total: @total}) %>")


### PR DESCRIPTION
This pull request adds a summary row to course scoresheets. The summary contains the count of the users and the sum of the solved exercise per user for each series.

![image](https://user-images.githubusercontent.com/21177904/169492057-6eead6e7-be16-4026-9e9d-90cdad92000e.png)

