### PR TITLE
Slightly darker danger and success in dark mode

### DIFF
--- a/app/assets/stylesheets/theme/m3-theme-dark.css.scss
+++ b/app/assets/stylesheets/theme/m3-theme-dark.css.scss
@@ -41,12 +41,14 @@
   $on-info: $info-20  !global;
   $on-info-container: $info-90  !global;
 
-  $success: $success-80  !global;
+  // changed from 80 to 70
+  $success: $success-70  !global;
   $success-container: $success-30  !global;
   $on-success: $success-20  !global;
   $on-success-container: $success-90  !global;
 
-  $danger: $danger-80  !global;
+  // changed from 80 to 70
+  $danger: $danger-70  !global;
   $danger-container: $danger-30  !global;
   $on-danger: $danger-20  !global;
   $on-danger-container: $danger-90  !global;


### PR DESCRIPTION
This pull request tweaks the danger and success colors in dark mode to be slightly darker.  A similar change was previously made in light mode.

Before:
![image](https://user-images.githubusercontent.com/481872/176668477-7bffea2e-80b4-41d6-9c19-db90154be414.png)

After:
![image](https://user-images.githubusercontent.com/481872/176668513-385534ee-1f19-4c3c-a2fe-76903b5c23c6.png)
