### PR TITLE
Fix about page header layout when it contains alerts

### DIFF
--- a/app/assets/stylesheets/pages/home.css.scss
+++ b/app/assets/stylesheets/pages/home.css.scss
@@ -11,8 +11,9 @@
 .home-header {
   position: relative;
 }
+
 .home-header:before {
-  content:"";
+  content: "";
   background: $primary-30;
   position: absolute;
   width: 100vw;

--- a/app/assets/stylesheets/pages/home.css.scss
+++ b/app/assets/stylesheets/pages/home.css.scss
@@ -8,6 +8,21 @@
   z-index: -1;
 }
 
+.home-header {
+  position: relative;
+}
+.home-header:before {
+  content:"";
+  background: $primary-30;
+  position: absolute;
+  width: 100vw;
+  height: 380px;
+  z-index: -1;
+  left: 50%;
+  transform: translate(-50%, 0);
+}
+
+
 .home-header img {
   margin-top: -35px;
   margin-bottom: -10px;


### PR DESCRIPTION
This pull request fixes the about page header layout when it contains alerts. The blue background now moves with the header.

It will work smoothly with alerts up to 380px height. 
Before
![image](https://user-images.githubusercontent.com/21177904/177119479-f4ccb34c-0389-445a-b375-7575c661994d.png)

After
![image](https://user-images.githubusercontent.com/21177904/177119435-347b98a4-672b-47f9-883b-eeb0cf3744e8.png)

