### PR TITLE
Add announcement in database seed with login tokens

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -467,14 +467,8 @@ if Rails.env.development?
 
   puts "Add announcements (#{Time.now - start})"
 
-  sign_in_announcement = Announcement.create text_nl: "## Log in met:
-- [zeus](/users/#{zeus.id}/token/#{zeus.token})
-- [staff](/users/#{staff.id}/token/#{staff.token})
-- [student](/users/#{jelix.id}/token/#{jelix.token})",
-                      text_en: "## Sign in to:
-- [zeus](/users/#{zeus.id}/token/#{zeus.token})
-- [staff](/users/#{staff.id}/token/#{staff.token})
-- [student](/users/#{jelix.id}/token/#{jelix.token})",
+  sign_in_announcement = Announcement.create text_nl: "Log in met [zeus](/users/#{zeus.id}/token/#{zeus.token}), [staff](/users/#{staff.id}/token/#{staff.token}) of [student](/users/#{jelix.id}/token/#{jelix.token})",
+                      text_en: "Sign in to [zeus](/users/#{zeus.id}/token/#{zeus.token}), [staff](/users/#{staff.id}/token/#{staff.token}) or [student](/users/#{jelix.id}/token/#{jelix.token})",
                       user_group: :everyone,
                       style: :info
   AnnouncementView.create user:zeus, announcement: sign_in_announcement

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -465,5 +465,22 @@ if Rails.env.development?
                     code: '',
                     result: File.read(Rails.root.join('db', 'results', "#{exercise.judge.name}-result.json"))
 
+  puts "Add announcements (#{Time.now - start})"
+
+  sign_in_announcement = Announcement.create text_nl: "## Log in met:
+- [zeus](/users/#{zeus.id}/token/#{zeus.token})
+- [staff](/users/#{staff.id}/token/#{staff.token})
+- [student](/users/#{jelix.id}/token/#{jelix.token})",
+                      text_en: "## Sign in to:
+- [zeus](/users/#{zeus.id}/token/#{zeus.token})
+- [staff](/users/#{staff.id}/token/#{staff.token})
+- [student](/users/#{jelix.id}/token/#{jelix.token})",
+                      user_group: :everyone,
+                      style: :info
+  AnnouncementView.create user:zeus, announcement: sign_in_announcement
+  AnnouncementView.create user:staff, announcement: sign_in_announcement
+  AnnouncementView.create user:jelix, announcement: sign_in_announcement
+
+
   puts "Finished! (#{Time.now - start})"
 end


### PR DESCRIPTION
This pull request adds an announcement with the login tokens for the default users to the database seed. This only impact or development environments. It improves usability of those environments.

![image](https://user-images.githubusercontent.com/21177904/177120709-6697b1bc-a652-4dcb-b7e2-62913b4d920b.png)

I'll fix the broken homepage design with announcements in a separate pr.
