### PR TITLE
Never link to activity when viewing inside course and not accessible

### DIFF
--- a/app/views/activities/_series_activities_table.html.erb
+++ b/app/views/activities/_series_activities_table.html.erb
@@ -53,8 +53,6 @@
           <%= "#{index + 1}." if local_assigns[:series]&.activity_numbers_enabled? %>
           <% if activity.accessible?(current_user, @course) %>
             <%= link_to activity.name, get_activity_path.call(activity) %>
-          <% elsif activity.access_public? %>
-            <%= link_to activity.name, activity_path(activity) %>
           <% else %>
             <%= activity.name %>
             <% if current_user&.course_admin?(@course) && current_user&.repository_admin?(activity.repository) %>


### PR DESCRIPTION
This resulted in confusing UX when students are not subscribed to a course and exercises in an evaluation were public. `accessible?` can only return `false` in the case of an exercise in a hidden series (for unregistered users), which is precisely the case we want to tighten up.
