### PR TITLE
Switch memcached server to calliope

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -78,7 +78,7 @@ Rails.application.configure do
   config.log_tags = [ :request_id ]
 
   # Use a different cache store in production.
-  config.cache_store = :mem_cache_store, 'elysium.ugent.be', {namespace: :"2"}
+  config.cache_store = :mem_cache_store, 'calliope.ugent.be', {namespace: :"2"}
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
   # config.active_job.queue_adapter     = :resque


### PR DESCRIPTION
This pull request switches the memcached server from elysium to calliope.

@rien the firewall on calliope seems to be too strict. It should allow incoming connections to 11211 (tcp) from dodona.ugent.be and the workers.

