### PR TITLE
Tweak the rainbow status color

### DIFF
--- a/app/assets/stylesheets/models/series.css.scss
+++ b/app/assets/stylesheets/models/series.css.scss
@@ -148,12 +148,12 @@
       $p6: 90%;
 
       background-image: linear-gradient(-135deg,
-          $red $p1,
-          $orange $p2,
-          $yellow $p3,
-          $green $p4,
-          $blue $p5,
-          $purple $p6 );
+          $red-70 $p1,
+          $orange-70 $p2,
+          $yellow-70 $p3,
+          $green-70 $p4,
+          $blue-70 $p5,
+          $purple-70 $p6 );
 
       i {
         font-weight: bolder;


### PR DESCRIPTION
This pull request fixes the rainbow status color. It was defined in css based on sass variables which were changed in the redesign. This PR picks a different tone to make them look more like the current design in production.

Before
![image](https://user-images.githubusercontent.com/481872/176689074-2a4acee5-ce1b-42b6-bed3-5366b8e3fc8d.png)

After
![image](https://user-images.githubusercontent.com/481872/176689172-9653088b-6673-4d4f-9fb9-213d8e1c58ad.png)
![image](https://user-images.githubusercontent.com/481872/176689249-6ebe903a-2ced-44d2-bdcd-f5614acf963f.png)
