### PR TITLE
Force office 365 sign in to prompt user selection before sign in

### DIFF
--- a/config/initializers/office365.rb
+++ b/config/initializers/office365.rb
@@ -10,7 +10,7 @@ module OmniAuth
       option :name, 'office365'
 
       option :client_options,
-             site: 'https://login.microsoftonline.com/',
+             site: 'https://login.microsoftonline.com/?prompt=select_account',
              authorize_url: '/common/oauth2/authorize',
              token_url: '/common/oauth2/token'
 

--- a/config/initializers/office365.rb
+++ b/config/initializers/office365.rb
@@ -10,7 +10,7 @@ module OmniAuth
       option :name, 'office365'
 
       option :client_options,
-             site: 'https://login.microsoftonline.com/?prompt=select_account',
+             site: 'https://login.microsoftonline.com/',
              authorize_url: '/common/oauth2/authorize',
              token_url: '/common/oauth2/token'
 
@@ -25,6 +25,7 @@ module OmniAuth
           end
 
           params[:scope] ||= DEFAULT_SCOPE
+          params[:prompt] = 'select_account'
         end
       end
 


### PR DESCRIPTION
This pull request forces microsoft to prompt the user to select their preferred microsoft account when signing in to dodona. This solves issues with people signing in using an unexpected account.

https://user-images.githubusercontent.com/21177904/171203881-53875c76-7047-429c-9986-957121518db8.mp4
