### PR TITLE
Set browser color scheme to dark in dark mode

### DIFF
--- a/app/assets/stylesheets/theme/m3-theme-dark.css.scss
+++ b/app/assets/stylesheets/theme/m3-theme-dark.css.scss
@@ -158,4 +158,8 @@
   .dark-only {
     display: unset;
   }
+
+  :root {
+    color-scheme: dark;
+  }
 }

--- a/app/assets/stylesheets/theme/m3-theme-light.css.scss
+++ b/app/assets/stylesheets/theme/m3-theme-light.css.scss
@@ -160,3 +160,7 @@ $skeleton-color: $surface-variant;
 .light-only {
   display: unset;
 }
+
+:root {
+  color-scheme: light;
+}


### PR DESCRIPTION
This pull request instructs the browser to use a dark color scheme when Dodona is set to dark mode. This causes the browser to use a different default set of styles which fixes some unstyled elements:

Before:
![image](https://user-images.githubusercontent.com/481872/176011643-becc1856-bfd9-4a01-b8b2-9454aab32056.png)

After:
![image](https://user-images.githubusercontent.com/481872/176011694-5e77c0fd-5da1-4fd2-a8b4-ccfe158d24dd.png)

