### PR TITLE
Improve the color scheme of heatmaps

### DIFF
--- a/app/assets/javascripts/heatmap.ts
+++ b/app/assets/javascripts/heatmap.ts
@@ -73,7 +73,7 @@ function drawHeatmap(data: [dayjs.Dayjs, number][], oldestFirst: boolean, year: 
     const darkMode = window.dodona.darkMode;
     const emptyColor = darkMode ? "#303034" : "#fcfcff";
     const lowColor = darkMode ? "#4a4046" : "#ffd9df";
-    const highColor = darkMode ? "#ffb2c0" : "#7c002d";
+    const highColor = darkMode ? "#ffb2c0" : "#bc0049";
 
     const longMonthNames = monthKeys.map(k => I18n.t(`js.months.long.${k}`));
     const shortMonthNames = monthKeys.map(k => I18n.t(`js.months.short.${k}`));

--- a/app/assets/javascripts/heatmap.ts
+++ b/app/assets/javascripts/heatmap.ts
@@ -71,9 +71,9 @@ function initHeatmap(url: string, oldestFirst: boolean, year: string | undefined
 
 function drawHeatmap(data: [dayjs.Dayjs, number][], oldestFirst: boolean, year: string | undefined): void {
     const darkMode = window.dodona.darkMode;
-    const emptyColor = darkMode ? "#001d36" : "#fcfcff";
-    const lowColor = darkMode ? "#00325a" : "#d0e4ff";
-    const highColor = darkMode ? "#9ccaff" : "#003d6c";
+    const emptyColor = darkMode ? "#303034" : "#fcfcff";
+    const lowColor = darkMode ? "#4a4046" : "#ffd9df";
+    const highColor = darkMode ? "#ffb2c0" : "#7c002d";
 
     const longMonthNames = monthKeys.map(k => I18n.t(`js.months.long.${k}`));
     const shortMonthNames = monthKeys.map(k => I18n.t(`js.months.short.${k}`));

--- a/app/assets/javascripts/visualisations/timeseries.ts
+++ b/app/assets/javascripts/visualisations/timeseries.ts
@@ -46,9 +46,9 @@ export class TimeseriesGraph extends SeriesExerciseGraph {
 
         super.draw(animation);
 
-        const emptyColor = this.darkMode ? "#001d36" : "#fcfcff";
-        const lowColor = this.darkMode ? "#00325a" : "#d0e4ff";
-        const highColor = this.darkMode ? "#9ccaff" : "#003d6c";
+        const emptyColor = this.darkMode ? "#303034" : "#fcfcff";
+        const lowColor = this.darkMode ? "#3e434d" : "#d0e4ff";
+        const highColor = this.darkMode ? "#9ccaff" : "#0061a6";
 
         const end = new Date(this.maxDate);
         end.setHours(0, 0, 0, 0); // bin and domain seem to handle end differently


### PR DESCRIPTION
This pr improves the color scheme of the heatmaps. In the course statistics we now use the secondary color to match the punchcards.

In both heathmaps I changed the lightmode primary tone to 40 as this tone is more frequently used throughout the app.
In both heathmaps I changed the darkmode lowColor to be the highcolor with 7/8 background color mixed in. (This causes the color to fade into the background instead of just growing darker) 

![image](https://user-images.githubusercontent.com/21177904/177149831-d9d25614-e1c9-4f0a-9c6c-70c850ea0b01.png)
![image](https://user-images.githubusercontent.com/21177904/177149838-5e162738-c34f-40cc-ae88-7f196d4f653d.png)
![image](https://user-images.githubusercontent.com/21177904/177149849-4defb0da-0f11-4016-aa74-38e7d9b66e3e.png)
![image](https://user-images.githubusercontent.com/21177904/177149864-a261327d-b86c-4b33-927b-2e0c85d198cf.png)
