### PR TITLE
Only allow submissions within the same course to be considered within an evaluation

### DIFF
--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -88,7 +88,7 @@ class Feedback < ApplicationRecord
 
   def determine_submission
     # First because the default order is id: :desc
-    self.submission = user.submissions.of_exercise(exercise).before_deadline(evaluation.deadline).first
+    self.submission = user.submissions.in_course(evaluation.series.course).of_exercise(exercise).before_deadline(evaluation.deadline).first
     self.completed = true if submission.nil?
   end
 
@@ -117,5 +117,6 @@ class Feedback < ApplicationRecord
   def submission_user_exercise_correct
     errors.add(:submission, 'user should be the same as in the evaluation') if submission.present? && submission.user_id != user.id
     errors.add(:submission, 'exercise should be the same as in the evaluation') if submission.present? && submission.exercise_id != exercise.id
+    errors.add(:submission, 'course should be the same as in the evaluation') if submission.present? && submission.course_id != evaluation.series.course_id
   end
 end

--- a/test/controllers/feedbacks_controller_test.rb
+++ b/test/controllers/feedbacks_controller_test.rb
@@ -45,7 +45,7 @@ class FeedbacksControllerTest < ActionDispatch::IntegrationTest
     @feedback.reload
     assert_equal 1, @feedback.scores.count
 
-    s = create :submission, exercise: @feedback.exercise, user: @feedback.user
+    s = create :submission, exercise: @feedback.exercise, user: @feedback.user, course: @feedback.evaluation.series.course
 
     patch evaluation_feedback_path(@evaluation, @feedback), params: {
       feedback: {
@@ -69,7 +69,7 @@ class FeedbacksControllerTest < ActionDispatch::IntegrationTest
     @feedback.reload
     assert_equal 10, @feedback.scores.count
 
-    s = create :submission, exercise: @feedback.exercise, user: @feedback.user
+    s = create :submission, exercise: @feedback.exercise, user: @feedback.user, course: @feedback.evaluation.series.course
 
     patch evaluation_feedback_path(@evaluation, @feedback), params: {
       feedback: {

--- a/test/models/feedback_test.rb
+++ b/test/models/feedback_test.rb
@@ -71,6 +71,23 @@ class FeedbackTest < ActiveSupport::TestCase
     assert_not feedback.completed
   end
 
+  test 'feedback cannot have submission from other course' do
+    feedback = @evaluation.feedbacks.where.not(submission_id: nil).first
+    user = feedback.user
+    exercise = feedback.exercise
+    course = create :course
+    submission = create :submission, user: user, exercise: exercise, course: @evaluation.series.course
+
+    feedback.update(submission_id: submission.id)
+    assert_empty feedback.errors
+
+    course = create :course
+    submission = create :submission, user: user, exercise: exercise, course: course
+
+    feedback.update(submission_id: submission.id)
+    assert_not_empty feedback.errors
+  end
+
   test 'score calculations are correct' do
     feedback = @evaluation.feedbacks.where.not(submission_id: nil).first
     si1 = create :score_item, evaluation_exercise: feedback.evaluation_exercise

--- a/test/models/feedback_test.rb
+++ b/test/models/feedback_test.rb
@@ -75,7 +75,6 @@ class FeedbackTest < ActiveSupport::TestCase
     feedback = @evaluation.feedbacks.where.not(submission_id: nil).first
     user = feedback.user
     exercise = feedback.exercise
-    course = create :course
     submission = create :submission, user: user, exercise: exercise, course: @evaluation.series.course
 
     feedback.update(submission_id: submission.id)


### PR DESCRIPTION
This pull request adds extra filters and checks to make sure no submission from outside the course are used in an evaluation.

This fixes a bug that has appeared in our test environment with dummy data.

- [x] Tests were added
