### PR TITLE
Make darkmode darker following material 3 spec

### DIFF
--- a/app/assets/stylesheets/layout/footer.css.scss
+++ b/app/assets/stylesheets/layout/footer.css.scss
@@ -13,8 +13,8 @@ $footer-height-sm: 180px;
   flex-shrink: 0;
   width: 100%;
   padding: 32px;
-  color: $gray-80;
-  background-color: $gray-20;
+  color: $on-footer;
+  background-color: $footer;
   height: $footer-height;
 }
 

--- a/app/assets/stylesheets/theme/m3-theme-dark.css.scss
+++ b/app/assets/stylesheets/theme/m3-theme-dark.css.scss
@@ -1,6 +1,7 @@
 // This file contains all "design tokens" according to material 3 in light mode.
 // At the bottom of this file, there are a number of dodona-specific variables
 
+@use "sass:color";
 @import "theme/m3-theme.css.scss";
 
 @mixin theme-dark {
@@ -20,12 +21,12 @@
   $on-tertiary: $tertiary-20  !global;
   $on-tertiary-container: $tertiary-90  !global;
 
-  $surface: $neutral-20  !global;
+  $surface: color.mix($neutral-10, $primary, $weight: 95%)  !global;
   $surface-variant: $neutral-variant-30  !global;
-  $background: $neutral-25  !global;
-  $on-surface: $neutral-90  !global;
+  $background: $neutral-10  !global;
+  $on-surface: color.mix($neutral-90, $primary, $weight: 95%)  !global;
   $on-surface-variant: $neutral-variant-80  !global;
-  $on-surface-muted: $neutral-80  !global;
+  $on-surface-muted: color.mix($neutral-80, $primary, $weight: 95%)  !global;
   $on-background: $neutral-90  !global;
 
   $outline: $neutral-variant-60  !global;
@@ -148,8 +149,11 @@
 
   $off-surface: $neutral-20  !global;
 
-  $code-bg: $neutral-30  !global;
+  $code-bg: $neutral-20  !global;
   $skeleton-color: $surface-variant  !global;
+
+  $footer: $surface  !global;
+  $on-footer: $on-surface  !global;
 
   .light-only {
     display: none;

--- a/app/assets/stylesheets/theme/m3-theme-light.css.scss
+++ b/app/assets/stylesheets/theme/m3-theme-light.css.scss
@@ -152,6 +152,9 @@ $off-surface: $neutral-95;
 $code-bg: $neutral-95;
 $skeleton-color: $surface-variant;
 
+$footer: $gray-20;
+$on-footer: $gray-80;
+
 // this should be fixed using css and not in scss
 .dark-only {
   display: none;


### PR DESCRIPTION
This pull request makes the dark surfaces of darkmode darker. This follows the darkmode material 3 spec that uses tone 10 as background.

Surfaces also use tone 10 in the spec, but elevated surfaces use an overlay with the primary color and low opacity. Recreating an overlay as specified was hard, so I simulated the same effect by using the color.mix sass function.

New
![image](https://user-images.githubusercontent.com/21177904/173347243-e6a41eee-8d26-45ce-b4ac-c7c641a3f0a4.png)
Old
![image](https://user-images.githubusercontent.com/21177904/173347299-c42df1d7-0ba6-41f9-b6b1-494e4572ff0e.png)
Merged with #3711
![image](https://user-images.githubusercontent.com/21177904/173348133-4bbf14f4-4be2-4769-b69f-7551dd34ca89.png)
Combined with #3711 and #3710 
![image](https://user-images.githubusercontent.com/21177904/173349626-54cd5b3b-fa3b-43a6-8c80-c3ff195bb0ee.png)


