### PR TITLE
Remove accidental blue in the feedback table

### DIFF
--- a/app/assets/stylesheets/models/submissions.css.scss
+++ b/app/assets/stylesheets/models/submissions.css.scss
@@ -1,5 +1,5 @@
-$feedback-diff-table-header-bg: $surface-variant;
-$feedback-diff-table-header-fg: $on-surface-variant;
+$feedback-diff-table-header-bg: $code-bg;
+$feedback-diff-table-header-fg: $on-background;
 
 .submissions-table {
   th.status-column {


### PR DESCRIPTION
This pull request removes an accidental blue color in the feedback table.

Before
![image](https://user-images.githubusercontent.com/481872/176681721-467f4b37-3e87-4b74-bc86-ef2f29112a7f.png)

After
![image](https://user-images.githubusercontent.com/481872/176681761-c1ab9389-2748-4f1a-9a60-dd5186292474.png)


