### PR TITLE
Allow scrolling the page

### DIFF
--- a/app/views/activities/_coding_scratchpad.html.erb
+++ b/app/views/activities/_coding_scratchpad.html.erb
@@ -6,7 +6,8 @@
 data-bs-target="#scratchpad-offcanvas" aria-controls="scratchpad-offcanvas" id="scratchpad-offcanvas-show-btn">
     <%= t '.start_coding' %>
 </button>
-<div class="offcanvas offcanvas-end" tabindex="-1" id="scratchpad-offcanvas" data-bs-keyboard="false">
+<div class="offcanvas offcanvas-end" tabindex="-1" id="scratchpad-offcanvas"
+data-bs-keyboard="false" data-bs-scroll="true">
     <div class="scratchpad-header">
         <h4>
             <%= activity_icon(@activity, 24) %>


### PR DESCRIPTION
This pull request allows scrolling the exercise page while Papyros is being shown. When focused, scroll events are captured by the relevant component in Papyros (i.e. the editor, or the offcanvas itself).

These changes were requested by a user to allow reading the assignment without having to close and re-open the coding tab.
