### PR TITLE
Format scss files

### DIFF
--- a/app/assets/stylesheets/bootstrap_variable_overrides.css.scss
+++ b/app/assets/stylesheets/bootstrap_variable_overrides.css.scss
@@ -11,29 +11,29 @@ $border-radius-base: 12px;
 
 // font stuff
 $font-family-sans-serif: Roboto, "Helvetica Neue", Helvetica, Arial, sans-serif;
-$font-size-base: 0.875rem;//14px;
+$font-size-base: 0.875rem; //14px;
 $baseLineHeight: 24px;
 $line-height-base: 1.3846153846;
 $min-contrast-ratio: 3;
 
 $link-decoration: none;
 
-$paragraph-margin-bottom:   0.875rem;
+$paragraph-margin-bottom: 0.875rem;
 
 $blockquote-font-size: $font-size-base;
 
 $alert-bg-scale: 0%;
 
-$blue:    $blue-500;
-$indigo:  $indigo-500;
-$purple:  $purple-500;
-$pink:    $pink-500;
-$red:     $red-500;
-$orange:  $orange-500;
-$yellow:  $yellow-500;
-$green:   $green-500;
-$teal:    $teal-500;
-$cyan:    $cyan-500;
+$blue: $blue-500;
+$indigo: $indigo-500;
+$purple: $purple-500;
+$pink: $pink-500;
+$red: $red-500;
+$orange: $orange-500;
+$yellow: $yellow-500;
+$green: $green-500;
+$teal: $teal-500;
+$cyan: $cyan-500;
 
 // bootstrap offcanvas overrides
 $offcanvas-horizontal-width: 700px;

--- a/app/assets/stylesheets/components.css.scss
+++ b/app/assets/stylesheets/components.css.scss
@@ -29,7 +29,10 @@
   flex-grow: 1;
 }
 
