### PR TITLE
Prevent Papyros CSS from overwriting our own styles

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@babel/plugin-transform-runtime": "^7.17.10",
     "@babel/preset-env": "^7.17.10",
     "@babel/preset-typescript": "^7.16.7",
-    "@dodona/papyros": "^0.3.7-scoped",
+    "@dodona/papyros": "^0.3.8",
     "@popperjs/core": "^2.11.5",
     "@rails/activestorage": "^7.0.3",
     "@rails/ujs": "^7.0.3",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@babel/plugin-transform-runtime": "^7.17.10",
     "@babel/preset-env": "^7.17.10",
     "@babel/preset-typescript": "^7.16.7",
-    "@dodona/papyros": "^0.3.6",
+    "@dodona/papyros": "^0.3.7-scoped",
     "@popperjs/core": "^2.11.5",
     "@rails/activestorage": "^7.0.3",
     "@rails/ujs": "^7.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1068,10 +1068,10 @@
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz#1d572bfbbe14b7704e0ba0f39b74815b84870d70"
   integrity sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==
 
-"@dodona/papyros@^0.3.7-scoped":
-  version "0.3.7-scoped"
-  resolved "https://registry.yarnpkg.com/@dodona/papyros/-/papyros-0.3.7-scoped.tgz#8a3c1471bcb6755cd9f947e3042e3bd4680c2da3"
-  integrity sha512-WhAYwSjJ7QFXdDPBcx47azdGM6OFXA36K4LJxrP18f8ZRkWGuFn8AsDx1MWw7Ejoe1MciRIUvxceZ5O4fxCIuQ==
+"@dodona/papyros@^0.3.8":
+  version "0.3.8"
+  resolved "https://registry.yarnpkg.com/@dodona/papyros/-/papyros-0.3.8.tgz#6e40ba27a99d9a976010bec77280bfcb85f416c4"
+  integrity sha512-Q3QVuW00mJL4Peg6Ct9shPHJ9M3pnQgc08Itp6nvzse5eWC3UQzSTYYDtv9VPYWlXuMrTNByAv0Zj/I6bSHdOQ==
   dependencies:
     "@codemirror/autocomplete" "^0.20.0"
     "@codemirror/commands" "^0.20.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1068,10 +1068,10 @@
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz#1d572bfbbe14b7704e0ba0f39b74815b84870d70"
   integrity sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==
 
-"@dodona/papyros@^0.3.6":
-  version "0.3.6"
-  resolved "https://registry.yarnpkg.com/@dodona/papyros/-/papyros-0.3.6.tgz#b9bfb3bb52546a2bae0b9f27fb665014c118fa53"
-  integrity sha512-SRgC4Cv+nnuq0+X0p+7pToJDPYtSX1WoR4KL4Xz8/8/Hqk+R0//CbnT07VQuQDOqL7imknlqZat4cGtQLczLDw==
+"@dodona/papyros@^0.3.7-scoped":
+  version "0.3.7-scoped"
+  resolved "https://registry.yarnpkg.com/@dodona/papyros/-/papyros-0.3.7-scoped.tgz#8a3c1471bcb6755cd9f947e3042e3bd4680c2da3"
+  integrity sha512-WhAYwSjJ7QFXdDPBcx47azdGM6OFXA36K4LJxrP18f8ZRkWGuFn8AsDx1MWw7Ejoe1MciRIUvxceZ5O4fxCIuQ==
   dependencies:
     "@codemirror/autocomplete" "^0.20.0"
     "@codemirror/commands" "^0.20.0"


### PR DESCRIPTION
This pull request removes the impact Tailwind css had on other parts of the pages where it was included.
![layout](https://user-images.githubusercontent.com/53743234/169656527-b848b4eb-ec9b-40e4-a05a-636fcc5d7a0f.png)

In order to deploy to Naos, I also had to set strscan to 3.0.1, otherwise deployment failed.
Closes #3638 .
