### PR TITLE
Fix sorting by activity read states for series and course scoresheet

### DIFF
--- a/app/controllers/series_controller.rb
+++ b/app/controllers/series_controller.rb
@@ -23,8 +23,14 @@ class SeriesController < ApplicationController
       else
         series = Series.find(controller.params[:id])
         if series.activities.exists? id: column
-          exercise = series.activities.find(column)
-          scope.order_by_exercise_submission_status_in_series(direction, exercise, series)
+          activity = series.activities.find(column)
+          if activity.exercise?
+            scope.order_by_exercise_submission_status_in_series direction, activity, series
+          elsif activity.content_page?
+            scope.order_by_activity_read_state_in_series direction, activity, series
+          else
+            scope
+          end
         else
           scope
         end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -145,9 +145,13 @@ class User < ApplicationRecord
   scope :order_by_solved_exercises_in_series, lambda { |direction, series|
     submissions = Submission.in_series(series)
     submissions = submissions.before_deadline(series.deadline) if series.deadline.present?
-    submissions = submissions.group(:user_id, :exercise_id).most_recent.correct.group(:user_id).select(:user_id, 'COUNT(*) AS count')
-    joins("LEFT JOIN (#{submissions.to_sql}) submissions ON submissions.user_id = users.id")
-      .reorder 'submissions.count': direction
+    submissions = submissions.group(:user_id, :exercise_id).most_recent.correct.select(:user_id)
+    read_states = ActivityReadState.in_series(series)
+    read_states = read_states.before_deadline(series.deadline) if series.deadline.present?
+    read_states = read_states.select(:user_id)
+    combined_sql = "(SELECT user_id, COUNT(*) AS count FROM ((#{read_states.to_sql}) UNION ALL (#{submissions.to_sql})) AS c GROUP BY user_id)"
+    joins("LEFT JOIN #{combined_sql} c ON c.user_id = users.id")
+      .reorder 'c.count': direction
   }
   scope :order_by_progress, lambda { |direction, course = nil|
     submissions = Submission.judged

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -142,6 +142,12 @@ class User < ApplicationRecord
     joins("LEFT JOIN (#{submissions.to_sql}) submissions ON submissions.user_id = users.id")
       .reorder 'submissions.status': direction
   }
+  scope :order_by_activity_read_state_in_series, lambda { |direction, content_page, series|
+    read_states = ActivityReadState.in_series(series).of_content_page(content_page)
+    read_states = read_states.before_deadline(series.deadline) if series.deadline.present?
+    joins("LEFT JOIN (#{read_states.to_sql}) read_states ON read_states.user_id = users.id")
+      .reorder 'read_states.id': direction
+  }
   scope :order_by_solved_exercises_in_series, lambda { |direction, series|
     submissions = Submission.in_series(series)
     submissions = submissions.before_deadline(series.deadline) if series.deadline.present?

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -342,6 +342,21 @@ class UserTest < ActiveSupport::TestCase
     assert_equal [u3.id, u2.id, u1.id], User.in_course(c).order_by_exercise_submission_status_in_series('DESC', e, s).pluck(:id)
   end
 
+  test 'should be able to order by activity_read_state in series' do
+    c = create :course
+    s = create :series, course: c
+    a = create :content_page
+    SeriesMembership.create series: s, activity: a
+    u1 = create :user
+    CourseMembership.create user: u1, course: c, status: 'student'
+    u2 = create :user
+    CourseMembership.create user: u2, course: c, status: 'student'
+    create :activity_read_state, user: u2, course: c, activity: a
+
+    assert_equal [u1.id, u2.id], User.in_course(c).order_by_activity_read_state_in_series('ASC', a, s).pluck(:id)
+    assert_equal [u2.id, u1.id], User.in_course(c).order_by_activity_read_state_in_series('DESC', a, s).pluck(:id)
+  end
+
   test 'should be able to order by solved exercises in series' do
     c = create :course
     s = create :series, course: c

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -347,8 +347,12 @@ class UserTest < ActiveSupport::TestCase
     s = create :series, course: c
     e1 = create :exercise
     e2 = create :exercise
+    a1 = create :content_page
+    a2 = create :content_page
     SeriesMembership.create series: s, activity: e1
     SeriesMembership.create series: s, activity: e2
+    SeriesMembership.create series: s, activity: a1
+    SeriesMembership.create series: s, activity: a2
     u1 = create :user
     CourseMembership.create user: u1, course: c, status: 'student'
     u2 = create :user
@@ -359,11 +363,16 @@ class UserTest < ActiveSupport::TestCase
     u3 = create :user
     CourseMembership.create user: u3, course: c, status: 'student'
     create :wrong_submission, user: u3, course: c, exercise: e1
-    create :correct_submission, user: u3, course: c, exercise: e1
-    create :correct_submission, user: u3, course: c, exercise: e2
+    create :activity_read_state, user: u3, course: c, activity: a1
+    create :activity_read_state, user: u3, course: c, activity: a2
+    u4 = create :user
+    CourseMembership.create user: u4, course: c, status: 'student'
+    create :correct_submission, user: u4, course: c, exercise: e1
+    create :correct_submission, user: u4, course: c, exercise: e2
+    create :activity_read_state, user: u4, course: c, activity: a1
 
-    assert_equal [u1.id, u2.id, u3.id], User.in_course(c).order_by_solved_exercises_in_series('ASC', s).pluck(:id)
-    assert_equal [u3.id, u2.id, u1.id], User.in_course(c).order_by_solved_exercises_in_series('DESC', s).pluck(:id)
+    assert_equal [u1.id, u2.id, u3.id, u4.id], User.in_course(c).order_by_solved_exercises_in_series('ASC', s).pluck(:id)
+    assert_equal [u4.id, u3.id, u2.id, u1.id], User.in_course(c).order_by_solved_exercises_in_series('DESC', s).pluck(:id)
   end
 
   test 'should be able to order by progress' do


### PR DESCRIPTION
This pull request adds support for sorting by activity read states. The existing sort was broken as it did not take activity read states into account.

- [x] Tests were added