-.h3-info-text, .h4-info-text, .h5-info-text, .header-info-text {
+.h3-info-text,
+.h4-info-text,
+.h5-info-text,
+.header-info-text {
   font-size: 85%;
   color: $text-muted;
 }
@@ -62,6 +65,7 @@
   0% {
     transform: scale(0.0);
   }
+
   100% {
     transform: scale(1.0);
     opacity: 0;
@@ -80,11 +84,35 @@
   @include media-breakpoint-down(sm) {
     text-align: left;
   }
+
   text-align: right;
   font-weight: bold;
 }
 
-h1 small, h2 small, h3 small, h4 small, h5 small, h6 small, .h1 small, .h2 small, .h3 small, .h4 small, .h5 small, .h6 small, h1 .small, h2 .small, h3 .small, h4 .small, h5 .small, h6 .small, .h1 .small, .h2 .small, .h3 .small, .h4 .small, .h5 .small, .h6 .small {
+h1 small,
+h2 small,
+h3 small,
+h4 small,
+h5 small,
+h6 small,
+.h1 small,
+.h2 small,
+.h3 small,
+.h4 small,
+.h5 small,
+.h6 small,
+h1 .small,
+h2 .small,
+h3 .small,
+h4 .small,
+h5 .small,
+h6 .small,
+.h1 .small,
+.h2 .small,
+.h3 .small,
+.h4 .small,
+.h5 .small,
+.h6 .small {
   font-size: 65%;
   font-weight: 400;
   line-height: 1;

--- a/app/assets/stylesheets/components/callout.css.scss
+++ b/app/assets/stylesheets/components/callout.css.scss
@@ -22,7 +22,7 @@
 }
 
 /* Tighten up space between multiple callouts */
-.callout + .callout {
+.callout+.callout {
   margin-top: -5px;
 }
 

--- a/app/assets/stylesheets/components/card.css.scss
+++ b/app/assets/stylesheets/components/card.css.scss
@@ -41,12 +41,13 @@ $card-supporting-text-padding: 16px;
   padding: 16px;
   box-sizing: border-box;
   flex-direction: column;
+
   &.card-title-flex {
-      display: flex;
-      justify-content: space-between;
-      flex-direction: row;
-      align-items: center;
-    }
+    display: flex;
+    justify-content: space-between;
+    flex-direction: row;
+    align-items: center;
+  }
 }
 
 .card-title.card-title-colored {
@@ -72,7 +73,7 @@ a.card-title-link:hover {
     color: $text-secondary-on-bg-color;
   }
 
-  .card-subtitle-text + .card-subtitle-text {
+  .card-subtitle-text+.card-subtitle-text {
     margin-top: 10px;
   }
 
@@ -85,39 +86,51 @@ a.card-title-link:hover {
   &.accent-red {
     background-color: $color-red-bg;
   }
+
   &.accent-pink {
     background-color: $color-pink-bg;
   }
+
   &.accent-purple {
     background-color: $color-purple-bg;
   }
+
   &.accent-deep-purple {
     background-color: $color-deep-purple-bg;
   }
+
   &.accent-indigo {
     background-color: $color-indigo-bg;
   }
+
   &.accent-teal {
     background-color: $color-teal-bg;
   }
+
   &.accent-orange {
     background-color: $color-orange-bg;
   }
+
   &.accent-brown {
     background-color: $color-brown-bg;
   }
+
   &.accent-blue-grey {
     background-color: $color-blue-grey-bg;
   }
+
   &.accent-blue {
     background-color: $color-blue-bg;
   }
+
   &.accent-yellow {
     background-color: $color-yellow-bg;
   }
+
   &.accent-green {
     background-color: $color-green-bg;
   }
+
   &.accent-cyan {
     background-color: $color-cyan-bg;
   }
@@ -143,7 +156,7 @@ a.card-title-link:hover {
   margin: 0;
 }
 
-.card-title-text + .card-subtitle-text {
+.card-title-text+.card-subtitle-text {
   margin-top: .4em;
 }
 
@@ -208,7 +221,7 @@ a.card-title-link:hover {
   border-top: 1px solid $divider-color;
 }
 
-.card-title + .card-border {
+.card-title+.card-border {
   border-top: 0px;
 }
 
@@ -295,6 +308,7 @@ a.card-title-link:hover {
 .card-tab .nav-tabs li a {
   color: $text-muted;
 }
+
 .card-title .nav-tabs li a,
 .card-tab .nav-tabs li a {
   display: block;

--- a/app/assets/stylesheets/components/code_listing.css.scss
+++ b/app/assets/stylesheets/components/code_listing.css.scss
@@ -69,13 +69,17 @@ $annotation-info: $info-500;
       }
 
       .lineno:first-child {
-        .rouge-code, .rouge-gutter {
+
+        .rouge-code,
+        .rouge-gutter {
           padding-top: 5px;
         }
       }
 
       .lineno:last-child {
-        .rouge-code, .rouge-gutter {
+
+        .rouge-code,
+        .rouge-gutter {
           padding-bottom: 5px;
         }
       }
@@ -138,7 +142,8 @@ $annotation-info: $info-500;
       }
 
       // General lighter background on the right side
-      .rouge-code, .annotation-cell {
+      .rouge-code,
+      .annotation-cell {
         background-color: $body-bg;
       }
 
@@ -179,7 +184,10 @@ $annotation-info: $info-500;
         color: $text-secondary;
       }
 
-      .annotation-edit, .question-resolve, .question-in_progress, .question-unresolve {
+      .annotation-edit,
+      .question-resolve,
+      .question-in_progress,
+      .question-unresolve {
         float: right;
         margin-top: 4px;
       }
@@ -188,6 +196,7 @@ $annotation-info: $info-500;
         &::before {
           vertical-align: bottom;
         }
+
         margin-left: 4px;
       }
 
@@ -207,7 +216,7 @@ $annotation-info: $info-500;
       // Override the normal pre padding & coloring
       pre {
         padding: 0;
-        background-color: $code-bg !important;
+        background-color: $code-bg  !important;
         margin-bottom: 0;
         border: none;
         border-radius: 0;
@@ -216,7 +225,8 @@ $annotation-info: $info-500;
       }
 
       // Stylize the embedded code block
-      .highlighter-rouge div.highlight, pre:not(.highlight) {
+      .highlighter-rouge div.highlight,
+      pre:not(.highlight) {
         padding: 5px 10px;
         margin-left: 10px;
         margin-right: 10px;
@@ -240,12 +250,15 @@ $annotation-info: $info-500;
         margin: 10px auto 20px;
 
         max-width: 300px;
+
         @include media-breakpoint-up(md) {
           max-width: calc(#{map-get($container-max-widths, "md")} * 0.6);
         }
+
         @include media-breakpoint-up(lg) {
           max-width: calc(#{map-get($container-max-widths, "lg")} * 0.7);
         }
+
         @include media-breakpoint-up(xl) {
           max-width: calc(#{map-get($container-max-widths, "xl")} * 0.7);
         }
@@ -253,7 +266,8 @@ $annotation-info: $info-500;
     }
   }
 
-  .annotation.question, .annotation.user {
+  .annotation.question,
+  .annotation.user {
     border-left-width: 5px;
   }
 
@@ -299,7 +313,8 @@ $annotation-info: $info-500;
       margin-bottom: 12px;
       text-align: right;
 
-      .annotation-control-button, .question-control-button {
+      .annotation-control-button,
+      .question-control-button {
         margin-left: 3px;
       }
 

--- a/app/assets/stylesheets/components/dropdown-filter.css.scss
+++ b/app/assets/stylesheets/components/dropdown-filter.css.scss
@@ -1,17 +1,17 @@
-
 .dropdown-filter {
   margin: 8px;
   margin-right: 0;
   display: inline-block;
 
-  .dropdown-toggle{
+  .dropdown-toggle {
     display: inline-flex;
     padding-left: 16px;
     padding-right: 16px;
     font-size: 14px;
     white-space: nowrap;
     box-shadow: none;
-    .mdi::before{
+
+    .mdi::before {
       line-height: 36px;
     }
 
@@ -26,7 +26,7 @@
     }
   }
 
-  .form-check-label{
+  .form-check-label {
     width: 100%;
   }
 }

--- a/app/assets/stylesheets/components/evaluations.css.scss
+++ b/app/assets/stylesheets/components/evaluations.css.scss
@@ -80,22 +80,24 @@
         cursor: auto;
       }
 
-      .form-control.in-progress, .input-group-addon.in-progress {
+      .form-control.in-progress,
+      .input-group-addon.in-progress {
         border-bottom-left-radius: 0;
         border-bottom-right-radius: 0;
       }
 
-      .form-control{
+      .form-control {
         border-color: $border-color;
         line-height: initial;
       }
 
-      .score-input{
+      .score-input {
         border-right: none;
         margin-right: -28px;
         padding-right: 28px;
       }
-      .score-state{
+
+      .score-state {
         border-left: none;
         width: 28px;
         background-color: $input-bg;
@@ -128,6 +130,7 @@
       text-decoration: inherit;
     }
   }
+
   .user-select-option:hover {
     border: 1px solid $text-disabled;
   }
@@ -135,6 +138,7 @@
   .user-select-option h1 small {
     font-weight: 100;
   }
+
   .selected-users {
     margin-top: 18px;
     display: inline-block;
@@ -150,18 +154,24 @@
 
 .feedback {
   padding-bottom: 6px;
+
   &.correct {
     border-bottom: 3px solid $success-300;
   }
+
   &.wrong {
     border-bottom: 3px solid $danger-300;
   }
+
   &.not-started {
     border-bottom: 3px solid $hairlinegray;
   }
-  .done, .provisional {
+
+  .done,
+  .provisional {
     color: $text-disabled;
   }
+
   a:hover .done,
   a:hover .provisional,
   .done:hover,
@@ -169,6 +179,7 @@
     color: $text-color;
   }
 }
+
 .user-feedback-row {
   display: flex;
   justify-content: space-around;
@@ -176,10 +187,12 @@
   a .done {
     color: $text-secondary;
   }
+
   .active a i {
     color: $info-500;
   }
 }
+
 .evaluation-form-title {
   line-height: normal;
 }
@@ -254,7 +267,8 @@ a.score-click {
     padding-left: 30px;
   }
 
-  td:first-child, th:first-child {
+  td:first-child,
+  th:first-child {
     max-width: 200px;
   }
 

--- a/app/assets/stylesheets/components/img.css.scss
+++ b/app/assets/stylesheets/components/img.css.scss
@@ -1,6 +1,6 @@
-.course-description :not(.dodona-centered-group) > img:not(.img-unresponsive),
-.exercise-description :not(.dodona-centered-group) > img:not(.img-unresponsive),
-.series-description :not(.dodona-centered-group) > img:not(.img-unresponsive) {
+.course-description :not(.dodona-centered-group)>img:not(.img-unresponsive),
+.exercise-description :not(.dodona-centered-group)>img:not(.img-unresponsive),
+.series-description :not(.dodona-centered-group)>img:not(.img-unresponsive) {
   display: block;
   max-width: 100%;
   height: auto;

--- a/app/assets/stylesheets/components/notification.css.scss
+++ b/app/assets/stylesheets/components/notification.css.scss
@@ -4,7 +4,9 @@ th.status-icon {
 
 .notification {
   &.unread {
-    .notification-icon, .read-indicator {
+
+    .notification-icon,
+    .read-indicator {
       color: $info-500;
     }
   }

--- a/app/assets/stylesheets/components/progress-chart.css.scss
+++ b/app/assets/stylesheets/components/progress-chart.css.scss
@@ -1,15 +1,19 @@
 .progress-chart {
-    shape-rendering: crispEdges;
-    .correct {
-      stroke: $success-300;
-    }
-    .info {
-      stroke: $info-500;
-    }
-    .wrong {
-      stroke: $danger-300;
-    }
-    .not-started {
-      stroke: $hairlinegray;
-    }
+  shape-rendering: crispEdges;
+
+  .correct {
+    stroke: $success-300;
+  }
+
+  .info {
+    stroke: $info-500;
+  }
+
+  .wrong {
+    stroke: $danger-300;
+  }
+
+  .not-started {
+    stroke: $hairlinegray;
+  }
 }

--- a/app/assets/stylesheets/components/scratchpad.css.scss
+++ b/app/assets/stylesheets/components/scratchpad.css.scss
@@ -57,8 +57,10 @@
 #scratchpad-editor-wrapper {
     margin-bottom: 20px;
 }
+
 // Wrapper and its child should take up as much space as possible
-#scratchpad-editor-wrapper , #scratchpad-editor-wrapper > div:first-child {
+#scratchpad-editor-wrapper,
+#scratchpad-editor-wrapper>div:first-child {
     height: 100%;
     max-height: 100%;
 }
@@ -74,11 +76,13 @@ div .cm-gutters {
     height: auto !important;
     min-height: 100% !important;
 }
+
 #scrathcpad-output-wrapper {
     margin-bottom: 10px;
 }
+
 // First child is the output area, limit its size
-#scratchpad-output-wrapper > div:first-child {
+#scratchpad-output-wrapper>div:first-child {
     max-height: 20vh;
 }
 

--- a/app/assets/stylesheets/components/search_field.css.scss
+++ b/app/assets/stylesheets/components/search_field.css.scss
@@ -1,4 +1,7 @@
-.search-filter:focus + .show-search-dropdown, .show-search-dropdown:focus, .show-search-dropdown:active, .show-search-dropdown:target {
+.search-filter:focus+.show-search-dropdown,
+.show-search-dropdown:focus,
+.show-search-dropdown:active,
+.show-search-dropdown:target {
   display: block;
   max-height: 400px;
   overflow-y: auto;

--- a/app/assets/stylesheets/components/stepper.css.scss
+++ b/app/assets/stylesheets/components/stepper.css.scss
@@ -33,6 +33,7 @@
 
         a {
           color: inherit;
+
           &.disabled {
             cursor: default;
             color: $text-muted;
@@ -46,13 +47,14 @@
     }
 
 
-    .panel-heading + .panel-collapse > .panel-body {
+    .panel-heading+.panel-collapse>.panel-body {
       @include shadow-z2;
       background-color: $content-bg;
 
       @include media-breakpoint-up(sm) {
         margin-left: 45px;
       }
+
       border: none;
       border-radius: $border-radius-base;
       padding: 0;
@@ -62,7 +64,7 @@
         @include shadow-z0;
       }
 
-      .row + .row {
+      .row+.row {
         margin-top: 20px;
       }
 

--- a/app/assets/stylesheets/components/table-toolbar.css.scss
+++ b/app/assets/stylesheets/components/table-toolbar.css.scss
@@ -31,7 +31,7 @@
   margin: 0;
 }
 
-.table-toolbar .table-toolbar-tools > .mdi::before {
+.table-toolbar .table-toolbar-tools>.mdi::before {
   margin-top: 3px;
   margin-left: 8px;
   color: $text-disabled;
@@ -106,7 +106,7 @@
   visibility: hidden;
 }
 
-.dodona-progress > .bar {
+.dodona-progress>.bar {
   display: block;
   position: absolute;
   top: 0;
@@ -115,41 +115,39 @@
   transition: width 0.2s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
-.dodona-progress > .progressbar {
+.dodona-progress>.progressbar {
   background-color: $progress-bar-bg;
   z-index: 1;
   left: 0;
 }
 
-.dodona-progress > .bufferbar {
-  background-image: linear-gradient(
-      to right,
+.dodona-progress>.bufferbar {
+  background-image: linear-gradient(to right,
       rgba(255, 255, 255, 0.7),
-      rgba(255, 255, 255, 0.7)
-    ),
+      rgba(255, 255, 255, 0.7)),
     linear-gradient(to right, $accent-A100, $accent-A100);
   z-index: 0;
   left: 0;
 }
 
-.dodona-progress > .auxbar {
+.dodona-progress>.auxbar {
   right: 0;
 }
 
-.dodona-progress.dodona-progress-indeterminate > .bar1,
-.dodona-progress.dodona-progress-indeterminate > .bar3 {
+.dodona-progress.dodona-progress-indeterminate>.bar1,
+.dodona-progress.dodona-progress-indeterminate>.bar3 {
   background-color: $progress-bar-bg;
   animation-duration: 2s;
   animation-iteration-count: infinite;
   animation-timing-function: linear;
 }
 
-.mdl-progress.mdl-progress-indeterminate > .bar3 {
+.mdl-progress.mdl-progress-indeterminate>.bar3 {
   background-image: none;
   animation-name: indeterminate2;
 }
 
-.dodona-progress.dodona-progress-indeterminate > .bar1 {
+.dodona-progress.dodona-progress-indeterminate>.bar1 {
   animation-name: indeterminate1;
 }
 
@@ -158,10 +156,12 @@
     left: 0%;
     width: 0%;
   }
+
   50% {
     left: 25%;
     width: 75%;
   }
+
   75% {
     left: 100%;
     width: 0%;
@@ -169,15 +169,18 @@
 }
 
 @keyframes indeterminate2 {
+
   0%,
   50% {
     left: 0%;
     width: 0%;
   }
+
   75% {
     left: 0%;
     width: 25%;
   }
+
   100% {
     left: 100%;
     width: 0%;

--- a/app/assets/stylesheets/components/table.css.scss
+++ b/app/assets/stylesheets/components/table.css.scss
@@ -15,18 +15,23 @@
   .table {
     border-collapse: separate;
 
-    td, th {
+    td,
+    th {
       margin: 0;
       white-space: nowrap;
     }
+
     .status-header {
       max-width: 100px;
       min-width: 100px;
     }
-    .status, .status-header {
+
+    .status,
+    .status-header {
       text-align: center;
       overflow: hidden;
     }
+
     .user-name {
       position: absolute;
       width: 200px;
@@ -34,9 +39,11 @@
       height: auto;
       top: auto;
     }
+
     td:not(.sticky-column) {
       height: 42px;
     }
+
     thead .user-name {
       height: auto !important;
     }
@@ -57,6 +64,7 @@ tr.gu-mirror {
   overflow: hidden;
   text-overflow: ellipsis;
   vertical-align: middle;
+
   form {
     display: inline;
   }

--- a/app/assets/stylesheets/components/tokenfield.css.scss
+++ b/app/assets/stylesheets/components/tokenfield.css.scss
@@ -11,12 +11,14 @@
   padding-bottom: 0px;
   z-index: 1;
 }
+
 .tokenfield.focus {
   border-color: #66afe9;
   outline: 0;
   box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075),
-  0 0 8px rgba(102, 175, 233, 0.6);
+    0 0 8px rgba(102, 175, 233, 0.6);
 }
+
 .tokenfield .token-input {
   background: none;
   width: 60px;
@@ -27,72 +29,88 @@
   margin-bottom: 6px;
   box-shadow: none;
 }
+
 .tokenfield .token-input:focus {
   border-color: transparent;
   outline: 0;
   box-shadow: none;
 }
+
 .tokenfield.disabled {
   cursor: not-allowed;
   background-color: #eeeeee;
 }
+
 .tokenfield.disabled .token-input {
   cursor: not-allowed;
 }
+
 .tokenfield.disabled .token:hover {
   cursor: not-allowed;
   border-color: #d9d9d9;
 }
+
 .tokenfield.disabled .token:hover .close {
   cursor: not-allowed;
   opacity: 0.2;
   filter: alpha(opacity=20);
 }
+
 .has-warning .tokenfield.focus {
   border-color: #66512c;
   box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #c0a16b;
 }
+
 .has-error .tokenfield.focus {
   border-color: #843534;
   box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #ce8483;
 }
+
 .has-success .tokenfield.focus {
   border-color: #2b542c;
   box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #67b168;
 }
+
 .tokenfield.form-control-sm,
 .input-group-sm .tokenfield {
   min-height: 30px;
   padding-bottom: 0px;
 }
+
 .input-group-sm .token,
 .tokenfield.form-control-sm .token {
   height: 20px;
   margin-bottom: 4px;
 }
+
 .input-group-sm .token-input,
 .tokenfield.form-control-sm .token-input {
   height: 18px;
   margin-bottom: 5px;
 }
+
 .tokenfield.form-control-lg,
 .input-group-lg .tokenfield {
   height: auto;
   min-height: 45px;
   padding-bottom: 4px;
 }
+
 .input-group-lg .token,
 .tokenfield.form-control-lg .token {
   height: 25px;
 }
+
 .input-group-lg .token-label,
 .tokenfield.form-control-lg .token-label {
   line-height: 23px;
 }
+
 .input-group-lg .token .close,
 .tokenfield.form-control-lg .token .close {
   line-height: 1.3em;
 }
+
 .input-group-lg .token-input,
 .tokenfield.form-control-lg .token-input {
   height: 23px;
@@ -100,13 +118,16 @@
   margin-bottom: 6px;
   vertical-align: top;
 }
+
 .tokenfield.rtl {
   direction: rtl;
   text-align: right;
 }
+
 .tokenfield.rtl .token {
   margin: -1px 0 5px 5px;
 }
+
 .tokenfield.rtl .token .token-label {
   padding-left: 0px;
   padding-right: 4px;
@@ -134,16 +155,19 @@
   white-space: nowrap;
   cursor: default;
 }
+
 .token .close {
   font-size: 18px;
   margin-left: 8px;
   margin-right: -4px; // a token with a close button has a right padding of 8 instead of 12px
   color: $text-on-bg-color;
 }
+
 .token .close:hover {
   color: $text-color;
   cursor: pointer;
 }
+
 a+a>.token,
 .token+.token {
   margin-left: 8px;
@@ -157,27 +181,35 @@ d-search-token>.token {
 .token.accent-red {
   background-color: $color-red-bg;
 }
+
 .token.accent-pink {
   background-color: $color-pink-bg;
 }
+
 .token.accent-purple {
   background-color: $color-purple-bg;
 }
+
 .token.accent-deep-purple {
   background-color: $color-deep-purple-bg;
 }
+
 .token.accent-indigo {
   background-color: $color-indigo-bg;
 }
+
 .token.accent-teal {
   background-color: $color-teal-bg;
 }
+
 .token.accent-orange {
   background-color: $color-orange-bg;
 }
+
 .token.accent-brown {
   background-color: $color-brown-bg;
 }
+
 .token.accent-blue-grey {
   background-color: $color-blue-grey-bg;
 }
@@ -241,6 +273,6 @@ d-search-token>.token {
   background-color: transparent;
 }
 
-.search-tokens{
+.search-tokens {
   margin-left: 16px;
 }

--- a/app/assets/stylesheets/components/tutor.css.scss
+++ b/app/assets/stylesheets/components/tutor.css.scss
@@ -81,7 +81,8 @@
   width: 100%;
 }
 
-#tutor.fullscreen .modal-dialog.tutor .modal-content, .modal-body {
+#tutor.fullscreen .modal-dialog.tutor .modal-content,
+.modal-body {
   width: 100%;
   height: 100%;
 }

--- a/app/assets/stylesheets/components/visualisations.css.scss
+++ b/app/assets/stylesheets/components/visualisations.css.scss
@@ -1,15 +1,14 @@
-
 .violin-label {
-    font-size: 11px;
+  font-size: 11px;
 }
 
 .violin-invisibar {
-    visibility: hidden;
-    fill: none
+  visibility: hidden;
+  fill: none
 }
 
 .metric-container {
-    stroke: $hairlinegray;
+  stroke: $hairlinegray;
 }
 
 .day-cell {
@@ -60,7 +59,7 @@
     .legend-text {
       margin-left: 4px;
     }
-  } 
+  }
 }
 
 .daterange-picker {

--- a/app/assets/stylesheets/layout.css.scss
+++ b/app/assets/stylesheets/layout.css.scss
@@ -10,9 +10,9 @@ body {
 
 // Set height of frame layout to fit-content to allow downsizing
 html.dodona-frame,
-html.dodona-frame > body,
+html.dodona-frame>body,
 html.lti-frame,
-html.lti-frame > body {
+html.lti-frame>body {
   height: fit-content;
   background: $content-bg;
 }
@@ -32,6 +32,7 @@ html.lti-frame > body {
 .container.main {
   padding-top: 20px;
   padding-bottom: 80px;
+
   @include media-breakpoint-down(md) {
     padding-bottom: 180px;
   }

--- a/app/assets/stylesheets/layout/drawer.css.scss
+++ b/app/assets/stylesheets/layout/drawer.css.scss
@@ -119,11 +119,13 @@ ul.drawer-list {
       background: $drawer-active;
     }
 
-    &:hover, &:focus {
+    &:hover,
+    &:focus {
       background: $drawer-hover;
     }
 
-    span, i {
+    span,
+    i {
       font-size: 18px;
       margin-right: 12px;
     }

--- a/app/assets/stylesheets/layout/footer.css.scss
+++ b/app/assets/stylesheets/layout/footer.css.scss
@@ -42,7 +42,7 @@ $footer-height-sm: 180px;
   }
 }
 
-.footer-block > * {
+.footer-block>* {
   flex-shrink: 0;
 }
 

--- a/app/assets/stylesheets/layout/navbar.css.scss
+++ b/app/assets/stylesheets/layout/navbar.css.scss
@@ -4,27 +4,25 @@ $navbar-height: 50px;
 .dodona-navbar {
   @include shadow-z3;
   background: $header-bg;
-
   height: $navbar-height;
-
   display: flex;
-
   position: fixed;
   top: 0;
   left: 0;
   right: 0;
   z-index: 10;
-
   width: 100vw;
   max-width: 100vw;
 
   ul {
     margin-bottom: 9.5px;
   }
+
   a {
     color: $header-fg;
     text-decoration: none;
   }
+
   li {
     display: inline-block;
   }
@@ -34,17 +32,17 @@ $navbar-height: 50px;
     display: flex;
     justify-content: center;
 
-    > .content {
+    >.content {
       display: inline-flex;
       justify-content: center;
     }
   }
 
-  .flex:first-child > .content {
+  .flex:first-child>.content {
     margin-right: auto;
   }
 
-  .flex:last-child > .content {
+  .flex:last-child>.content {
     margin-left: auto;
   }
 
@@ -56,18 +54,23 @@ $navbar-height: 50px;
   .center {
     flex-shrink: 1;
     flex-grow: 100;
+
     @include media-breakpoint-up(sm) {
       max-width: calc(100vw - 240px);
     }
+
     @include media-breakpoint-up(md) {
       max-width: math.div(map-get($container-max-widths, "md"), 12) * 10;
     }
+
     @include media-breakpoint-up(lg) {
       max-width: math.div(map-get($container-max-widths, "lg"), 12) * 10;
     }
+
     @include media-breakpoint-up(xl) {
       max-width: math.div(map-get($container-max-widths, "xl"), 12) * 10;
     }
+
     @include media-breakpoint-up(xxl) {
       max-width: math.div(map-get($container-max-widths, "xxl"), 12) * 10;
     }
@@ -107,6 +110,7 @@ $navbar-height: 50px;
 
       i {
         line-height: $navbar-height;
+
         @include media-breakpoint-up(sm) {
           display: none;
         }
@@ -122,15 +126,19 @@ $navbar-height: 50px;
     @include media-breakpoint-up(sm) {
       max-width: calc(100vw - 240px);
     }
+
     @include media-breakpoint-up(md) {
       max-width: calc((#{map-get($container-max-widths, "md")} / 12 * 10) - #{$grid-gutter-width});
     }
+
     @include media-breakpoint-up(lg) {
       max-width: calc((#{map-get($container-max-widths, "lg")} / 12 * 10) - #{$grid-gutter-width});
     }
+
     @include media-breakpoint-up(xl) {
       max-width: calc((#{map-get($container-max-widths, "xl")} / 12 * 10) - #{$grid-gutter-width});
     }
+
     @include media-breakpoint-up(xxl) {
       max-width: calc((#{map-get($container-max-widths, "xxl")} / 12 * 10) - #{$grid-gutter-width});
     }
@@ -139,6 +147,7 @@ $navbar-height: 50px;
       @include media-breakpoint-down(sm) {
         display: none;
       }
+
       flex-shrink: 0;
       align-self: flex-end;
       align-content: flex-end;
@@ -150,8 +159,10 @@ $navbar-height: 50px;
       li a {
         padding-left: 8px;
         padding-right: 8px;
+
         @include media-breakpoint-up(sm) {
           padding-bottom: 11px;
+
           &.active {
             padding-bottom: 8px;
             border-bottom: solid #fff 3px;
@@ -170,9 +181,10 @@ $navbar-height: 50px;
       padding-left: 20px;
 
       .notification-dropdown {
-        .table > tbody > tr:first-of-type > td {
+        .table>tbody>tr:first-of-type>td {
           border-top: none;
         }
+
         .notification {
           cursor: pointer;
 
@@ -193,18 +205,23 @@ $navbar-height: 50px;
             line-height: 24px;
           }
         }
+
         .read-toggle-button {
           cursor: pointer;
         }
+
         a {
           padding-left: 0px;
           color: $text-color;
+
           &.btn-icon {
             color: $text-secondary;
           }
         }
+
         .notification-overflow a {
           color: $link-color;
+
           &:hover {
             text-decoration: underline;
           }
@@ -214,6 +231,7 @@ $navbar-height: 50px;
       li a {
         padding-left: 8px;
       }
+
       li a .dropdown-box::before {
         float: right; // position to right of text
         top: -6px;
@@ -231,6 +249,7 @@ $navbar-height: 50px;
         li {
           display: block;
         }
+
         a {
           color: $text-color;
         }
@@ -252,7 +271,9 @@ $navbar-height: 50px;
         }
 
         .dropdown-menu {
-          li, a {
+
+          li,
+          a {
             color: $text-color;
           }
 
@@ -275,6 +296,7 @@ $navbar-height: 50px;
     @include media-breakpoint-up(sm) {
       display: none;
     }
+
     position: absolute;
     top: 0;
     right: 10px;
@@ -297,6 +319,7 @@ $navbar-height: 50px;
     @include media-breakpoint-up(sm) {
       display: inline-block;
     }
+
     @include media-breakpoint-down(sm) {
       @include shadow-z3;
       position: absolute;
@@ -319,13 +342,17 @@ $navbar-height: 50px;
           display: none;
         }
       }
+
       display: inline-block;
+
       @include media-breakpoint-down(sm) {
         padding-left: 25px;
       }
+
       transform: translateY(-.5em);
     }
   }
+
   .custom-material-icons svg {
     margin-bottom: 13px;
   }
@@ -352,6 +379,7 @@ $navbar-height: 50px;
     overflow: hidden;
     text-overflow: ellipsis;
   }
+
   .crumb.list a {
     margin-right: 12px;
   }
@@ -360,14 +388,16 @@ $navbar-height: 50px;
     overflow: hidden;
     flex-shrink: 1;
 
-    .mdi::before{
+    .mdi::before {
       line-height: $navbar-height;
       margin-left: 4px;
       margin-right: 4px;
     }
   }
 
-  .crumb, .crumb a, .crumb-separator {
+  .crumb,
+  .crumb a,
+  .crumb-separator {
     color: $header-fg;
   }
 
@@ -375,7 +405,8 @@ $navbar-height: 50px;
     text-decoration: none;
   }
 
-  .crumb:last-child:not(:first-child), .crumb:last-child:not(:first-child) a {
+  .crumb:last-child:not(:first-child),
+  .crumb:last-child:not(:first-child) a {
     color: $header-fg-secondary;
     pointer-events: none;
     cursor: default;

--- a/app/assets/stylesheets/material_icons.css.scss
+++ b/app/assets/stylesheets/material_icons.css.scss
@@ -63,13 +63,16 @@
   top: 2px;
   left: -8px;
 }
+
 .dropdown-menu .mdi-box::before {
   left: 10px;
   position: relative; // required to use left
 }
 
 .dodona-navbar {
-  .actions , .dropdown {
+
+  .actions,
+  .dropdown {
     .mdi::before {
       vertical-align: text-bottom;
       line-height: 30px;
@@ -174,39 +177,51 @@
   &.accent-red {
     color: $color-red-bg;
   }
+
   &.accent-pink {
     color: $color-pink-bg;
   }
+
   &.accent-purple {
     color: $color-purple-bg;
   }
+
   &.accent-deep-purple {
     color: $color-deep-purple-bg;
   }
+
   &.accent-indigo {
     color: $color-indigo-bg;
   }
+
   &.accent-teal {
     color: $color-teal-bg;
   }
+
   &.accent-orange {
     color: $color-orange-bg;
   }
+
   &.accent-brown {
     color: $color-brown-bg;
   }
+
   &.accent-blue-grey {
     color: $color-blue-grey-bg;
   }
+
   &.accent-blue {
     color: $color-blue-bg;
   }
+
   &.accent-yellow {
     color: $color-yellow-bg;
   }
+
   &.accent-green {
     color: $color-green-bg;
   }
+
   &.accent-cyan {
     color: $color-cyan-bg;
   }

--- a/app/assets/stylesheets/models/course.css.scss
+++ b/app/assets/stylesheets/models/course.css.scss
@@ -61,22 +61,24 @@
       width: calc((100vw - var(--scrollbar-width) - (#{map-get($container-max-widths, "lg")} / 12 * 10)) / 2);
     }
   }
+
   @include media-breakpoint-up(xl) {
     .nav {
       width: calc((100vw - var(--scrollbar-width) - (#{map-get($container-max-widths, "xl")} / 12 * 10)) / 2);
     }
   }
+
   @include media-breakpoint-up(xxl) {
     .nav {
       width: calc((100vw - var(--scrollbar-width) - (#{map-get($container-max-widths, "xxl")} / 12 * 10)) / 2);
     }
   }
 
-  .nav > li.header {
+  .nav>li.header {
     color: $text-secondary;
   }
 
-  .nav > li > a {
+  .nav>li>a {
     display: block;
     padding: 6px 6px;
     font-size: 13px;
@@ -84,14 +86,14 @@
     color: $text-disabled;
   }
 
-  .nav > li > a.active,
-  .nav > li > a.active:hover {
+  .nav>li>a.active,
+  .nav>li>a.active:hover {
     border-left: 2px solid $primary-800;
     padding-left: 4px;
     color: $text-secondary;
   }
 
-  .nav > li > a:hover {
+  .nav>li>a:hover {
     border-left: 1px solid $primary-800;
     padding-left: 5px;
     color: $text-secondary;

--- a/app/assets/stylesheets/models/programming_languages.css.scss
+++ b/app/assets/stylesheets/models/programming_languages.css.scss
@@ -1,5 +1,7 @@
 .language-table {
-  th.type-icon, td.type-icon {
+
+  th.type-icon,
+  td.type-icon {
     color: $text-secondary;
   }
 }

--- a/app/assets/stylesheets/models/questions.css.scss
+++ b/app/assets/stylesheets/models/questions.css.scss
@@ -17,6 +17,7 @@
 
   .selection-row {
     cursor: pointer;
+
     &:hover {
       background-color: table-hover-bg;
     }
@@ -48,6 +49,7 @@
 
   .selection-row {
     cursor: pointer;
+
     &:hover {
       background-color: $table-hover-bg;
     }

--- a/app/assets/stylesheets/models/series.css.scss
+++ b/app/assets/stylesheets/models/series.css.scss
@@ -80,14 +80,15 @@
     border-radius: 50%;
     background-color: $series-summary-icon-bg;
 
-    & > .mdi::before{
+    &>.mdi::before {
       line-height: 24px;
     }
 
     &.deadline-missed .mdi-alarm-off {
-      &::before{
+      &::before {
         color: $brand-danger;
       }
+
       background-color: $content-bg;
       position: absolute;
       top: 24px;
@@ -96,9 +97,10 @@
     }
 
     &.deadline-met .mdi-alarm-check {
-      &::before{
+      &::before {
         color: $brand-success;
       }
+
       background-color: $content-bg;
       position: absolute;
       top: 24px;
@@ -121,7 +123,8 @@
       }
     }
 
-    &.started, &.completed.deadline-missed {
+    &.started,
+    &.completed.deadline-missed {
       background-color: $brand-success;
 
       i {
@@ -145,13 +148,12 @@
       $p6: 90%;
 
       background-image: linear-gradient(-135deg,
-      $red $p1,
-      $orange $p2,
-      $yellow $p3,
-      $green $p4,
-      $blue $p5,
-      $purple $p6
-      );
+          $red $p1,
+          $orange $p2,
+          $yellow $p3,
+          $green $p4,
+          $blue $p5,
+          $purple $p6 );
 
       i {
         font-weight: bolder;
@@ -184,14 +186,14 @@
     height: 33px;
     background-repeat: no-repeat;
     background-image: linear-gradient($skeleton-color 100%, transparent 0),
-    linear-gradient($skeleton-color 100%, transparent 0),
-    linear-gradient($skeleton-color 100%, transparent 0);
+      linear-gradient($skeleton-color 100%, transparent 0),
+      linear-gradient($skeleton-color 100%, transparent 0);
     background-size: 56px 12px,
-    90px 12px,
-    115px 12px;
+      90px 12px,
+      115px 12px;
     background-position: 58px 10px,
-    calc(100% - 230px) 10px,
-    calc(100% - 75px) 10px;
+      calc(100% - 230px) 10px,
+      calc(100% - 75px) 10px;
   }
 
   .skeleton-row {
@@ -199,17 +201,17 @@
     height: 37px;
     background-repeat: no-repeat;
     background-image: linear-gradient($skeleton-color 100%, transparent 0),
-    linear-gradient($skeleton-color 100%, transparent 0),
-    linear-gradient($skeleton-color 100%, transparent 0),
-    linear-gradient($skeleton-color 100%, transparent 0);
+      linear-gradient($skeleton-color 100%, transparent 0),
+      linear-gradient($skeleton-color 100%, transparent 0),
+      linear-gradient($skeleton-color 100%, transparent 0);
     background-size: 90px 12px,
-    100px 12px,
-    90px 12px,
-    8px 12px;
+      100px 12px,
+      90px 12px,
+      8px 12px;
     background-position: 58px 15px,
-    calc(100% - 220px) 15px,
-    calc(100% - 100px) 15px,
-    calc(100% - 25px) 15px;
+      calc(100% - 220px) 15px,
+      calc(100% - 100px) 15px,
+      calc(100% - 25px) 15px;
     padding-right: 8px;
   }
 }
@@ -237,6 +239,7 @@
 
 .svg-icon-btn {
   fill: currentColor;
+
   &.rotate {
     transform: rotate(90deg);
   }

--- a/app/assets/stylesheets/models/submissions.css.scss
+++ b/app/assets/stylesheets/models/submissions.css.scss
@@ -12,28 +12,33 @@
       border-left: 3px solid;
       border-radius: 0;
     }
+
     .badge.bg-danger {
       color: $brand-danger;
       border-color: $brand-danger;
-      background-color: $content-bg !important;
+      background-color: $content-bg  !important;
     }
+
     .badge.bg-success {
       color: $brand-success;
       border-color: $brand-success;
-      background-color: $content-bg !important;
+      background-color: $content-bg  !important;
     }
   }
 
   .description {
     background-color: $code-bg;
+
     pre {
       border: none;
     }
   }
+
   .groups {
     margin: 0;
     margin-right: 15px;
   }
+
   .group {
     background-color: $content-bg;
     margin-bottom: 12px;
@@ -44,10 +49,12 @@
     &.correct {
       border-left-color: $brand-success;
     }
+
     &.wrong {
       border-left-color: $brand-danger;
     }
   }
+
   .testcase {
     .indicator {
       width: 15px;
@@ -59,7 +66,8 @@
         margin: auto;
       }
     }
-    & > div {
+
+    &>div {
       margin-bottom: 3px;
     }
 
@@ -68,12 +76,14 @@
         color: $brand-success;
       }
     }
+
     &.wrong {
       .indicator {
         color: $brand-danger;
       }
     }
   }
+
   .test .output,
   .code {
     font-family: $font-family-monospace;
@@ -81,19 +91,23 @@
     white-space: pre-wrap;
     overflow-wrap: break-word;
   }
+
   table.diff {
     overflow: auto;
     font-size: 13px;
     margin: 0;
     padding: 0;
     width: 100%;
+
     td {
       vertical-align: top;
     }
+
     td.line-nr {
       text-align: right;
       white-space: pre-wrap;
     }
+
     th {
       font-weight: normal;
       padding-left: 5px;
@@ -102,6 +116,7 @@
       color: $feedback-diff-table-header-fg;
       vertical-align: center;
     }
+
     .del,
     .ins,
     .unchanged {
@@ -112,52 +127,70 @@
       word-break: break-all;
       white-space: pre-wrap;
       font-family: $font-family-monospace;
+
       strong {
         font-weight: normal;
         border-radius: 0.2em;
       }
     }
+
     .ins {
       background: $feedback-diff-table-ins;
     }
+
     .del {
       background: $feedback-diff-table-del;
     }
+
     .ins strong {
       background: $feedback-diff-table-ins-strong;
     }
+
     .del strong {
       background: $feedback-diff-table-del-strong;
     }
+
     .line-nr {
       background: $feedback-diff-table-header-bg;
       color: $feedback-diff-table-header-fg;
       padding-left: 10px;
       padding-right: 10px;
     }
+
     .line-nr:empty::before {
-      content: " "; /* make sure the line-height is respected */
+      content: " ";
+      /* make sure the line-height is respected */
     }
+
     .output {
       width: 100%;
     }
+
     .ins-output,
     .del-output {
       width: 50%;
       max-width: 50%;
     }
+
     .tr {
       padding: 0;
       margin: 0;
       line-height: 1.0;
     }
   }
+
   table.diff.csv-diff {
-    td, .del, .ins, .unchanged {
+
+    td,
+    .del,
+    .ins,
+    .unchanged {
       padding: 2px 6px;
       white-space: pre;
     }
-    td.line-nr, th.line-nr {
+
+    td.line-nr,
+    th.line-nr {
       position: -webkit-sticky;
       position: sticky;
       left: 0;
@@ -165,18 +198,25 @@
       text-align: right;
     }
   }
-  .diffs .unified-diff, .diffs .split-diff {
+
+  .diffs .unified-diff,
+  .diffs .split-diff {
     display: none;
   }
-  .diffs.show-unified .unified-diff, .diffs.show-split .split-diff {
+
+  .diffs.show-unified .unified-diff,
+  .diffs.show-split .split-diff {
     display: table;
   }
+
   .diffs.show-split .split-diff.csv-diff {
     display: inline-block;
     width: 50%;
     vertical-align: top;
   }
-  .diffs.show-unified .unified-diff.csv-diff, .test-accepted .diffs .diff {
+
+  .diffs.show-unified .unified-diff.csv-diff,
+  .test-accepted .diffs .diff {
     display: inline-block;
   }
 
@@ -187,6 +227,7 @@
 
     .switch-buttons {
       margin-left: 1em;
+
       span {
         margin-right: .5em;
       }
@@ -204,63 +245,87 @@
   .linter pre {
     border: none;
   }
+
   .linter pre.lineno {
     border-right: 1px solid $divider-color;
     padding-right: 25px;
   }
+
   .linter td.code {
     width: 100%;
   }
+
   .linter .lint-errors {
     list-style-type: none;
     padding-left: 5px;
   }
+
   .lint-errors .code {
     margin-left: 30px;
   }
+
   .code.wrong {
     background: #fee;
     color: #b00;
   }
+
   .code.correct {
     background: #dfd;
     color: #080;
   }
+
   .feedback-table-messages {
     margin-bottom: 9.5px;
   }
-  .row > .messages {
+
+  .row>.messages {
     margin-left: 1em;
     margin-right: 1em;
   }
-  .message-zeus, .message-staff {
+
+  .message-zeus,
+  .message-staff {
     border-left: 3px solid $text-secondary;
     padding-left: 25px
   }
-  .message-zeus:before, .message-staff:before, .tab-zeus:before, .tab-staff:before {
+
+  .message-zeus:before,
+  .message-staff:before,
+  .tab-zeus:before,
+  .tab-staff:before {
     font: normal normal normal 24px/1 "Material Design Icons";
     color: $text-secondary;
     font-size: 18px;
   }
-  .message-zeus:before, .message-staff:before {
+
+  .message-zeus:before,
+  .message-staff:before {
     position: absolute;
     left: 22px;
   }
-  .tab-zeus:before, .tab-staff:before {
+
+  .tab-zeus:before,
+  .tab-staff:before {
     padding-right: 7px;
   }
-  .message-zeus:before, .tab-zeus:before {
+
+  .message-zeus:before,
+  .tab-zeus:before {
     content: "\F0032";
   }
-  .message-staff:before, .tab-staff:before {
+
+  .message-staff:before,
+  .tab-staff:before {
     content: "\F0474";
   }
+
   .message-zeus+.message-zeus:before,
   .message-staff+.message-staff:before {
     content: '';
   }
+
   .tab-link-marker {
-    background: $brand-warning !important;
+    background: $brand-warning  !important;
   }
 }
 
@@ -297,12 +362,18 @@ iframe.file {
   .status-icon {
     padding-right: 6px;
   }
-  .status-line, .byline, .description, .score {
+
+  .status-line,
+  .byline,
+  .description,
+  .score {
     display: block;
   }
+
   .description {
     margin-bottom: 6px;
   }
+
   .edit-score {
     margin-left: 10px;
   }
@@ -334,6 +405,6 @@ iframe.file {
   .submission-link {
     min-width: 24px;
     display: inline-block;
-    margin-right:6px;
+    margin-right: 6px;
   }
 }

--- a/app/assets/stylesheets/models/users.css.scss
+++ b/app/assets/stylesheets/models/users.css.scss
@@ -6,22 +6,29 @@
   .user-icon {
     padding-right: 12px;
   }
+
   .profile-byline {
     margin-bottom: 3px;
   }
-  .profile-line, .profile-byline {
+
+  .profile-line,
+  .profile-byline {
     display: block;
   }
+
   .name {
     font-weight: 400;
     font-size: 18px;
   }
+
   .timezone {
     margin-left: 48px;
   }
+
   .stat {
     margin-bottom: 12px;
   }
+
   .labels {
     margin-left: 6px;
   }

--- a/app/assets/stylesheets/pages/export.css.scss
+++ b/app/assets/stylesheets/pages/export.css.scss
@@ -1,5 +1,6 @@
 .copy-table .selection-row {
   cursor: pointer;
+
   &:hover {
     background-color: $table-hover-bg;
   }

--- a/app/assets/stylesheets/pages/home.css.scss
+++ b/app/assets/stylesheets/pages/home.css.scss
@@ -17,7 +17,8 @@
   color: $home-lead-fg;
   margin-bottom: 20px;
 
-  .btn, .btn:active {
+  .btn,
+  .btn:active {
     border-radius: 2px;
     background-color: $content-bg;
     border-color: $home-lead-bg;
@@ -69,6 +70,7 @@
 .info-step img {
   padding-left: 25px;
   padding-right: 25px;
+
   @include media-breakpoint-down(md) {
     margin: auto;
   }
@@ -132,6 +134,7 @@
   margin-right: 45px;
   margin-top: 10px;
   margin-bottom: 15px;
+
   @media (max-width: 480px) {
     margin-top: 5px;
     margin-bottom: 5px;
@@ -174,6 +177,7 @@
   margin-top: -6px;
   margin-bottom: -6px;
 }
+
 .metric {
   margin-top: 6px;
   margin-bottom: 6px;

--- a/app/assets/stylesheets/pages/sign-in.css.scss
+++ b/app/assets/stylesheets/pages/sign-in.css.scss
@@ -9,6 +9,7 @@
   .card {
     flex-grow: 1;
   }
+
   .login-button {
     border-bottom-left-radius: 0;
     border-top-left-radius: 0;
@@ -28,6 +29,7 @@
 .sign-in-dialog-wrapper h2 {
   line-height: 1;
   margin-top: 15px;
+
   small {
     font-size: 50%;
   }
@@ -66,7 +68,9 @@ input:focus {
   .card {
     margin-bottom: 0;
   }
+
   margin-bottom: 16px;
+
   .tt-menu {
     max-height: 150px;
     overflow-y: auto;
@@ -78,7 +82,8 @@ input:focus {
     background-color: lightskyblue;
   }
 
-  .tt-input, .tt-hint {
+  .tt-input,
+  .tt-hint {
     border: none;
     font-size: 18px;
     min-height: 42px;

--- a/app/assets/stylesheets/print.css.scss
+++ b/app/assets/stylesheets/print.css.scss
@@ -20,7 +20,12 @@
   }
 
   // Do not underline titles that are links
-  h1, h2, h3, h4, h5, h6 {
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
     a {
       text-decoration: none;
     }


### PR DESCRIPTION
This pull request formats all scss files.

In the material 3 PR, I was struggling to not include simple formatting changes in the PR. Since more css work is planned, this PR formats all scss files according to some rules:

- separate rulesets by a blank line
- separate selectors with a new line
- preserve new lines
- no spaces around >, + or ~

This depends on #3685.