### PR TITLE
Add stylelint as scss linter

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -41,3 +41,21 @@ jobs:
     - name: Lint
       run: |
         yarn lint --quiet
+
+  css:
+    name: CSS
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 12.x
+          cache: yarn
+      - name: Install dependencies
+        run: |
+          yarn install
+      - name: Lint
+        run: |
+          yarn lint:css
+

--- a/.stylelintrc
+++ b/.stylelintrc
@@ -1,0 +1,11 @@
+extends:
+  - "stylelint-config-standard-scss"
+rules:
+  color-hex-length: long
+  scss/dollar-variable-empty-line-before: null
+  scss/at-import-partial-extension: null
+  no-descending-specificity: null
+  alpha-value-notation: number
+  no-invalid-position-at-import-rule: null
+  number-max-precision: null
+

--- a/app/assets/stylesheets/base.css.scss
+++ b/app/assets/stylesheets/base.css.scss
@@ -5,14 +5,13 @@
 @import "theme/m3-theme-light.css.scss";
 @import "theme/m3-theme-dark.css.scss";
 
-@if $theme =="dark" {
+@if $theme == "dark" {
   @include theme-dark;
 }
 
 @import "bootstrap_variable_overrides.css.scss";
 @import "mixins.css.scss";
 @import "vendor";
-
 @import "theme/rouge.css.scss";
 @import "theme/ace.css.scss";
 
@@ -42,23 +41,27 @@
 @import "../../../node_modules/bootstrap/scss/button-group";
 @import "../../../node_modules/bootstrap/scss/nav";
 @import "../../../node_modules/bootstrap/scss/navbar";
-//@import "../../../node_modules/bootstrap/scss/card";
+
+// @import "../../../node_modules/bootstrap/scss/card";
 @import "../../../node_modules/bootstrap/scss/accordion";
+
 // @import "../../../node_modules/bootstrap/scss/breadcrumb";
 @import "../../../node_modules/bootstrap/scss/pagination";
 @import "../../../node_modules/bootstrap/scss/badge";
 @import "../../../node_modules/bootstrap/scss/alert";
-//@import "../../../node_modules/bootstrap/scss/progress";
+
+// @import "../../../node_modules/bootstrap/scss/progress";
 @import "../../../node_modules/bootstrap/scss/list-group";
 @import "../../../node_modules/bootstrap/scss/close";
-//@import "../../../node_modules/bootstrap/scss/toasts";
+
+// @import "../../../node_modules/bootstrap/scss/toasts";
 @import "../../../node_modules/bootstrap/scss/modal";
 @import "../../../node_modules/bootstrap/scss/tooltip";
 @import "../../../node_modules/bootstrap/scss/popover";
-//@import "../../../node_modules/bootstrap/scss/carousel";
+
+// @import "../../../node_modules/bootstrap/scss/carousel";
 @import "../../../node_modules/bootstrap/scss/spinners";
 @import "../../../node_modules/bootstrap/scss/offcanvas";
-@import "../../../node_modules/bootstrap/scss/helpers";
 @import "../../../node_modules/bootstrap/scss/utilities/api";
 
 :root {
@@ -75,6 +78,7 @@
 @import "models.css.scss";
 @import "print.css.scss";
 
+/* stylelint-disable-next-line selector-class-pattern */
 .field_with_errors input {
   border-color: $danger;
 }

--- a/app/assets/stylesheets/bootstrap_style_overrides.css.scss
+++ b/app/assets/stylesheets/bootstrap_style_overrides.css.scss
@@ -41,6 +41,7 @@ code {
 }
 
 .img-responsive {
+  /* stylelint-disable-next-line scss/at-extend-no-missing-placeholder */
   @extend .img-fluid;
 }
 
@@ -92,8 +93,10 @@ code {
 // popovers
 .popover {
   border-radius: 4px;
-  padding: 0px;
+  padding: 0;
+
   @include shadow-z5;
+
   z-index: 5;
 }
 
@@ -134,7 +137,7 @@ code {
   color: $on-surface-muted;
   padding-bottom: 8px;
   border-bottom-width: 2px;
-  border-bottom-color: $divider  !important;
+  border-bottom-color: $divider !important;
 }
 
 // modals
@@ -162,6 +165,7 @@ code {
 .panel {
   border: 0;
   margin-bottom: 6px;
+
   @include shadow-z3;
 }
 

--- a/app/assets/stylesheets/bootstrap_variable_overrides.css.scss
+++ b/app/assets/stylesheets/bootstrap_variable_overrides.css.scss
@@ -1,6 +1,7 @@
 // boostrap color overrides
 
-// primary, secondary, success, info, warning, danger and the variables for color names are already overridden in m3-theme-light
+// primary, secondary, success, info, warning, danger and the variables for color names
+// are already overridden in m3-theme-light
 
 $body-bg: $background;
 $content-bg: $surface;
@@ -43,9 +44,9 @@ $enable-caret: false;
 $border-radius-base: 12px;
 
 // font stuff
-$font-family-sans-serif: Roboto, "Helvetica Neue", Helvetica, Arial, sans-serif;
-$font-size-base: 0.875rem; //14px;
-$baseLineHeight: 24px;
+$font-family-sans-serif: roboto, "Helvetica Neue", helvetica, arial, sans-serif;
+$font-size-base: 0.875rem; // 14px;
+$baseLineHeight: 24px; /* stylelint-disable-line scss/dollar-variable-pattern */
 $line-height-base: 1.3846153846;
 $min-contrast-ratio: 3;
 
@@ -59,7 +60,7 @@ $alert-bg-scale: 0%;
 
 // bootstrap offcanvas overrides
 $offcanvas-horizontal-width: 700px;
-$offcanvas-border-width: 0px;
+$offcanvas-border-width: 0;
 
 // button stuff
 $btn-padding-x: 24px;

--- a/app/assets/stylesheets/components.css.scss
+++ b/app/assets/stylesheets/components.css.scss
@@ -63,11 +63,11 @@
 
 @keyframes scaleout {
   0% {
-    transform: scale(0.0);
+    transform: scale(0);
   }
 
   100% {
-    transform: scale(1.0);
+    transform: scale(1);
     opacity: 0;
   }
 }

--- a/app/assets/stylesheets/components/btn.css.scss
+++ b/app/assets/stylesheets/components/btn.css.scss
@@ -142,6 +142,7 @@
     &:focus,
     &:active {
       opacity: 1;
+      /* stylelint-disable-next-line color-function-notation */
       background: rgba(white, 0.1);
     }
   }

--- a/app/assets/stylesheets/components/btn.css.scss
+++ b/app/assets/stylesheets/components/btn.css.scss
@@ -142,7 +142,8 @@
     &:focus,
     &:active {
       opacity: 1;
-      background: rgb(white 0.1);
+      /* stylelint-disable-next-line color-function-notation */
+      background: rgba(white, 0.1);
     }
   }
 

--- a/app/assets/stylesheets/components/btn.css.scss
+++ b/app/assets/stylesheets/components/btn.css.scss
@@ -127,7 +127,6 @@
   color: $on-surface-variant;
 
   &:not(.btn-icon-filled) {
-
     &:hover,
     &:focus,
     &:active {
@@ -143,7 +142,7 @@
     &:focus,
     &:active {
       opacity: 1;
-      background: rgba(white, 0.1);
+      background: rgb(white 0.1);
     }
   }
 
@@ -165,6 +164,7 @@
   border-radius: 16px;
   background: $secondary-container;
   color: $on-secondary-container;
+
   @include shadow-z2;
 
   &:hover,
@@ -174,6 +174,7 @@
   &.disabled {
     opacity: 1;
     filter: brightness(0.95);
+
     @include shadow-z3;
   }
 
@@ -187,8 +188,7 @@
 }
 
 .btn-group {
-
-  &>.btn {
+  & > .btn {
     padding-left: 12px;
     padding-right: 12px;
     border: 1px solid $divider;
@@ -235,8 +235,10 @@
   padding: 12px;
   background-color: $surface;
   border-radius: 4px;
-  transition: box-shadow 0.1s cubic-bezier(.4, 0, .2, 1);
+  transition: box-shadow 0.1s cubic-bezier(0.4, 0, 0.2, 1);
+
   @include shadow-z2;
+
   cursor: pointer;
 
   .option-btn-img {

--- a/app/assets/stylesheets/components/btn.css.scss
+++ b/app/assets/stylesheets/components/btn.css.scss
@@ -142,7 +142,6 @@
     &:focus,
     &:active {
       opacity: 1;
-      /* stylelint-disable-next-line color-function-notation */
       background: rgba(white, 0.1);
     }
   }

--- a/app/assets/stylesheets/components/callout.css.scss
+++ b/app/assets/stylesheets/components/callout.css.scss
@@ -22,7 +22,7 @@
 }
 
 /* Tighten up space between multiple callouts */
-.callout+.callout {
+.callout + .callout {
   margin-top: -5px;
 }
 

--- a/app/assets/stylesheets/components/card.css.scss
+++ b/app/assets/stylesheets/components/card.css.scss
@@ -11,8 +11,10 @@ $card-supporting-text-padding: 16px;
   overflow: visible;
   background: $surface;
   border-radius: $border-radius-base;
-  transition: box-shadow 0.2s cubic-bezier(.4, 0, .2, 1);
+  transition: box-shadow 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+
   @include shadow-z2;
+
   margin-bottom: $card-margin-bottom;
 }
 
@@ -75,19 +77,17 @@ a.card-title-link:hover {
 
   .card-subtitle-text {
     margin-top: 3px;
-    opacity: 75%;
+    opacity: 0.75;
   }
 
-  .card-subtitle-text+.card-subtitle-text {
+  .card-subtitle-text + .card-subtitle-text {
     margin-top: 10px;
   }
 
   a {
     color: inherit;
   }
-}
 
-.card-title.card-colored-accent {
   &.accent-red {
     background-color: $red-container;
     color: $on-red-container;
@@ -174,8 +174,8 @@ a.card-title-link:hover {
   margin: 0;
 }
 
-.card-title-text+.card-subtitle-text {
-  margin-top: .4em;
+.card-title-text + .card-subtitle-text {
+  margin-top: 0.4em;
 }
 
 .card-title-text.float-end {
@@ -189,9 +189,9 @@ a.card-title-link:hover {
 }
 
 .card-title-image {
-  background: rgba(0, 0, 0, 0.5);
+  background: rgb(0 0 0 / 0.5);
   color: $on-primary;
-  text-shadow: 0 1px 3px rgba(0, 0, 0, 0.6);
+  text-shadow: 0 1px 3px rgb(0 0 0 / 0.6);
   height: 61px;
   margin-top: -61px;
   z-index: 1;
@@ -233,14 +233,15 @@ a.card-title-link:hover {
   border-top: 1px solid $divider;
 }
 
-.card-title+.card-border {
-  border-top: 0px;
+.card-title + .card-border {
+  border-top: 0;
 }
 
 .card-expand {
   flex-grow: 1;
 }
 
+/* stylelint-disable-next-line selector-class-pattern */
 .card_menu {
   position: absolute;
   right: 16px;
@@ -298,9 +299,6 @@ a.card-title-link:hover {
 
 .card-tab .nav-tabs li a,
 .card-title .nav-tabs li a {
-  padding-bottom: 8px;
-  padding-left: 10px;
-  padding-right: 10px;
   margin-right: 10px;
   height: 55px;
   border: none;
@@ -309,6 +307,9 @@ a.card-title-link:hover {
   transition-duration: 0.2s;
   transition-property: height;
   transition-timing-function: ease-out;
+  display: block;
+  padding: 10px 10px 8px;
+  line-height: 25px;
 }
 
 .card-title-colored .nav-tabs li a,
@@ -319,13 +320,6 @@ a.card-title-link:hover {
 
 .card-tab .nav-tabs li a {
   color: $on-surface-muted;
-}
-
-.card-title .nav-tabs li a,
-.card-tab .nav-tabs li a {
-  display: block;
-  padding-top: 10px;
-  line-height: 25px;
 }
 
 .card-tab .nav-tabs li a.active,
@@ -356,7 +350,7 @@ a.card-title-link:hover {
 }
 
 .card-nav .card-title .btn-icon:hover {
-  background-color: rgba(255, 255, 255, .3);
+  background-color: rgb(255 255 255 / 0.3);
 }
 
 .card-nav .badge {

--- a/app/assets/stylesheets/components/code_listing.css.scss
+++ b/app/assets/stylesheets/components/code_listing.css.scss
@@ -1,3 +1,4 @@
+@use "sass:map";
 $dot-size: 9px;
 
 // Annotation colors
@@ -25,7 +26,6 @@ $annotation-info: $info;
       display: block;
       overflow-x: auto;
       white-space: nowrap;
-
       background-color: $content-bg;
 
       // Override the normal pre padding & coloring
@@ -42,7 +42,8 @@ $annotation-info: $info;
       // Highlight for the line numbers.
       .lineno.marked {
         background-color: $warning-container;
-        //border-left: $code-warning-border-left solid $warning;
+
+        // border-left: $code-warning-border-left solid $warning;
         // Only do the line number, don't extend to the full height
         background-clip: content-box;
       }
@@ -69,7 +70,6 @@ $annotation-info: $info;
       }
 
       .lineno:first-child {
-
         .rouge-code,
         .rouge-gutter {
           padding-top: 5px;
@@ -77,7 +77,6 @@ $annotation-info: $info;
       }
 
       .lineno:last-child {
-
         .rouge-code,
         .rouge-gutter {
           padding-bottom: 5px;
@@ -129,7 +128,7 @@ $annotation-info: $info;
         }
 
         .dot-user {
-          background-color: $annotation-user
+          background-color: $annotation-user;
         }
 
         .dot-error {
@@ -154,7 +153,6 @@ $annotation-info: $info;
       .annotation-cell {
         width: 100%;
         min-width: 100%;
-
       }
     }
   }
@@ -164,18 +162,14 @@ $annotation-info: $info;
   }
 
   .annotation {
-
-    margin: 3px 5px 3px 5px;
+    margin: 3px 5px;
     padding: 2px 5px 2px 10px;
-
     border-top-right-radius: 5px;
     border-bottom-right-radius: 5px;
     border: 1px solid $divider;
     border-left-width: 3px;
     border-left-color: $outline;
-
     background: $content-bg;
-
     white-space: normal;
 
     .annotation-header {
@@ -183,13 +177,14 @@ $annotation-info: $info;
         font-size: 85%;
         color: $on-surface-muted;
       }
-
+      /* stylelint-disable selector-class-pattern */
       .annotation-edit,
       .question-resolve,
       .question-in_progress,
       .question-unresolve {
         float: right;
       }
+      /* stylelint-enable selector-class-pattern */
 
       .annotation-visibility {
         &::before {
@@ -215,7 +210,7 @@ $annotation-info: $info;
       // Override the normal pre padding & coloring
       pre {
         padding: 0;
-        background-color: $code-bg  !important;
+        background-color: $code-bg !important;
         margin-bottom: 0;
         border: none;
         border-radius: 0;
@@ -247,19 +242,18 @@ $annotation-info: $info;
       img {
         display: block;
         margin: 10px auto 20px;
-
         max-width: 300px;
 
         @include media-breakpoint-up(md) {
-          max-width: calc(#{map-get($container-max-widths, "md")} * 0.6);
+          max-width: calc(#{map.get($container-max-widths, "md")} * 0.6);
         }
 
         @include media-breakpoint-up(lg) {
-          max-width: calc(#{map-get($container-max-widths, "lg")} * 0.7);
+          max-width: calc(#{map.get($container-max-widths, "lg")} * 0.7);
         }
 
         @include media-breakpoint-up(xl) {
-          max-width: calc(#{map-get($container-max-widths, "xl")} * 0.7);
+          max-width: calc(#{map.get($container-max-widths, "xl")} * 0.7);
         }
       }
     }
@@ -293,6 +287,7 @@ $annotation-info: $info;
   .annotation.machine-annotation {
     .annotation-text {
       font-family: $font-family-monospace;
+
       // pre-wrap for browsers that don't support break-spaces.
       white-space: pre-wrap;
       white-space: break-spaces;
@@ -332,5 +327,4 @@ $annotation-info: $info;
       border-color: $danger;
     }
   }
-
 }

--- a/app/assets/stylesheets/components/evaluations.css.scss
+++ b/app/assets/stylesheets/components/evaluations.css.scss
@@ -206,6 +206,7 @@ $user-column-width: 170px;
 .score-table {
   // Allows borders to be sticky.
   border-collapse: separate;
+
   // Prevent rows from becoming ugly; we provide scrolling instead.
   white-space: nowrap;
 
@@ -245,6 +246,7 @@ $user-column-width: 170px;
   thead tr th:nth-child(2) {
     background: $content-bg;
     position: sticky;
+
     // Raise index, to prevent sticky column from rolling over the header.
     z-index: 2;
     left: $user-column-width - 4px;

--- a/app/assets/stylesheets/components/histogram.css.scss
+++ b/app/assets/stylesheets/components/histogram.css.scss
@@ -1,6 +1,7 @@
 d-histogram {
   --d-histogram-baseline: #{$divider};
   --d-histogram-bar: #{$secondary};
+
   max-width: 150px;
   margin: auto;
 }

--- a/app/assets/stylesheets/components/img.css.scss
+++ b/app/assets/stylesheets/components/img.css.scss
@@ -1,6 +1,6 @@
-.course-description :not(.dodona-centered-group)>img:not(.img-unresponsive),
-.exercise-description :not(.dodona-centered-group)>img:not(.img-unresponsive),
-.series-description :not(.dodona-centered-group)>img:not(.img-unresponsive) {
+.course-description :not(.dodona-centered-group) > img:not(.img-unresponsive),
+.exercise-description :not(.dodona-centered-group) > img:not(.img-unresponsive),
+.series-description :not(.dodona-centered-group) > img:not(.img-unresponsive) {
   display: block;
   max-width: 100%;
   height: auto;

--- a/app/assets/stylesheets/components/notification.css.scss
+++ b/app/assets/stylesheets/components/notification.css.scss
@@ -4,7 +4,6 @@ th.status-icon {
 
 .notification {
   &.unread {
-
     .notification-icon,
     .read-indicator {
       color: $info;

--- a/app/assets/stylesheets/components/progress-chart.css.scss
+++ b/app/assets/stylesheets/components/progress-chart.css.scss
@@ -1,5 +1,5 @@
 .progress-chart {
-  shape-rendering: crispEdges;
+  shape-rendering: crispedges;
 
   .correct {
     stroke: $success;

--- a/app/assets/stylesheets/components/scratchpad.css.scss
+++ b/app/assets/stylesheets/components/scratchpad.css.scss
@@ -1,87 +1,88 @@
 .offcanvas-show-btn {
-    white-space: nowrap;
-    font-size: 16px;
-    background-color: $content-bg;
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
-    border-color: $divider;
-    border-bottom: 0;
-    padding-top: 10px;
-    padding-bottom: 10px;
-    position: fixed;
-    bottom: 100px;
-    left: 100%;
-    transform-origin: 0% 100%;
-    transform: rotate(270deg);
+  white-space: nowrap;
+  font-size: 16px;
+  background-color: $content-bg;
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+  border-color: $divider;
+  border-bottom: 0;
+  padding-top: 10px;
+  padding-bottom: 10px;
+  position: fixed;
+  bottom: 100px;
+  left: 100%;
+  transform-origin: 0% 100%;
+  transform: rotate(270deg);
 }
 
 .scratchpad-header {
-    color: $on-primary;
-    background-color: $primary;
-    height: $navbar-height;
-    display: flex;
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    z-index: 10;
-    margin: 0;
-    margin-bottom: 5px;
-    padding-left: 16px;
-    padding-right: 16px;
-    align-items: center;
+  color: $on-primary;
+  background-color: $primary;
+  height: $navbar-height;
+  display: flex;
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 10;
+  margin: 0;
+  margin-bottom: 5px;
+  padding-left: 16px;
+  padding-right: 16px;
+  align-items: center;
 }
 
 .scratchpad-info {
-    padding-left: 20px;
-    font-size: 14px;
-    color: $on-surface-muted;
-    // Header has absolute position, simulate its height using margin-top
-    margin-top: $navbar-height + 5;
+  padding-left: 20px;
+  font-size: 14px;
+  color: $on-surface-muted;
+
+  // Header has absolute position, simulate its height using margin-top
+  margin-top: $navbar-height + 5;
 }
 
 #scratchpad-code-copy-btn {
-    color: white;
-    background-color: $blue-gray;
-    white-space: nowrap;
+  color: white;
+  background-color: $blue-gray;
+  white-space: nowrap;
 }
 
 .scratchpad-content {
-    // Allow children to fill up remaining content
-    display: flex;
-    flex-flow: column;
-    height: 100%;
+  // Allow children to fill up remaining content
+  display: flex;
+  flex-flow: column;
+  height: 100%;
 }
 
 // Wrapper around editor provides margin
 #scratchpad-editor-wrapper {
-    margin-bottom: 20px;
+  margin-bottom: 20px;
 }
 
 // Wrapper and its child should take up as much space as possible
 #scratchpad-editor-wrapper,
-#scratchpad-editor-wrapper>div:first-child {
-    display: flex;
-    flex-flow: column;
-    flex: 1 1 auto;
-    overflow-y: auto;
+#scratchpad-editor-wrapper > div:first-child {
+  display: flex;
+  flex-flow: column;
+  flex: 1 1 auto;
+  overflow-y: auto;
 }
 
 #scrathcpad-output-wrapper {
-    margin-bottom: 10px;
-    flex: 0 1 auto;
+  margin-bottom: 10px;
+  flex: 0 1 auto;
 }
 
 // First child is the output area, limit its size
-#scratchpad-output-wrapper>div:first-child {
-    max-height: 20vh !important;
-    flex: 0 1 auto;
+#scratchpad-output-wrapper > div:first-child {
+  max-height: 20vh !important;
+  flex: 0 1 auto;
 }
 
 #scratchpad-input-wrapper {
-    flex: 0 1 auto;
+  flex: 0 1 auto;
 }
 
 #scratchpad-offcanvas.show {
-    @include shadow-z3;
+  @include shadow-z3;
 }

--- a/app/assets/stylesheets/components/search_field.css.scss
+++ b/app/assets/stylesheets/components/search_field.css.scss
@@ -1,4 +1,4 @@
-.search-filter:focus+.show-search-dropdown,
+.search-filter:focus + .show-search-dropdown,
 .show-search-dropdown:focus,
 .show-search-dropdown:active,
 .show-search-dropdown:target {
@@ -13,5 +13,4 @@
   .dropdown-item {
     padding-left: 2rem;
   }
-
 }

--- a/app/assets/stylesheets/components/stepper.css.scss
+++ b/app/assets/stylesheets/components/stepper.css.scss
@@ -1,6 +1,7 @@
 .stepper {
   .panel {
     @include shadow-z0;
+
     border-radius: 0;
     background-color: transparent;
 
@@ -46,9 +47,9 @@
       }
     }
 
-
-    .panel-heading+.panel-collapse>.panel-body {
+    .panel-heading + .panel-collapse > .panel-body {
       @include shadow-z2;
+
       background-color: $content-bg;
 
       @include media-breakpoint-up(sm) {
@@ -61,10 +62,11 @@
 
       &.panel-body-transparent {
         background-color: transparent;
+
         @include shadow-z0;
       }
 
-      .row+.row {
+      .row + .row {
         margin-top: 20px;
       }
 

--- a/app/assets/stylesheets/components/table-toolbar.css.scss
+++ b/app/assets/stylesheets/components/table-toolbar.css.scss
@@ -31,14 +31,14 @@
   margin: 0;
 }
 
-.table-toolbar .table-toolbar-tools>.mdi::before {
+.table-toolbar .table-toolbar-tools > .mdi::before {
   margin-top: 3px;
   margin-left: 8px;
   color: $on-surface-muted;
 }
 
 .table-toolbar .table-toolbar-tools .search {
-  margin-left: 0px;
+  margin-left: 0;
   flex: 1;
 
   input {
@@ -53,6 +53,7 @@
     outline: none;
   }
 
+  /* stylelint-disable */
   input::-webkit-input-placeholder {
     color: $on-surface-muted;
     font-weight: 300;
@@ -72,6 +73,7 @@
     color: $on-surface-muted;
     font-weight: 300;
   }
+  /* stylelint-enable */
 }
 
 .table-toolbar input {
@@ -106,7 +108,7 @@
   visibility: hidden;
 }
 
-.dodona-progress>.bar {
+.dodona-progress > .bar {
   display: block;
   position: absolute;
   top: 0;
@@ -115,39 +117,42 @@
   transition: width 0.2s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
-.dodona-progress>.progressbar {
+.dodona-progress > .progressbar {
   background-color: $progress-bar-bg;
   z-index: 1;
   left: 0;
 }
 
-.dodona-progress>.bufferbar {
-  background-image: linear-gradient(to right,
-      rgba(255, 255, 255, 0.7),
-      rgba(255, 255, 255, 0.7)),
+.dodona-progress > .bufferbar {
+  background-image:
+    linear-gradient(
+      to right,
+      rgb(255 255 255 / 0.7),
+      rgb(255 255 255 / 0.7)
+    ),
     linear-gradient(to right, $secondary, $secondary);
   z-index: 0;
   left: 0;
 }
 
-.dodona-progress>.auxbar {
+.dodona-progress > .auxbar {
   right: 0;
 }
 
-.dodona-progress.dodona-progress-indeterminate>.bar1,
-.dodona-progress.dodona-progress-indeterminate>.bar3 {
+.dodona-progress.dodona-progress-indeterminate > .bar1,
+.dodona-progress.dodona-progress-indeterminate > .bar3 {
   background-color: $progress-bar-bg;
   animation-duration: 2s;
   animation-iteration-count: infinite;
   animation-timing-function: linear;
 }
 
-.mdl-progress.mdl-progress-indeterminate>.bar3 {
+.mdl-progress.mdl-progress-indeterminate > .bar3 {
   background-image: none;
   animation-name: indeterminate2;
 }
 
-.dodona-progress.dodona-progress-indeterminate>.bar1 {
+.dodona-progress.dodona-progress-indeterminate > .bar1 {
   animation-name: indeterminate1;
 }
 
@@ -169,7 +174,6 @@
 }
 
 @keyframes indeterminate2 {
-
   0%,
   50% {
     left: 0%;

--- a/app/assets/stylesheets/components/table.css.scss
+++ b/app/assets/stylesheets/components/table.css.scss
@@ -1,6 +1,10 @@
 .table-scroll-wrapper {
   overflow-x: auto;
-  background-image: linear-gradient(to right, $content-bg, $content-bg), linear-gradient(to right, $content-bg, $content-bg), linear-gradient(to right, $divider, rgba(255, 255, 255, 0)), linear-gradient(to left, $divider, rgba(255, 255, 255, 0));
+  background-image:
+    linear-gradient(to right, $content-bg, $content-bg),
+    linear-gradient(to right, $content-bg, $content-bg),
+    linear-gradient(to right, $divider, rgb(255 255 255 / 0)),
+    linear-gradient(to left, $divider, rgb(255 255 255 / 0));
   background-position: left center, right center, left center, right center;
   background-repeat: no-repeat;
   background-color: $content-bg;
@@ -55,7 +59,8 @@
 }
 
 tr.gu-mirror {
-  display: table; // ensure that rows dragged from their table parent still have the correct display-style (Dragula table-row issue)
+  // ensure that rows dragged from their table parent still have the correct display-style (Dragula table-row issue)
+  display: table;
 }
 
 .table.table-resource td {
@@ -87,6 +92,7 @@ tr.gu-mirror {
     background: $content-bg;
     position: sticky;
     left: 0;
+
     // Raise index, to prevent sticky column from rolling over the header.
     z-index: 2;
   }
@@ -99,16 +105,18 @@ tr.gu-mirror {
 }
 
 .sticky-wrapper {
+  /* stylelint-disable-next-line max-line-length */
   max-height: calc(100vh - #{$footer-height} - #{$navbar-height} - #{$card-margin-bottom} - #{$card-supporting-text-padding});
+
   // If the height is less than this, it becomes impossible to use the table,
   // so forego the sticky headers a bit.
   min-height: 400px;
   overflow-x: auto;
 }
 
-
 @include media-breakpoint-down(sm) {
   .sticky-wrapper {
+    /* stylelint-disable-next-line max-line-length */
     max-height: calc(100vh - #{$footer-height-sm} - #{$navbar-height} - #{$card-margin-bottom} - #{$card-supporting-text-padding});
   }
 }

--- a/app/assets/stylesheets/components/tokenfield.css.scss
+++ b/app/assets/stylesheets/components/tokenfield.css.scss
@@ -8,15 +8,16 @@
 .tokenfield {
   height: auto;
   min-height: 34px;
-  padding-bottom: 0px;
+  padding-bottom: 0;
   z-index: 1;
 }
 
 .tokenfield.focus {
   border-color: #66afe9;
   outline: 0;
-  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075),
-    0 0 8px rgba(102, 175, 233, 0.6);
+  box-shadow:
+    inset 0 1px 1px rgb(0 0 0 / 0.075),
+    0 0 8px rgb(102 175 233 / 0.6);
 }
 
 .tokenfield .token-input {
@@ -58,23 +59,23 @@
 
 .has-warning .tokenfield.focus {
   border-color: #66512c;
-  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #c0a16b;
+  box-shadow: inset 0 1px 1px rgb(0 0 0 / 0.075), 0 0 6px #c0a16b;
 }
 
 .has-error .tokenfield.focus {
   border-color: #843534;
-  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #ce8483;
+  box-shadow: inset 0 1px 1px rgb(0 0 0 / 0.075), 0 0 6px #ce8483;
 }
 
 .has-success .tokenfield.focus {
   border-color: #2b542c;
-  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #67b168;
+  box-shadow: inset 0 1px 1px rgb(0 0 0 / 0.075), 0 0 6px #67b168;
 }
 
 .tokenfield.form-control-sm,
 .input-group-sm .tokenfield {
   min-height: 30px;
-  padding-bottom: 0px;
+  padding-bottom: 0;
 }
 
 .input-group-sm .token,
@@ -129,7 +130,7 @@
 }
 
 .tokenfield.rtl .token .token-label {
-  padding-left: 0px;
+  padding-left: 0;
   padding-right: 4px;
 }
 
@@ -143,16 +144,18 @@
   font-weight: 400;
   line-height: 1.3846153846;
   $token-height: 32px;
+
   display: inline-flex;
   align-items: center;
   height: $token-height;
   border-radius: 8px;
   padding-left: 12px;
   padding-right: 12px;
-  border-width: 0px;
+  border-width: 0;
   text-transform: capitalize;
   white-space: nowrap;
   cursor: default;
+  margin-right: 8px;
 }
 
 .token .close {
@@ -165,10 +168,6 @@
 .token .close:hover {
   color: $on-surface;
   cursor: pointer;
-}
-
-.token {
-  margin-right: 8px;
 }
 
 .token.accent-red {
@@ -216,17 +215,19 @@
   background-color: $blue-gray-container;
 }
 
+/* stylelint-disable-next-line no-duplicate-selectors */
 .tokenfield {
-
   .form-control {
     height: auto;
   }
 
+  /* stylelint-disable-next-line selector-id-pattern */
   #course_membership_course_labels-tokenfield {
     height: auto;
     padding: 0;
   }
 
+  /* stylelint-disable-next-line selector-id-pattern */
   #exercise_labels-tokenfield {
     height: auto;
     padding: 0;

--- a/app/assets/stylesheets/components/visualisations.css.scss
+++ b/app/assets/stylesheets/components/visualisations.css.scss
@@ -4,11 +4,13 @@
 
 .violin-invisibar {
   visibility: hidden;
-  fill: none
+  fill: none;
 }
 
 .metric-container {
   stroke: $divider;
+  fill: none;
+  stroke-width: 2;
 }
 
 .day-cell {
@@ -27,20 +29,15 @@
   flex-direction: column;
 }
 
+/* stylelint-disable-next-line selector-class-pattern */
 .graph_placeholder {
   margin: auto;
 }
 
-.metric-container {
-  fill: none;
-  stroke-width: 2;
-}
-
 .legend {
   display: flex;
-  flex-direction: row;
+  flex-flow: row wrap;
   justify-content: center;
-  flex-wrap: wrap;
   overflow: hidden;
 
   .legend-item {

--- a/app/assets/stylesheets/layout.css.scss
+++ b/app/assets/stylesheets/layout.css.scss
@@ -10,9 +10,9 @@ body {
 
 // Set height of frame layout to fit-content to allow downsizing
 html.dodona-frame,
-html.dodona-frame>body,
+html.dodona-frame > body,
 html.lti-frame,
-html.lti-frame>body {
+html.lti-frame > body {
   height: fit-content;
   background: $content-bg;
 }
@@ -21,12 +21,10 @@ html.lti-frame>body {
   min-height: 100%;
   position: relative;
   padding-top: 50px;
-
   display: flex;
   flex-direction: row;
   margin: 0;
   width: 100%;
-
 }
 
 .container.main {

--- a/app/assets/stylesheets/layout/drawer.css.scss
+++ b/app/assets/stylesheets/layout/drawer.css.scss
@@ -5,17 +5,14 @@ aside.drawer {
   position: fixed;
   top: 0;
   left: 0;
-
   height: 100vh;
-
   width: 0;
-
   z-index: 5;
 
   .drawer-background {
     z-index: -1;
     opacity: 0;
-    transition: opacity .3s;
+    transition: opacity 0.3s;
     background: $surface;
     position: fixed;
     top: 0;
@@ -32,21 +29,18 @@ aside.drawer {
     padding-top: 50px;
     width: 100%;
     max-width: $drawer-width;
-
     z-index: 6;
-
     display: inline-flex;
     flex-direction: column;
-
     border-left: 0;
     border-right: 1px solid $drawer-border;
-
     overflow-y: auto;
     overflow-x: hidden;
-
     background: $surface;
+
     @include shadow-z5;
-    transition: .3s;
+
+    transition: 0.3s;
   }
 
   &.active {
@@ -61,7 +55,6 @@ aside.drawer {
       width: 100vw;
     }
   }
-
 }
 
 .drawer-group {
@@ -125,7 +118,7 @@ ul.drawer-list {
     &:focus {
       background: $secondary-container;
       color: $on-secondary-container;
-      opacity: 75%;
+      opacity: 0.75;
     }
 
     span,
@@ -133,7 +126,6 @@ ul.drawer-list {
       font-size: 18px;
       margin-right: 12px;
     }
-
   }
 }
 

--- a/app/assets/stylesheets/layout/footer.css.scss
+++ b/app/assets/stylesheets/layout/footer.css.scss
@@ -6,8 +6,7 @@ $footer-height-sm: 180px;
   bottom: 0;
   left: 0;
   display: flex;
-  flex-direction: row;
-  flex-wrap: nowrap;
+  flex-flow: row nowrap;
   justify-content: center;
   align-items: flex-start;
   flex-shrink: 0;
@@ -18,15 +17,14 @@ $footer-height-sm: 180px;
   height: $footer-height;
 }
 
-.footer:after {
-  content: '';
+.footer::after {
+  content: "";
   display: block;
 }
 
 .footer-block {
   display: flex;
-  flex-direction: row;
-  flex-wrap: nowrap;
+  flex-flow: row nowrap;
   flex-shrink: 0;
   align-self: stretch;
   align-items: center;
@@ -36,13 +34,13 @@ $footer-height-sm: 180px;
     margin-left: 1em;
 
     &:hover {
-      opacity: 80%;
+      opacity: 0.8;
       text-decoration: none;
     }
   }
 }
 
-.footer-block>* {
+.footer-block > * {
   flex-shrink: 0;
 }
 

--- a/app/assets/stylesheets/layout/navbar.css.scss
+++ b/app/assets/stylesheets/layout/navbar.css.scss
@@ -1,8 +1,10 @@
 @use "sass:math";
+@use "sass:map";
 $navbar-height: 50px;
 
 .dodona-navbar {
   @include shadow-z3;
+
   background: $primary;
   height: $navbar-height;
   display: flex;
@@ -38,11 +40,11 @@ $navbar-height: 50px;
     }
   }
 
-  .flex:first-child>.content {
+  .flex:first-child > .content {
     margin-right: auto;
   }
 
-  .flex:last-child>.content {
+  .flex:last-child > .content {
     margin-left: auto;
   }
 
@@ -60,19 +62,19 @@ $navbar-height: 50px;
     }
 
     @include media-breakpoint-up(md) {
-      max-width: math.div(map-get($container-max-widths, "md"), 12) * 10;
+      max-width: math.div(map.get($container-max-widths, "md"), 12) * 10;
     }
 
     @include media-breakpoint-up(lg) {
-      max-width: math.div(map-get($container-max-widths, "lg"), 12) * 10;
+      max-width: math.div(map.get($container-max-widths, "lg"), 12) * 10;
     }
 
     @include media-breakpoint-up(xl) {
-      max-width: math.div(map-get($container-max-widths, "xl"), 12) * 10;
+      max-width: math.div(map.get($container-max-widths, "xl"), 12) * 10;
     }
 
     @include media-breakpoint-up(xxl) {
-      max-width: math.div(map-get($container-max-widths, "xxl"), 12) * 10;
+      max-width: math.div(map.get($container-max-widths, "xxl"), 12) * 10;
     }
   }
 
@@ -128,19 +130,19 @@ $navbar-height: 50px;
     }
 
     @include media-breakpoint-up(md) {
-      max-width: calc((#{map-get($container-max-widths, "md")} / 12 * 10) - #{$grid-gutter-width});
+      max-width: calc((#{map.get($container-max-widths, "md")} / 12 * 10) - #{$grid-gutter-width});
     }
 
     @include media-breakpoint-up(lg) {
-      max-width: calc((#{map-get($container-max-widths, "lg")} / 12 * 10) - #{$grid-gutter-width});
+      max-width: calc((#{map.get($container-max-widths, "lg")} / 12 * 10) - #{$grid-gutter-width});
     }
 
     @include media-breakpoint-up(xl) {
-      max-width: calc((#{map-get($container-max-widths, "xl")} / 12 * 10) - #{$grid-gutter-width});
+      max-width: calc((#{map.get($container-max-widths, "xl")} / 12 * 10) - #{$grid-gutter-width});
     }
 
     @include media-breakpoint-up(xxl) {
-      max-width: calc((#{map-get($container-max-widths, "xxl")} / 12 * 10) - #{$grid-gutter-width});
+      max-width: calc((#{map.get($container-max-widths, "xxl")} / 12 * 10) - #{$grid-gutter-width});
     }
 
     .actions {
@@ -181,7 +183,7 @@ $navbar-height: 50px;
       padding-left: 20px;
 
       .notification-dropdown {
-        .table>tbody>tr:first-of-type>td {
+        .table > tbody > tr:first-of-type > td {
           border-top: none;
         }
 
@@ -211,7 +213,7 @@ $navbar-height: 50px;
         }
 
         a {
-          padding-left: 0px;
+          padding-left: 0;
           color: $on-surface;
 
           &.btn-icon {
@@ -271,7 +273,6 @@ $navbar-height: 50px;
         }
 
         .dropdown-menu {
-
           li,
           a {
             color: $on-surface;
@@ -322,6 +323,7 @@ $navbar-height: 50px;
 
     @include media-breakpoint-down(sm) {
       @include shadow-z3;
+
       position: absolute;
       top: $navbar-height;
       right: 0;
@@ -349,7 +351,7 @@ $navbar-height: 50px;
         padding-left: 25px;
       }
 
-      transform: translateY(-.5em);
+      transform: translateY(-0.5em);
     }
   }
 
@@ -359,6 +361,7 @@ $navbar-height: 50px;
 
   .caret {
     @include caret-down;
+
     display: inline-block;
   }
 }
@@ -407,7 +410,7 @@ $navbar-height: 50px;
 
   .crumb:last-child:not(:first-child),
   .crumb:last-child:not(:first-child) a {
-    opacity: 75%;
+    opacity: 0.75;
     pointer-events: none;
     cursor: default;
   }
@@ -417,8 +420,8 @@ $navbar-height: 50px;
   }
 }
 
-a.notification:before {
-  content: '';
+a.notification::before {
+  content: "";
   width: 12px;
   height: 12px;
   border-radius: 50%;
@@ -431,7 +434,7 @@ a.notification:before {
   z-index: 10;
 }
 
-a.notification-left:before {
+a.notification-left::before {
   margin-right: 5px;
   left: 15px;
 }

--- a/app/assets/stylesheets/libraries/dragula.css.scss
+++ b/app/assets/stylesheets/libraries/dragula.css.scss
@@ -22,9 +22,5 @@
 }
 
 .drag-handle .mdi {
-  cursor: grab;
-}
-
-.drag-handle .mdi {
   cursor: grabbing;
 }

--- a/app/assets/stylesheets/libraries/glightbox.css.scss
+++ b/app/assets/stylesheets/libraries/glightbox.css.scss
@@ -1,10 +1,10 @@
 @import "../../../../node_modules/glightbox/dist/css/glightbox";
 
 .glightbox-clean .gslide-description {
-    background: none;
-    font-size: 1.4em;
+  background: none;
+  font-size: 1.4em;
 }
 
 .gslide-desc {
-    color: white;
+  color: white;
 }

--- a/app/assets/stylesheets/mails.sass.scss
+++ b/app/assets/stylesheets/mails.sass.scss
@@ -14,11 +14,11 @@ a {
 }
 
 .error-list {
-  margin: 10px 0px;
+  margin: 10px 0;
 }
 
 .error-report {
-  margin: 25px 0px;
+  margin: 25px 0;
   font-family: monospace;
   font-size: 12px;
 }

--- a/app/assets/stylesheets/material_icons.css.scss
+++ b/app/assets/stylesheets/material_icons.css.scss
@@ -37,7 +37,7 @@
   margin-top: 12px;
 }
 
-.mdi.mdi-icons-strikethrough.mdi-18:after {
+.mdi.mdi-icons-strikethrough.mdi-18::after {
   position: relative;
   top: -27px;
   left: 19px;
@@ -70,7 +70,6 @@
 }
 
 .dodona-navbar {
-
   .actions,
   .dropdown {
     .mdi::before {
@@ -113,13 +112,13 @@
 .list-group-item .mdi::before {
   position: relative;
   top: 3px;
-  left: -3px
+  left: -3px;
 }
 
 .filter-icon {
   color: $on-surface-muted;
-
   letter-spacing: -2px;
+
   /* make sure the tooltip with the filtering information is centered
   regarding the filter icon (displayed when hovering over the icon) */
 
@@ -141,6 +140,7 @@
   &.fix-alignment {
     position: absolute;
 
+    /* stylelint-disable-next-line selector-class-pattern */
     &.square_edit {
       top: 11px;
       right: 10px;

--- a/app/assets/stylesheets/mixins.css.scss
+++ b/app/assets/stylesheets/mixins.css.scss
@@ -3,21 +3,21 @@
 }
 
 @mixin shadow-z1 {
-  box-shadow: 0 3px 1px -2px rgba(0, 0, 0, .14), 0 2px 2px 0 rgba(0, 0, 0, .098), 0 1px 5px 0 rgba(0, 0, 0, .084);
+  box-shadow: 0 3px 1px -2px rgb(0 0 0 / 0.14), 0 2px 2px 0 rgb(0 0 0 / 0.098), 0 1px 5px 0 rgb(0 0 0 / 0.084);
 }
 
 @mixin shadow-z2 {
-  box-shadow: 0 2px 4px -1px rgba(0, 0, 0, .14), 0 4px 5px 0 rgba(0, 0, 0, .098), 0 1px 10px 0 rgba(0, 0, 0, .084);
+  box-shadow: 0 2px 4px -1px rgb(0 0 0 / 0.14), 0 4px 5px 0 rgb(0 0 0 / 0.098), 0 1px 10px 0 rgb(0 0 0 / 0.084);
 }
 
 @mixin shadow-z3 {
-  box-shadow: 0 3px 5px -1px rgba(0, 0, 0, .14), 0 6px 10px 0 rgba(0, 0, 0, .098), 0 1px 18px 0 rgba(0, 0, 0, .084);
+  box-shadow: 0 3px 5px -1px rgb(0 0 0 / 0.14), 0 6px 10px 0 rgb(0 0 0 / 0.098), 0 1px 18px 0 rgb(0 0 0 / 0.084);
 }
 
 @mixin shadow-z4 {
-  box-shadow: 0 5px 5px -3px rgba(0, 0, 0, .14), 0 8px 10px 1px rgba(0, 0, 0, .098), 0 3px 14px 2px rgba(0, 0, 0, .084);
+  box-shadow: 0 5px 5px -3px rgb(0 0 0 / 0.14), 0 8px 10px 1px rgb(0 0 0 / 0.098), 0 3px 14px 2px rgb(0 0 0 / 0.084);
 }
 
 @mixin shadow-z5 {
-  box-shadow: 0 8px 10px -5px rgba(0, 0, 0, .14), 0 16px 24px 2px rgba(0, 0, 0, .098), 0 6px 30px 5px rgba(0, 0, 0, .084);
+  box-shadow: 0 8px 10px -5px rgb(0 0 0 / 0.14), 0 16px 24px 2px rgb(0 0 0 / 0.098), 0 6px 30px 5px rgb(0 0 0 / 0.084);
 }

--- a/app/assets/stylesheets/models/activities.css.scss
+++ b/app/assets/stylesheets/models/activities.css.scss
@@ -25,6 +25,7 @@
   }
 }
 
+/* stylelint-disable-next-line selector-class-pattern */
 .progress_visibility {
   position: relative;
   top: 1px; // move the icon a bit downwards
@@ -81,16 +82,13 @@
   width: auto;
   display: inline-table;
   vertical-align: middle;
-}
-
-.activity-description .dodona-centered-group table {
   text-align: left;
 }
 
-.activity-description .dodona-centered-group img+img,
-.activity-description .dodona-centered-group img+table,
-.activity-description .dodona-centered-group table+img,
-.activity-description .dodona-centered-group table+table {
+.activity-description .dodona-centered-group img + img,
+.activity-description .dodona-centered-group img + table,
+.activity-description .dodona-centered-group table + img,
+.activity-description .dodona-centered-group table + table {
   margin-left: 16px;
 }
 
@@ -100,6 +98,7 @@
   display: flex;
   justify-content: space-between;
 
+  /* stylelint-disable-next-line selector-id-pattern */
   #content_page_read_action {
     display: inline-flex;
   }
@@ -158,12 +157,12 @@ center img {
       text-overflow: ellipsis;
       overflow: hidden;
       white-space: nowrap;
-      padding-top: .3em;
+      padding-top: 0.3em;
     }
 
     i {
       vertical-align: -3px;
-      padding-right: .6em;
+      padding-right: 0.6em;
     }
   }
 

--- a/app/assets/stylesheets/models/announcements.css.scss
+++ b/app/assets/stylesheets/models/announcements.css.scss
@@ -17,8 +17,8 @@
 
   .status-col {
     border-left-width: 6px;
-    border-bottom-color: $divider  !important;
-    width: 0
+    border-bottom-color: $divider !important;
+    width: 0;
   }
 
   .markdown-col {

--- a/app/assets/stylesheets/models/course.css.scss
+++ b/app/assets/stylesheets/models/course.css.scss
@@ -1,3 +1,5 @@
+@use "sass:map";
+
 .admin-card-info {
   margin-top: 24px;
 }
@@ -41,7 +43,7 @@
 
   @include media-breakpoint-up(md) {
     .nav {
-      width: calc((100vw - var(--scrollbar-width) - (#{map-get($container-max-widths, "md")} / 12 * 10)) / 2);
+      width: calc((100vw - var(--scrollbar-width) - (#{map.get($container-max-widths, "md")} / 12 * 10)) / 2);
       max-height: calc(100vh - (#{$navbar-height} + 20px));
       display: block;
       overflow-y: auto;
@@ -58,47 +60,47 @@
 
   @include media-breakpoint-up(lg) {
     .nav {
-      width: calc((100vw - var(--scrollbar-width) - (#{map-get($container-max-widths, "lg")} / 12 * 10)) / 2);
+      width: calc((100vw - var(--scrollbar-width) - (#{map.get($container-max-widths, "lg")} / 12 * 10)) / 2);
     }
   }
 
   @include media-breakpoint-up(xl) {
     .nav {
-      width: calc((100vw - var(--scrollbar-width) - (#{map-get($container-max-widths, "xl")} / 12 * 10)) / 2);
+      width: calc((100vw - var(--scrollbar-width) - (#{map.get($container-max-widths, "xl")} / 12 * 10)) / 2);
     }
   }
 
   @include media-breakpoint-up(xxl) {
     .nav {
-      width: calc((100vw - var(--scrollbar-width) - (#{map-get($container-max-widths, "xxl")} / 12 * 10)) / 2);
+      width: calc((100vw - var(--scrollbar-width) - (#{map.get($container-max-widths, "xxl")} / 12 * 10)) / 2);
     }
   }
 
-  .nav>li.header {
+  .nav > li.header {
     color: $on-surface-muted;
   }
 
-  .nav>li>a {
+  .nav > li > a {
     display: block;
-    padding: 6px 6px;
+    padding: 6px;
     font-size: 13px;
     font-weight: 500;
     color: $on-surface-muted;
-    opacity: 75%;
+    opacity: 0.75;
   }
 
-  .nav>li>a.active,
-  .nav>li>a.active:hover {
+  .nav > li > a.active,
+  .nav > li > a.active:hover {
     border-left: 2px solid $secondary;
     padding-left: 4px;
     color: $on-surface-muted;
-    opacity: 100%;
+    opacity: 1;
   }
 
-  .nav>li>a:hover {
+  .nav > li > a:hover {
     border-left: 1px solid $secondary;
     padding-left: 5px;
     color: $on-surface-muted;
-    opacity: 100%;
+    opacity: 1;
   }
 }

--- a/app/assets/stylesheets/models/programming_languages.css.scss
+++ b/app/assets/stylesheets/models/programming_languages.css.scss
@@ -1,5 +1,4 @@
 .language-table {
-
   th.type-icon,
   td.type-icon {
     color: $on-surface-muted;

--- a/app/assets/stylesheets/models/repository.css.scss
+++ b/app/assets/stylesheets/models/repository.css.scss
@@ -15,7 +15,7 @@
   right: 0;
 }
 
-.repository-courses-table-wrapper .text:before {
-  content: '';
+.repository-courses-table-wrapper .text::before {
+  content: "";
   display: inline-block;
 }

--- a/app/assets/stylesheets/models/series.css.scss
+++ b/app/assets/stylesheets/models/series.css.scss
@@ -74,13 +74,12 @@
     display: flex;
     justify-content: center;
     align-items: center;
-
     font-size: 22px;
     margin-right: 16px;
     border-radius: 50%;
     background-color: $gray;
 
-    &>.mdi::before {
+    & > .mdi::before {
       line-height: 24px;
     }
 
@@ -147,13 +146,16 @@
       $p5: 75%;
       $p6: 90%;
 
-      background-image: linear-gradient(-135deg,
+      background-image:
+        linear-gradient(
+          -135deg,
           $red-70 $p1,
           $orange-70 $p2,
           $yellow-70 $p3,
           $green-70 $p4,
           $blue-70 $p5,
-          $purple-70 $p6 );
+          $purple-70 $p6
+        );
 
       i {
         font-weight: bolder;
@@ -185,13 +187,16 @@
     border-bottom: solid 1px $skeleton-color;
     height: 33px;
     background-repeat: no-repeat;
-    background-image: linear-gradient($skeleton-color 100%, transparent 0),
+    background-image:
+      linear-gradient($skeleton-color 100%, transparent 0),
       linear-gradient($skeleton-color 100%, transparent 0),
       linear-gradient($skeleton-color 100%, transparent 0);
-    background-size: 56px 12px,
+    background-size:
+      56px 12px,
       90px 12px,
       115px 12px;
-    background-position: 58px 10px,
+    background-position:
+      58px 10px,
       calc(100% - 230px) 10px,
       calc(100% - 75px) 10px;
   }
@@ -200,15 +205,18 @@
     border-top: solid 1px $skeleton-color;
     height: 37px;
     background-repeat: no-repeat;
-    background-image: linear-gradient($skeleton-color 100%, transparent 0),
+    background-image:
+      linear-gradient($skeleton-color 100%, transparent 0),
       linear-gradient($skeleton-color 100%, transparent 0),
       linear-gradient($skeleton-color 100%, transparent 0),
       linear-gradient($skeleton-color 100%, transparent 0);
-    background-size: 90px 12px,
+    background-size:
+      90px 12px,
       100px 12px,
       90px 12px,
       8px 12px;
-    background-position: 58px 15px,
+    background-position:
+      58px 15px,
       calc(100% - 220px) 15px,
       calc(100% - 100px) 15px,
       calc(100% - 25px) 15px;
@@ -234,11 +242,11 @@
 
 .graph-info {
   margin-left: 5px;
-  color: $on-surface-muted
+  color: $on-surface-muted;
 }
 
 .svg-icon-btn {
-  fill: currentColor;
+  fill: currentcolor;
 
   &.rotate {
     transform: rotate(90deg);

--- a/app/assets/stylesheets/models/submissions.css.scss
+++ b/app/assets/stylesheets/models/submissions.css.scss
@@ -9,6 +9,8 @@ $feedback-diff-table-header-fg: $on-background;
 
 .feedback-table {
   .groups {
+    margin: 0 15px 0 0;
+
     .badge {
       display: block;
       text-align: left;
@@ -19,13 +21,13 @@ $feedback-diff-table-header-fg: $on-background;
     .badge.bg-danger {
       color: $danger;
       border-color: $danger;
-      background-color: $content-bg  !important;
+      background-color: $content-bg !important;
     }
 
     .badge.bg-success {
       color: $success;
       border-color: $success;
-      background-color: $content-bg  !important;
+      background-color: $content-bg !important;
     }
   }
 
@@ -35,11 +37,6 @@ $feedback-diff-table-header-fg: $on-background;
     pre {
       border: none;
     }
-  }
-
-  .groups {
-    margin: 0;
-    margin-right: 15px;
   }
 
   .group {
@@ -70,7 +67,7 @@ $feedback-diff-table-header-fg: $on-background;
       }
     }
 
-    &>div {
+    & > div {
       margin-bottom: 3px;
     }
 
@@ -166,6 +163,7 @@ $feedback-diff-table-header-fg: $on-background;
 
     .line-nr:empty::before {
       content: " ";
+
       /* make sure the line-height is respected */
     }
 
@@ -182,12 +180,11 @@ $feedback-diff-table-header-fg: $on-background;
     .tr {
       padding: 0;
       margin: 0;
-      line-height: 1.0;
+      line-height: 1;
     }
   }
 
   table.diff.csv-diff {
-
     td,
     .del,
     .ins,
@@ -198,7 +195,6 @@ $feedback-diff-table-header-fg: $on-background;
 
     td.line-nr,
     th.line-nr {
-      position: -webkit-sticky;
       position: sticky;
       left: 0;
       vertical-align: top;
@@ -236,7 +232,7 @@ $feedback-diff-table-header-fg: $on-background;
       margin-left: 1em;
 
       span {
-        margin-right: .5em;
+        margin-right: 0.5em;
       }
     }
 
@@ -272,20 +268,20 @@ $feedback-diff-table-header-fg: $on-background;
   }
 
   .code.wrong {
-    background: #fee;
-    color: #b00;
+    background: #ffeeee;
+    color: #bb0000;
   }
 
   .code.correct {
-    background: #dfd;
-    color: #080;
+    background: #ddffdd;
+    color: #008800;
   }
 
   .feedback-table-messages {
     margin-bottom: 9.5px;
   }
 
-  .row>.messages {
+  .row > .messages {
     margin-left: 1em;
     margin-right: 1em;
   }
@@ -293,46 +289,47 @@ $feedback-diff-table-header-fg: $on-background;
   .message-zeus,
   .message-staff {
     border-left: 3px solid $on-surface-muted;
-    padding-left: 25px
+    padding-left: 25px;
   }
 
-  .message-zeus:before,
-  .message-staff:before,
-  .tab-zeus:before,
-  .tab-staff:before {
+  .message-zeus::before,
+  .message-staff::before,
+  .tab-zeus::before,
+  .tab-staff::before {
+    /* stylelint-disable-next-line font-family-no-missing-generic-family-keyword */
     font: normal normal normal 24px/1 "Material Design Icons";
     color: $on-surface-muted;
     font-size: 18px;
   }
 
-  .message-zeus:before,
-  .message-staff:before {
+  .message-zeus::before,
+  .message-staff::before {
     position: absolute;
     left: 22px;
   }
 
-  .tab-zeus:before,
-  .tab-staff:before {
+  .tab-zeus::before,
+  .tab-staff::before {
     padding-right: 7px;
   }
 
-  .message-zeus:before,
-  .tab-zeus:before {
+  .message-zeus::before,
+  .tab-zeus::before {
     content: "\F0032";
   }
 
-  .message-staff:before,
-  .tab-staff:before {
+  .message-staff::before,
+  .tab-staff::before {
     content: "\F0474";
   }
 
-  .message-zeus+.message-zeus:before,
-  .message-staff+.message-staff:before {
-    content: '';
+  .message-zeus + .message-zeus::before,
+  .message-staff + .message-staff::before {
+    content: "";
   }
 
   .tab-link-marker {
-    background: $warning  !important;
+    background: $warning !important;
   }
 }
 
@@ -340,6 +337,7 @@ $feedback-diff-table-header-fg: $on-background;
   background-color: $gray-10;
 }
 
+/* stylelint-disable-next-line selector-class-pattern */
 #editor-result .ace_content {
   background-color: $code-bg;
   cursor: default;
@@ -349,6 +347,7 @@ iframe.file {
   border: none;
 }
 
+/* stylelint-disable-next-line selector-class-pattern */
 .ace_gutter-cell {
   background-position: 2px top !important;
 }

--- a/app/assets/stylesheets/models/users.css.scss
+++ b/app/assets/stylesheets/models/users.css.scss
@@ -33,7 +33,7 @@
     margin-left: 6px;
   }
 
-  .sign-in-method-container{
+  .sign-in-method-container {
     padding-left: 12px;
     padding-right: 12px;
 
@@ -56,7 +56,7 @@
       }
 
       .sign-in-method-title h3 {
-          line-height: 1;
+        line-height: 1;
       }
     }
   }

--- a/app/assets/stylesheets/pages/home.css.scss
+++ b/app/assets/stylesheets/pages/home.css.scss
@@ -32,7 +32,7 @@
 }
 
 .home-card .info-step img {
-  @if $theme =="dark" {
+  @if $theme == "dark" {
     filter: invert(1);
   }
 }
@@ -152,7 +152,6 @@
     .privacy-disclaimer-icon {
       margin-right: 1em;
     }
-
   }
 }
 

--- a/app/assets/stylesheets/pages/sign-in.css.scss
+++ b/app/assets/stylesheets/pages/sign-in.css.scss
@@ -5,7 +5,6 @@
 
 // sign in page
 .sign-in-dialog-wrapper {
-
   .card {
     flex-grow: 1;
   }
@@ -89,6 +88,5 @@ input:focus {
     min-height: 42px;
     color: $on-surface;
     border-radius: 6px 0 0 6px !important;
-
   }
 }

--- a/app/assets/stylesheets/print.css.scss
+++ b/app/assets/stylesheets/print.css.scss
@@ -1,7 +1,6 @@
 @media print {
-
   @page {
-    size: A4;
+    size: a4;
     margin: 25mm;
   }
 
@@ -47,7 +46,7 @@
   //  }
   body {
     min-height: initial !important;
-    margin: 0 0 0 0;
+    margin: 0;
   }
 
   // Make font size a little bit bigger
@@ -65,7 +64,7 @@
   }
 
   // Bootstrap places link href after the text, remove it
-  a[href]:after {
+  a[href]::after {
     content: none;
   }
 }

--- a/app/assets/stylesheets/theme/ace.css.scss
+++ b/app/assets/stylesheets/theme/ace.css.scss
@@ -1,3 +1,4 @@
+/* stylelint-disable selector-class-pattern */
 .ace-tm {
   background-color: $code-bg;
   color: $on-background;
@@ -11,8 +12,9 @@
     width: 1px;
     background: $divider;
   }
+
   .ace_cursor {
-    color:  $secondary;
+    color: $secondary;
   }
 
   .ace_marker-layer .ace_selection {
@@ -86,7 +88,7 @@
   }
 
   .ace_variable.ace_parameter {
-    font-style: italic
+    font-style: italic;
   }
 
   .ace_string {
@@ -110,3 +112,4 @@
     color: $tertiary;
   }
 }
+/* stylelint-enable selector-class-pattern */

--- a/app/assets/stylesheets/theme/m3-theme-dark.css.scss
+++ b/app/assets/stylesheets/theme/m3-theme-dark.css.scss
@@ -5,153 +5,153 @@
 
 @mixin theme-dark {
 
-  $primary: $primary-80  !global;
-  $primary-container: $primary-30  !global;
-  $on-primary: $primary-20  !global;
-  $on-primary-container: $primary-90  !global;
+  $primary: $primary-80 !global;
+  $primary-container: $primary-30 !global;
+  $on-primary: $primary-20 !global;
+  $on-primary-container: $primary-90 !global;
 
-  $secondary: $secondary-80  !global;
-  $secondary-container: $secondary-30  !global;
-  $on-secondary: $secondary-20  !global;
-  $on-secondary-container: $secondary-90  !global;
+  $secondary: $secondary-80 !global;
+  $secondary-container: $secondary-30 !global;
+  $on-secondary: $secondary-20 !global;
+  $on-secondary-container: $secondary-90 !global;
 
-  $tertiary: $tertiary-80  !global;
-  $tertiary-container: $tertiary-30  !global;
-  $on-tertiary: $tertiary-20  !global;
-  $on-tertiary-container: $tertiary-90  !global;
+  $tertiary: $tertiary-80 !global;
+  $tertiary-container: $tertiary-30 !global;
+  $on-tertiary: $tertiary-20 !global;
+  $on-tertiary-container: $tertiary-90 !global;
 
-  $surface: $neutral-20  !global;
-  $surface-variant: $neutral-variant-30  !global;
-  $background: $neutral-25  !global;
-  $on-surface: $neutral-90  !global;
-  $on-surface-variant: $neutral-variant-80  !global;
-  $on-surface-muted: $neutral-80  !global;
-  $on-background: $neutral-90  !global;
+  $surface: $neutral-20 !global;
+  $surface-variant: $neutral-variant-30 !global;
+  $background: $neutral-25 !global;
+  $on-surface: $neutral-90 !global;
+  $on-surface-variant: $neutral-variant-80 !global;
+  $on-surface-muted: $neutral-80 !global;
+  $on-background: $neutral-90 !global;
 
-  $outline: $neutral-variant-60  !global;
-  $divider: $neutral-30  !global;
-  $shadow: $neutral-0  !global;
-  $surface-tint: $primary  !global;
-  $inverse-surface: $neutral-90  !global;
-  $inverse-on-surface: $neutral-20  !global;
-  $inverse-primary: $primary-40  !global;
+  $outline: $neutral-variant-60 !global;
+  $divider: $neutral-30 !global;
+  $shadow: $neutral-0 !global;
+  $surface-tint: $primary !global;
+  $inverse-surface: $neutral-90 !global;
+  $inverse-on-surface: $neutral-20 !global;
+  $inverse-primary: $primary-40 !global;
 
-  $info: $info-80  !global;
-  $info-container: $info-30  !global;
-  $on-info: $info-20  !global;
-  $on-info-container: $info-90  !global;
-
-  // changed from 80 to 70
-  $success: $success-70  !global;
-  $success-container: $success-30  !global;
-  $on-success: $success-20  !global;
-  $on-success-container: $success-90  !global;
+  $info: $info-80 !global;
+  $info-container: $info-30 !global;
+  $on-info: $info-20 !global;
+  $on-info-container: $info-90 !global;
 
   // changed from 80 to 70
-  $danger: $danger-70  !global;
-  $danger-container: $danger-30  !global;
-  $on-danger: $danger-20  !global;
-  $on-danger-container: $danger-90  !global;
+  $success: $success-70 !global;
+  $success-container: $success-30 !global;
+  $on-success: $success-20 !global;
+  $on-success-container: $success-90 !global;
 
-  $warning: $warning-80  !global;
-  $warning-container: $warning-30  !global;
-  $on-warning: $warning-20  !global;
-  $on-warning-container: $warning-90  !global;
+  // changed from 80 to 70
+  $danger: $danger-70 !global;
+  $danger-container: $danger-30 !global;
+  $on-danger: $danger-20 !global;
+  $on-danger-container: $danger-90 !global;
 
-  $red: $red-80  !global;
-  $red-container: $red-30  !global;
-  $on-red: $red-20  !global;
-  $on-red-container: $red-90  !global;
+  $warning: $warning-80 !global;
+  $warning-container: $warning-30 !global;
+  $on-warning: $warning-20 !global;
+  $on-warning-container: $warning-90 !global;
 
-  $pink: $pink-80  !global;
-  $pink-container: $pink-30  !global;
-  $on-pink: $pink-20  !global;
-  $on-pink-container: $pink-90  !global;
+  $red: $red-80 !global;
+  $red-container: $red-30 !global;
+  $on-red: $red-20 !global;
+  $on-red-container: $red-90 !global;
 
-  $purple: $purple-80  !global;
-  $purple-container: $purple-30  !global;
-  $on-purple: $purple-20  !global;
-  $on-purple-container: $purple-90  !global;
+  $pink: $pink-80 !global;
+  $pink-container: $pink-30 !global;
+  $on-pink: $pink-20 !global;
+  $on-pink-container: $pink-90 !global;
 
-  $deep-purple: $deep-purple-80  !global;
-  $deep-purple-container: $deep-purple-30  !global;
-  $on-deep-purple: $deep-purple-20  !global;
-  $on-deep-purple-container: $deep-purple-90  !global;
+  $purple: $purple-80 !global;
+  $purple-container: $purple-30 !global;
+  $on-purple: $purple-20 !global;
+  $on-purple-container: $purple-90 !global;
 
-  $indigo: $indigo-80  !global;
-  $indigo-container: $indigo-30  !global;
-  $on-indigo: $indigo-20  !global;
-  $on-indigo-container: $indigo-90  !global;
+  $deep-purple: $deep-purple-80 !global;
+  $deep-purple-container: $deep-purple-30 !global;
+  $on-deep-purple: $deep-purple-20 !global;
+  $on-deep-purple-container: $deep-purple-90 !global;
 
-  $blue: $blue-80  !global;
-  $blue-container: $blue-30  !global;
-  $on-blue: $blue-20  !global;
-  $on-blue-container: $blue-90  !global;
+  $indigo: $indigo-80 !global;
+  $indigo-container: $indigo-30 !global;
+  $on-indigo: $indigo-20 !global;
+  $on-indigo-container: $indigo-90 !global;
 
-  $light-blue: $light-blue-80  !global;
-  $light-blue-container: $light-blue-30  !global;
-  $on-light-blue: $light-blue-20  !global;
-  $on-light-blue-container: $light-blue-90  !global;
+  $blue: $blue-80 !global;
+  $blue-container: $blue-30 !global;
+  $on-blue: $blue-20 !global;
+  $on-blue-container: $blue-90 !global;
 
-  $cyan: $cyan-80  !global;
-  $cyan-container: $cyan-30  !global;
-  $on-cyan: $cyan-20  !global;
-  $on-cyan-container: $cyan-90  !global;
+  $light-blue: $light-blue-80 !global;
+  $light-blue-container: $light-blue-30 !global;
+  $on-light-blue: $light-blue-20 !global;
+  $on-light-blue-container: $light-blue-90 !global;
 
-  $teal: $teal-80  !global;
-  $teal-container: $teal-30  !global;
-  $on-teal: $teal-20  !global;
-  $on-teal-container: $teal-90  !global;
+  $cyan: $cyan-80 !global;
+  $cyan-container: $cyan-30 !global;
+  $on-cyan: $cyan-20 !global;
+  $on-cyan-container: $cyan-90 !global;
 
-  $green: $green-80  !global;
-  $green-container: $green-30  !global;
-  $on-green: $green-20  !global;
-  $on-green-container: $green-90  !global;
+  $teal: $teal-80 !global;
+  $teal-container: $teal-30 !global;
+  $on-teal: $teal-20 !global;
+  $on-teal-container: $teal-90 !global;
 
-  $light-green: $light-green-80  !global;
-  $light-green-container: $light-green-30  !global;
-  $on-light-green: $light-green-20  !global;
-  $on-light-green-container: $light-green-90  !global;
+  $green: $green-80 !global;
+  $green-container: $green-30 !global;
+  $on-green: $green-20 !global;
+  $on-green-container: $green-90 !global;
 
-  $yellow: $yellow-80  !global;
-  $yellow-container: $yellow-30  !global;
-  $on-yellow: $yellow-20  !global;
-  $on-yellow-container: $yellow-90  !global;
+  $light-green: $light-green-80 !global;
+  $light-green-container: $light-green-30 !global;
+  $on-light-green: $light-green-20 !global;
+  $on-light-green-container: $light-green-90 !global;
 
-  $amber: $amber-80  !global;
-  $amber-container: $amber-30  !global;
-  $on-amber: $amber-20  !global;
-  $on-amber-container: $amber-90  !global;
+  $yellow: $yellow-80 !global;
+  $yellow-container: $yellow-30 !global;
+  $on-yellow: $yellow-20 !global;
+  $on-yellow-container: $yellow-90 !global;
 
-  $orange: $orange-80  !global;
-  $orange-container: $orange-30  !global;
-  $on-orange: $orange-20  !global;
-  $on-orange-container: $orange-90  !global;
+  $amber: $amber-80 !global;
+  $amber-container: $amber-30 !global;
+  $on-amber: $amber-20 !global;
+  $on-amber-container: $amber-90 !global;
 
-  $deep-orange: $deep-orange-80  !global;
-  $deep-orange-container: $deep-orange-30  !global;
-  $on-deep-orange: $deep-orange-20  !global;
-  $on-deep-orange-container: $deep-orange-90  !global;
+  $orange: $orange-80 !global;
+  $orange-container: $orange-30 !global;
+  $on-orange: $orange-20 !global;
+  $on-orange-container: $orange-90 !global;
 
-  $brown: $brown-80  !global;
-  $brown-container: $brown-30  !global;
-  $on-brown: $brown-20  !global;
-  $on-brown-container: $brown-90  !global;
+  $deep-orange: $deep-orange-80 !global;
+  $deep-orange-container: $deep-orange-30 !global;
+  $on-deep-orange: $deep-orange-20 !global;
+  $on-deep-orange-container: $deep-orange-90 !global;
 
-  $gray: $gray-80  !global;
-  $gray-container: $gray-30  !global;
-  $on-gray: $gray-20  !global;
-  $on-gray-container: $gray-90  !global;
+  $brown: $brown-80 !global;
+  $brown-container: $brown-30 !global;
+  $on-brown: $brown-20 !global;
+  $on-brown-container: $brown-90 !global;
 
-  $blue-gray: $blue-gray-80  !global;
-  $blue-gray-container: $blue-gray-30  !global;
-  $on-blue-gray: $blue-gray-20  !global;
-  $on-blue-gray-container: $blue-gray-90  !global;
+  $gray: $gray-80 !global;
+  $gray-container: $gray-30 !global;
+  $on-gray: $gray-20 !global;
+  $on-gray-container: $gray-90 !global;
 
-  $off-surface: $neutral-20  !global;
+  $blue-gray: $blue-gray-80 !global;
+  $blue-gray-container: $blue-gray-30 !global;
+  $on-blue-gray: $blue-gray-20 !global;
+  $on-blue-gray-container: $blue-gray-90 !global;
 
-  $code-bg: $neutral-30  !global;
-  $skeleton-color: $surface-variant  !global;
+  $off-surface: $neutral-20 !global;
+
+  $code-bg: $neutral-30 !global;
+  $skeleton-color: $surface-variant !global;
 
   .light-only {
     display: none;

--- a/app/assets/stylesheets/theme/rouge.css.scss
+++ b/app/assets/stylesheets/theme/rouge.css.scss
@@ -1,5 +1,5 @@
 .highlighter-rouge .hll {
-  background-color: #f1fa8c
+  background-color: #f1fa8c;
 }
 
 .highlighter-rouge {
@@ -89,7 +89,7 @@
 /* Generic.Emph */
 .highlighter-rouge .ge {
   color: $on-background;
-  text-decoration: underline
+  text-decoration: underline;
 }
 
 /* Generic.Error */
@@ -100,13 +100,13 @@
 /* Generic.Heading */
 .highlighter-rouge .gh {
   color: $on-background;
-  font-weight: bold
+  font-weight: bold;
 }
 
 /* Generic.Inserted */
 .highlighter-rouge .gi {
   color: $on-background;
-  font-weight: bold
+  font-weight: bold;
 }
 
 /* Generic.Output */
@@ -127,7 +127,7 @@
 /* Generic.Subheading */
 .highlighter-rouge .gu {
   color: $on-background;
-  font-weight: bold
+  font-weight: bold;
 }
 
 /* Generic.Traceback */
@@ -143,7 +143,7 @@
 /* Keyword.Declaration */
 .highlighter-rouge .kd {
   color: $primary;
-  font-style: italic
+  font-style: italic;
 }
 
 /* Keyword.Namespace */
@@ -189,7 +189,7 @@
 /* Name.Builtin */
 .highlighter-rouge .nb {
   color: $tertiary;
-  font-style: italic
+  font-style: italic;
 }
 
 /* Name.Class */
@@ -225,7 +225,7 @@
 /* Name.Label */
 .highlighter-rouge .nl {
   color: $primary;
-  font-style: italic
+  font-style: italic;
 }
 
 /* Name.Namespace */
@@ -251,7 +251,7 @@
 /* Name.Variable */
 .highlighter-rouge .nv {
   color: $on-background;
-  font-style: italic
+  font-style: italic;
 }
 
 /* Operator.Word */
@@ -367,25 +367,25 @@
 /* Name.Variable.Class */
 .highlighter-rouge .vc {
   color: $tertiary;
-  font-style: italic
+  font-style: italic;
 }
 
 /* Name.Variable.Global */
 .highlighter-rouge .vg {
   color: $tertiary;
-  font-style: italic
+  font-style: italic;
 }
 
 /* Name.Variable.Instance */
 .highlighter-rouge .vi {
   color: $tertiary;
-  font-style: italic
+  font-style: italic;
 }
 
 /* Name.Variable.Magic */
 .highlighter-rouge .vm {
   color: $tertiary;
-  font-style: italic
+  font-style: italic;
 }
 
 /* Literal.Number.Integer.Long */

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "scripts": {
     "lint": "eslint  --ext '.js' --ext '.ts' app/javascript app/assets/javascripts",
+    "lint:css": "stylelint app/assets/stylesheets",
     "test": "jest --coverage",
     "build:css": "./bin/build-css",
     "build:js": "webpack --config ./config/webpack/webpack.config.js",
@@ -52,6 +53,9 @@
     "eslint-plugin-no-jquery": "^2.7.0",
     "jest": "^26.6.3",
     "jest-junit": "^14.0.0",
+    "stylelint": "^14.9.1",
+    "stylelint-config-standard": "^26.0.0",
+    "stylelint-config-standard-scss": "^4.0.0",
     "ts-jest": "^26.5.6",
     "webpack-bundle-analyzer": "^4.5.0"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1095,6 +1095,11 @@
     style-mod "^4.0.0"
     w3c-keyname "^2.2.4"
 
+"@csstools/selector-specificity@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@csstools/selector-specificity/-/selector-specificity-2.0.1.tgz#b6b8d81780b9a9f6459f4bfe9226ac6aefaefe87"
+  integrity sha512-aG20vknL4/YjQF9BSV7ts4EWm/yrjagAN7OWBNmlbEOUiu0llj4OGrFoOKK3g2vey4/p2omKCoHrWtPxSwV3HA==
+
 "@discoveryjs/json-ext@^0.5.0":
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz#1d572bfbbe14b7704e0ba0f39b74815b84870d70"
@@ -1796,6 +1801,11 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.11.tgz#d421b6c527a3037f7c84433fd2c4229e016863d3"
   integrity sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==
 
+"@types/minimist@^1.2.0":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.2.tgz#ee771e2ba4b3dc5b372935d549fd9617bf345b8c"
+  integrity sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==
+
 "@types/node@*":
   version "17.0.23"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.23.tgz#3b41a6e643589ac6442bdbd7a4a3ded62f33f7da"
@@ -2146,6 +2156,16 @@ ajv@^6.10.0, ajv@^6.12.4, ajv@^6.12.5:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
+ajv@^8.0.1:
+  version "8.11.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.11.0.tgz#977e91dd96ca669f54a11e23e378e33b884a565f"
+  integrity sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==
+  dependencies:
+    fast-deep-equal "^3.1.1"
+    json-schema-traverse "^1.0.0"
+    require-from-string "^2.0.2"
+    uri-js "^4.2.2"
+
 ansi-escapes@^4.2.1:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-4.3.2.tgz#6b2291d1db7d98b6521d5f1efa42d0f3a9feb65e"
@@ -2230,10 +2250,20 @@ array-unique@^0.3.2:
   resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.3.2.tgz#a894b75d4bc4f6cd679ef3244a9fd8f46ae2d428"
   integrity sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=
 
+arrify@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
+  integrity sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==
+
 assign-symbols@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
   integrity sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=
+
+astral-regex@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-2.0.0.tgz#483143c567aeed4785759c0865786dc77d7d2e31"
+  integrity sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==
 
 asynckit@^0.4.0:
   version "0.4.0"
@@ -2366,6 +2396,11 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
+balanced-match@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-2.0.0.tgz#dc70f920d78db8b858535795867bf48f820633d9"
+  integrity sha512-1ugUSr8BHXRnK23KfuYS+gVMC3LB8QGH9W1iGtDPsNWoQbgtXSExkBu2aDR4epiGWZOjZsj6lDl/N/AqqTC3UA==
+
 base@^0.11.1:
   version "0.11.2"
   resolved "https://registry.yarnpkg.com/base/-/base-0.11.2.tgz#7bde5ced145b6d551a90db87f83c558b4eb48a8f"
@@ -2495,6 +2530,15 @@ callsites@^3.0.0:
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
   integrity sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
 
+camelcase-keys@^6.2.2:
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/camelcase-keys/-/camelcase-keys-6.2.2.tgz#5e755d6ba51aa223ec7d3d52f25778210f9dc3c0"
+  integrity sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==
+  dependencies:
+    camelcase "^5.3.1"
+    map-obj "^4.0.0"
+    quick-lru "^4.0.1"
+
 camelcase@^5.0.0, camelcase@^5.3.1:
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
@@ -2611,6 +2655,13 @@ clone-deep@^4.0.1:
     kind-of "^6.0.2"
     shallow-clone "^3.0.0"
 
+clone-regexp@^2.1.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/clone-regexp/-/clone-regexp-2.2.0.tgz#7d65e00885cd8796405c35a737e7a86b7429e36f"
+  integrity sha512-beMpP7BOtTipFuW8hrJvREQ2DrRu3BE7by0ZpibtfBA+qfHYvMGTc2Yb1JMYPKg/JUw0CHYvpg796aNTSW9z7Q==
+  dependencies:
+    is-regexp "^2.0.0"
+
 co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
@@ -2652,6 +2703,11 @@ color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
+
+colord@^2.9.2:
+  version "2.9.2"
+  resolved "https://registry.yarnpkg.com/colord/-/colord-2.9.2.tgz#25e2bacbbaa65991422c07ea209e2089428effb1"
+  integrity sha512-Uqbg+J445nc1TKn4FoDPS6ZZqAvEDnwrH42yo8B40JSOgSLxMZ/gt3h4nmCtPLQeXhjJJkqBx7SCY35WnIixaQ==
 
 colorette@^2.0.14:
   version "2.0.16"
@@ -2733,7 +2789,7 @@ core-js@^3.23.3:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.23.3.tgz#3b977612b15da6da0c9cc4aec487e8d24f371112"
   integrity sha512-oAKwkj9xcWNBAvGbT//WiCdOMpb9XQG92/Fe3ABFM/R16BsHgePG00mFOgKf7IsCtfj8tA1kHtf/VwErhriz5Q==
 
-cosmiconfig@^7.0.0:
+cosmiconfig@^7.0.0, cosmiconfig@^7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-7.0.1.tgz#714d756522cace867867ccb4474c5d01bbae5d6d"
   integrity sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==
@@ -2775,6 +2831,16 @@ crossvent@1.5.5:
   integrity sha1-rSCHjkkh6b5z2daXb4suzQ9xoLE=
   dependencies:
     custom-event "^1.0.0"
+
+css-functions-list@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/css-functions-list/-/css-functions-list-3.1.0.tgz#cf5b09f835ad91a00e5959bcfc627cd498e1321b"
+  integrity sha512-/9lCvYZaUbBGvYUgYGFJ4dcYiyqdhSjG7IPVluoV8A1ILjkF7ilmhp1OGUz8n+nmBcu0RNrQAzgD8B6FJbrt2w==
+
+cssesc@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/cssesc/-/cssesc-3.0.0.tgz#37741919903b868565e1c09ea747445cd18983ee"
+  integrity sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==
 
 cssom@^0.4.4:
   version "0.4.4"
@@ -3070,7 +3136,15 @@ debug@^2.2.0, debug@^2.3.3:
   dependencies:
     ms "2.0.0"
 
-decamelize@^1.2.0:
+decamelize-keys@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/decamelize-keys/-/decamelize-keys-1.1.0.tgz#d171a87933252807eb3cb61dc1c1445d078df2d9"
+  integrity sha512-ocLWuYzRPoS9bfiSdDd3cxvrzovVMZnRDVEzAs+hWIVXGDbHxWMECij2OBuyB/An0FFW/nLuq6Kv1i/YC5Qfzg==
+  dependencies:
+    decamelize "^1.1.0"
+    map-obj "^1.0.0"
+
+decamelize@^1.1.0, decamelize@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
   integrity sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=
@@ -3466,6 +3540,13 @@ execa@^5.0.0:
     signal-exit "^3.0.3"
     strip-final-newline "^2.0.0"
 
+execall@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/execall/-/execall-2.0.0.tgz#16a06b5fe5099df7d00be5d9c06eecded1663b45"
+  integrity sha512-0FU2hZ5Hh6iQnarpRtQurM/aAvp3RIbfvgLHrcqJYzhXyV2KFruhuChf9NC6waAhiUR7FFtlugkI4p7f2Fqlow==
+  dependencies:
+    clone-regexp "^2.1.0"
+
 exit@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/exit/-/exit-0.1.2.tgz#0632638f8d877cc82107d30a0fff1a17cba1cd0c"
@@ -3530,7 +3611,7 @@ fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
-fast-glob@^3.2.9:
+fast-glob@^3.2.11, fast-glob@^3.2.9:
   version "3.2.11"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.11.tgz#a1172ad95ceb8a16e20caa5c5e56480e5129c1d9"
   integrity sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==
@@ -3699,6 +3780,11 @@ get-package-type@^0.1.0:
   resolved "https://registry.yarnpkg.com/get-package-type/-/get-package-type-0.1.0.tgz#8de2d803cff44df3bc6c456e6668b36c3926e11a"
   integrity sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==
 
+get-stdin@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-8.0.0.tgz#cbad6a73feb75f6eeb22ba9e01f89aa28aa97a53"
+  integrity sha512-sY22aA6xchAzprjyqmSEQv4UbAAzRN0L2dQB0NlN5acTTK9Don6nhoc3eAbUnpZiCANAMfd/+40kVdKfFygohg==
+
 get-stream@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-4.1.0.tgz#c1b255575f3dc21d59bfc79cd3d2b46b1c3a54b5"
@@ -3770,6 +3856,22 @@ glob@^8.0.3:
     minimatch "^5.0.1"
     once "^1.3.0"
 
+global-modules@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/global-modules/-/global-modules-2.0.0.tgz#997605ad2345f27f51539bea26574421215c7780"
+  integrity sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==
+  dependencies:
+    global-prefix "^3.0.0"
+
+global-prefix@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/global-prefix/-/global-prefix-3.0.0.tgz#fc85f73064df69f50421f47f883fe5b913ba9b97"
+  integrity sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==
+  dependencies:
+    ini "^1.3.5"
+    kind-of "^6.0.2"
+    which "^1.3.1"
+
 globals@^11.1.0:
   version "11.12.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.12.0.tgz#ab8795338868a0babd8525758018c2a7eb95c42e"
@@ -3794,6 +3896,11 @@ globby@^11.1.0:
     merge2 "^1.4.1"
     slash "^3.0.0"
 
+globjoin@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/globjoin/-/globjoin-0.1.4.tgz#2f4494ac8919e3767c5cbb691e9f463324285d43"
+  integrity sha512-xYfnw62CKG8nLkZBfWbhWwDw02CHty86jfPcc2cr3ZfeuK9ysoVPPEUxf21bAD/rWAgk52SuBrLJlefNy8mvFg==
+
 good-listener@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/good-listener/-/good-listener-1.2.2.tgz#d53b30cdf9313dffb7dc9a0d477096aa6d145c50"
@@ -3817,6 +3924,11 @@ gzip-size@^6.0.0:
   integrity sha512-ax7ZYomf6jqPTQ4+XCpUGyXKHk5WweS+e05MBO4/y3WJ5RkmPXNKvX+bx1behVILVwr6JSQvZAku021CHPXG3Q==
   dependencies:
     duplexer "^0.1.2"
+
+hard-rejection@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/hard-rejection/-/hard-rejection-2.1.0.tgz#1c6eda5c1685c63942766d79bb40ae773cecd883"
+  integrity sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==
 
 has-flag@^3.0.0:
   version "3.0.0"
@@ -3876,6 +3988,13 @@ hosted-git-info@^2.1.4:
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.9.tgz#dffc0bf9a21c02209090f2aa69429e1414daf3f9"
   integrity sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==
 
+hosted-git-info@^4.0.1:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-4.1.0.tgz#827b82867e9ff1c8d0c4d9d53880397d2c86d224"
+  integrity sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==
+  dependencies:
+    lru-cache "^6.0.0"
+
 html-encoding-sniffer@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-2.0.1.tgz#42a6dc4fd33f00281176e8b23759ca4e4fa185f3"
@@ -3887,6 +4006,11 @@ html-escaper@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/html-escaper/-/html-escaper-2.0.2.tgz#dfd60027da36a36dfcbe236262c00a5822681453"
   integrity sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==
+
+html-tags@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/html-tags/-/html-tags-3.2.0.tgz#dbb3518d20b726524e4dd43de397eb0a95726961"
+  integrity sha512-vy7ClnArOZwCnqZgvv+ddgHgJiAFXe3Ge9ML5/mBctVJoUoYPCdxVucOywjDARn6CVoh3dRSFdPHy2sX80L0Wg==
 
 http-proxy-agent@^4.0.1:
   version "4.0.1"
@@ -3957,6 +4081,11 @@ import-fresh@^3.0.0, import-fresh@^3.2.1:
     parent-module "^1.0.0"
     resolve-from "^4.0.0"
 
+import-lazy@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/import-lazy/-/import-lazy-4.0.0.tgz#e8eb627483a0a43da3c03f3e35548be5cb0cc153"
+  integrity sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==
+
 import-local@^3.0.2:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/import-local/-/import-local-3.1.0.tgz#b4479df8a5fd44f6cdce24070675676063c95cb4"
@@ -3970,6 +4099,11 @@ imurmurhash@^0.1.4:
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
 
+indent-string@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-4.0.0.tgz#624f8f4497d619b2d9768531d58f4122854d7251"
+  integrity sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==
+
 inflight@^1.0.4:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9"
@@ -3982,6 +4116,11 @@ inherits@2:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
+
+ini@^1.3.5:
+  version "1.3.8"
+  resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.8.tgz#a29da425b48806f34767a4efce397269af28432c"
+  integrity sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==
 
 "internmap@1 - 2":
   version "2.0.3"
@@ -4030,6 +4169,13 @@ is-ci@^2.0.0:
   integrity sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==
   dependencies:
     ci-info "^2.0.0"
+
+is-core-module@^2.5.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.9.0.tgz#e1c34429cd51c6dd9e09e0799e396e27b19a9c69"
+  integrity sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==
+  dependencies:
+    has "^1.0.3"
 
 is-core-module@^2.8.1:
   version "2.8.1"
@@ -4121,6 +4267,11 @@ is-number@^7.0.0:
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
   integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
 
+is-plain-obj@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
+  integrity sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==
+
 is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-2.0.4.tgz#2c163b3fafb1b606d9d17928f05c2a1c38e07677"
@@ -4128,10 +4279,20 @@ is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   dependencies:
     isobject "^3.0.1"
 
+is-plain-object@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-5.0.0.tgz#4427f50ab3429e9025ea7d52e9043a9ef4159344"
+  integrity sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==
+
 is-potential-custom-element-name@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz#171ed6f19e3ac554394edf78caa05784a45bebb5"
   integrity sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==
+
+is-regexp@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-regexp/-/is-regexp-2.1.0.tgz#cd734a56864e23b956bf4e7c66c396a4c0b22c2d"
+  integrity sha512-OZ4IlER3zmRIoB9AqNhEggVxqIH4ofDns5nRrPS6yQxXE1TPCUpFznBfRQmQa8uC+pXqjMnukiJBxCisIxiLGA==
 
 is-stream@^1.1.0:
   version "1.1.0"
@@ -4729,6 +4890,11 @@ json-schema-traverse@^0.4.1:
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
   integrity sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
 
+json-schema-traverse@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz#ae7bcb3656ab77a73ba5c49bf654f38e6b6860e2"
+  integrity sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==
+
 json-stable-stringify-without-jsonify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
@@ -4758,7 +4924,7 @@ kind-of@^5.0.0:
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-5.1.0.tgz#729c91e2d857b7a419a1f9aa65685c4c33f5845d"
   integrity sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==
 
-kind-of@^6.0.0, kind-of@^6.0.2:
+kind-of@^6.0.0, kind-of@^6.0.2, kind-of@^6.0.3:
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
   integrity sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==
@@ -4767,6 +4933,11 @@ kleur@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
   integrity sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==
+
+known-css-properties@^0.25.0:
+  version "0.25.0"
+  resolved "https://registry.yarnpkg.com/known-css-properties/-/known-css-properties-0.25.0.tgz#6ebc4d4b412f602e5cfbeb4086bd544e34c0a776"
+  integrity sha512-b0/9J1O9Jcyik1GC6KC42hJ41jKwdO/Mq8Mdo5sYN+IuRTXs2YFHZC3kZSx6ueusqa95x3wLYe/ytKjbAfGixA==
 
 leven@^3.1.0:
   version "3.1.0"
@@ -4849,7 +5020,12 @@ lodash.merge@^4.6.2:
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
-lodash@4.x, lodash@^4.17.20, lodash@^4.7.0:
+lodash.truncate@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/lodash.truncate/-/lodash.truncate-4.4.2.tgz#5a350da0b1113b837ecfffd5812cbe58d6eae193"
+  integrity sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==
+
+lodash@4.x, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.7.0:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -4885,12 +5061,45 @@ map-cache@^0.2.2:
   resolved "https://registry.yarnpkg.com/map-cache/-/map-cache-0.2.2.tgz#c32abd0bd6525d9b051645bb4f26ac5dc98a0dbf"
   integrity sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=
 
+map-obj@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-1.0.1.tgz#d933ceb9205d82bdcf4886f6742bdc2b4dea146d"
+  integrity sha512-7N/q3lyZ+LVCp7PzuxrJr4KMbBE2hW7BT7YNia330OFxIf4d3r5zVpicP2650l7CPN6RM9zOJRl3NGpqSiw3Eg==
+
+map-obj@^4.0.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-4.3.0.tgz#9304f906e93faae70880da102a9f1df0ea8bb05a"
+  integrity sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==
+
 map-visit@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/map-visit/-/map-visit-1.0.0.tgz#ecdca8f13144e660f1b5bd41f12f3479d98dfb8f"
   integrity sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=
   dependencies:
     object-visit "^1.0.0"
+
+mathml-tag-names@^2.1.3:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/mathml-tag-names/-/mathml-tag-names-2.1.3.tgz#4ddadd67308e780cf16a47685878ee27b736a0a3"
+  integrity sha512-APMBEanjybaPzUrfqU0IMU5I0AswKMH7k8OTLs0vvV4KZpExkTkY87nR/zpbuTPj+gARop7aGUbl11pnDfW6xg==
+
+meow@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/meow/-/meow-9.0.0.tgz#cd9510bc5cac9dee7d03c73ee1f9ad959f4ea364"
+  integrity sha512-+obSblOQmRhcyBt62furQqRAQpNyWXo8BuQ5bN7dG8wmwQ+vwHKp/rCFD4CrTP8CsDQD1sjoZ94K417XEUk8IQ==
+  dependencies:
+    "@types/minimist" "^1.2.0"
+    camelcase-keys "^6.2.2"
+    decamelize "^1.2.0"
+    decamelize-keys "^1.1.0"
+    hard-rejection "^2.1.0"
+    minimist-options "4.1.0"
+    normalize-package-data "^3.0.0"
+    read-pkg-up "^7.0.1"
+    redent "^3.0.0"
+    trim-newlines "^3.0.0"
+    type-fest "^0.18.0"
+    yargs-parser "^20.2.3"
 
 merge-stream@^2.0.0:
   version "2.0.0"
@@ -4921,7 +5130,7 @@ micromatch@^3.1.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.2"
 
-micromatch@^4.0.2, micromatch@^4.0.4:
+micromatch@^4.0.2, micromatch@^4.0.4, micromatch@^4.0.5:
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.5.tgz#bc8999a7cbbf77cdc89f132f6e467051b49090c6"
   integrity sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==
@@ -4946,6 +5155,11 @@ mimic-fn@^2.1.0:
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
 
+min-indent@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/min-indent/-/min-indent-1.0.1.tgz#a63f681673b30571fbe8bc25686ae746eefa9869"
+  integrity sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==
+
 minimatch@^3.0.4, minimatch@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
@@ -4959,6 +5173,15 @@ minimatch@^5.0.1:
   integrity sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==
   dependencies:
     brace-expansion "^2.0.1"
+
+minimist-options@4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/minimist-options/-/minimist-options-4.1.0.tgz#c0655713c53a8a2ebd77ffa247d342c40f010619"
+  integrity sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==
+  dependencies:
+    arrify "^1.0.1"
+    is-plain-obj "^1.1.0"
+    kind-of "^6.0.3"
 
 minimist@^1.1.1, minimist@^1.2.0:
   version "1.2.6"
@@ -4992,6 +5215,11 @@ ms@2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
+
+nanoid@^3.3.4:
+  version "3.3.4"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.4.tgz#730b67e3cd09e2deacf03c027c81c9d9dbc5e8ab"
+  integrity sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==
 
 nanomatch@^1.2.9:
   version "1.2.13"
@@ -5055,6 +5283,16 @@ normalize-package-data@^2.5.0:
     hosted-git-info "^2.1.4"
     resolve "^1.10.0"
     semver "2 || 3 || 4 || 5"
+    validate-npm-package-license "^3.0.1"
+
+normalize-package-data@^3.0.0:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-3.0.3.tgz#dbcc3e2da59509a0983422884cd172eefdfa525e"
+  integrity sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==
+  dependencies:
+    hosted-git-info "^4.0.1"
+    is-core-module "^2.5.0"
+    semver "^7.3.4"
     validate-npm-package-license "^3.0.1"
 
 normalize-path@^2.1.1:
@@ -5290,6 +5528,48 @@ posix-character-classes@^0.1.0:
   resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
   integrity sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=
 
+postcss-media-query-parser@^0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/postcss-media-query-parser/-/postcss-media-query-parser-0.2.3.tgz#27b39c6f4d94f81b1a73b8f76351c609e5cef244"
+  integrity sha512-3sOlxmbKcSHMjlUXQZKQ06jOswE7oVkXPxmZdoB1r5l0q6gTFTQSHxNxOrCccElbW7dxNytifNEo8qidX2Vsig==
+
+postcss-resolve-nested-selector@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/postcss-resolve-nested-selector/-/postcss-resolve-nested-selector-0.1.1.tgz#29ccbc7c37dedfac304e9fff0bf1596b3f6a0e4e"
+  integrity sha512-HvExULSwLqHLgUy1rl3ANIqCsvMS0WHss2UOsXhXnQaZ9VCc2oBvIpXrl00IUFT5ZDITME0o6oiXeiHr2SAIfw==
+
+postcss-safe-parser@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/postcss-safe-parser/-/postcss-safe-parser-6.0.0.tgz#bb4c29894171a94bc5c996b9a30317ef402adaa1"
+  integrity sha512-FARHN8pwH+WiS2OPCxJI8FuRJpTVnn6ZNFiqAM2aeW2LwTHWWmWgIyKC6cUo0L8aeKiF/14MNvnpls6R2PBeMQ==
+
+postcss-scss@^4.0.2:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/postcss-scss/-/postcss-scss-4.0.4.tgz#aa8f60e19ee18259bc193db9e4b96edfce3f3b1f"
+  integrity sha512-aBBbVyzA8b3hUL0MGrpydxxXKXFZc5Eqva0Q3V9qsBOLEMsjb6w49WfpsoWzpEgcqJGW4t7Rio8WXVU9Gd8vWg==
+
+postcss-selector-parser@^6.0.10, postcss-selector-parser@^6.0.6:
+  version "6.0.10"
+  resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz#79b61e2c0d1bfc2602d549e11d0876256f8df88d"
+  integrity sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==
+  dependencies:
+    cssesc "^3.0.0"
+    util-deprecate "^1.0.2"
+
+postcss-value-parser@^4.1.0, postcss-value-parser@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz#723c09920836ba6d3e5af019f92bc0971c02e514"
+  integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
+
+postcss@^8.4.14:
+  version "8.4.14"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.14.tgz#ee9274d5622b4858c1007a74d76e42e56fd21caf"
+  integrity sha512-E398TUmfAYFPBSdzgeieK2Y1+1cpdxJx8yXbK/m57nRhKSmk1GB2tO4lbLBtlkfPQTDKfe4Xqv1ASWPpayPEig==
+  dependencies:
+    nanoid "^3.3.4"
+    picocolors "^1.0.0"
+    source-map-js "^1.0.2"
+
 prelude-ls@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
@@ -5357,6 +5637,11 @@ queue-microtask@^1.2.2:
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
   integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
 
+quick-lru@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-4.0.1.tgz#5b8878f113a58217848c6482026c73e1ba57727f"
+  integrity sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==
+
 randombytes@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a"
@@ -5401,6 +5686,14 @@ rechoir@^0.7.0:
   integrity sha512-/njmZ8s1wVeR6pjTZ+0nCnv8SpZNRMT2D1RLOJQESlYFDBvwpTA4KWJpZ+sBJ4+vhjILRcK7JIFdGCdxEAAitg==
   dependencies:
     resolve "^1.9.0"
+
+redent@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/redent/-/redent-3.0.0.tgz#e557b7998316bb53c9f1f56fa626352c6963059f"
+  integrity sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==
+  dependencies:
+    indent-string "^4.0.0"
+    strip-indent "^3.0.0"
 
 regenerate-unicode-properties@^10.0.1:
   version "10.0.1"
@@ -5482,6 +5775,11 @@ require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
   integrity sha1-jGStX9MNqxyXbiNE/+f3kqam30I=
+
+require-from-string@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
+  integrity sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==
 
 require-main-filename@^2.0.0:
   version "2.0.0"
@@ -5649,7 +5947,7 @@ semver@7.0.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.0.0.tgz#5f3ca35761e47e05b206c6daff2cf814f0316b8e"
   integrity sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==
 
-semver@7.x, semver@^7.3.2, semver@^7.3.7:
+semver@7.x, semver@^7.3.2, semver@^7.3.4, semver@^7.3.7:
   version "7.3.7"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.7.tgz#12c5b649afdbf9049707796e22a4028814ce523f"
   integrity sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==
@@ -5719,7 +6017,7 @@ shellwords@^0.1.1:
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
   integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
 
-signal-exit@^3.0.0, signal-exit@^3.0.2, signal-exit@^3.0.3:
+signal-exit@^3.0.0, signal-exit@^3.0.2, signal-exit@^3.0.3, signal-exit@^3.0.7:
   version "3.0.7"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.7.tgz#a9a1767f8af84155114eaabd73f99273c8f59ad9"
   integrity sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==
@@ -5742,6 +6040,15 @@ slash@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
   integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
+
+slice-ansi@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-4.0.0.tgz#500e8dd0fd55b05815086255b3195adf2a45fe6b"
+  integrity sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==
+  dependencies:
+    ansi-styles "^4.0.0"
+    astral-regex "^2.0.0"
+    is-fullwidth-code-point "^3.0.0"
 
 snapdragon-node@^2.0.1:
   version "2.1.1"
@@ -5773,7 +6080,7 @@ snapdragon@^0.8.1:
     source-map-resolve "^0.5.0"
     use "^3.1.0"
 
-"source-map-js@>=0.6.2 <2.0.0":
+"source-map-js@>=0.6.2 <2.0.0", source-map-js@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.2.tgz#adbc361d9c62df380125e7f161f71c826f1e490c"
   integrity sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==
@@ -5883,7 +6190,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-string-width@^4.1.0, string-width@^4.2.0:
+string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -5914,6 +6221,13 @@ strip-final-newline@^2.0.0:
   resolved "https://registry.yarnpkg.com/strip-final-newline/-/strip-final-newline-2.0.0.tgz#89b852fb2fcbe936f6f4b3187afb0a12c1ab58ad"
   integrity sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==
 
+strip-indent@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-3.0.0.tgz#c32e1cee940b6b3432c771bc2c54bcce73cd3001"
+  integrity sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==
+  dependencies:
+    min-indent "^1.0.0"
+
 strip-json-comments@^3.1.0, strip-json-comments@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
@@ -5923,6 +6237,109 @@ style-mod@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/style-mod/-/style-mod-4.0.0.tgz#97e7c2d68b592975f2ca7a63d0dd6fcacfe35a01"
   integrity sha512-OPhtyEjyyN9x3nhPsu76f52yUGXiZcgvsrFVtvTkyGRQJ0XK+GPc6ov1z+lRpbeabka+MYEQxOYRnt5nF30aMw==
+
+style-search@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/style-search/-/style-search-0.1.0.tgz#7958c793e47e32e07d2b5cafe5c0bf8e12e77902"
+  integrity sha512-Dj1Okke1C3uKKwQcetra4jSuk0DqbzbYtXipzFlFMZtowbF1x7BKJwB9AayVMyFARvU8EDrZdcax4At/452cAg==
+
+stylelint-config-recommended-scss@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/stylelint-config-recommended-scss/-/stylelint-config-recommended-scss-6.0.0.tgz#02baeace2b7f30f80369b6ee2da77aae5a01bff6"
+  integrity sha512-6QOe2/OzXV2AP5FE12A7+qtKdZik7Saf42SMMl84ksVBBPpTdrV+9HaCbPYiRMiwELY9hXCVdH4wlJ+YJb5eig==
+  dependencies:
+    postcss-scss "^4.0.2"
+    stylelint-config-recommended "^7.0.0"
+    stylelint-scss "^4.0.0"
+
+stylelint-config-recommended@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/stylelint-config-recommended/-/stylelint-config-recommended-7.0.0.tgz#7497372ae83ab7a6fffc18d7d7b424c6480ae15e"
+  integrity sha512-yGn84Bf/q41J4luis1AZ95gj0EQwRX8lWmGmBwkwBNSkpGSpl66XcPTulxGa/Z91aPoNGuIGBmFkcM1MejMo9Q==
+
+stylelint-config-recommended@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/stylelint-config-recommended/-/stylelint-config-recommended-8.0.0.tgz#7736be9984246177f017c39ec7b1cd0f19ae9117"
+  integrity sha512-IK6dWvE000+xBv9jbnHOnBq01gt6HGVB2ZTsot+QsMpe82doDQ9hvplxfv4YnpEuUwVGGd9y6nbaAnhrjcxhZQ==
+
+stylelint-config-standard-scss@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/stylelint-config-standard-scss/-/stylelint-config-standard-scss-4.0.0.tgz#9c1dc99eea73394bf22ad15648a5b1d9b74ff649"
+  integrity sha512-xizu8PTEyB6zYXBiVg6VtvUYn9m57x+6ZtaOdaxsfpbe5eagLPGNlbYnKfm/CfN69ArUpnwR6LjgsTHzlGbtXQ==
+  dependencies:
+    stylelint-config-recommended-scss "^6.0.0"
+    stylelint-config-standard "^25.0.0"
+
+stylelint-config-standard@^25.0.0:
+  version "25.0.0"
+  resolved "https://registry.yarnpkg.com/stylelint-config-standard/-/stylelint-config-standard-25.0.0.tgz#2c916984e6655d40d6e8748b19baa8603b680bff"
+  integrity sha512-21HnP3VSpaT1wFjFvv9VjvOGDtAviv47uTp3uFmzcN+3Lt+RYRv6oAplLaV51Kf792JSxJ6svCJh/G18E9VnCA==
+  dependencies:
+    stylelint-config-recommended "^7.0.0"
+
+stylelint-config-standard@^26.0.0:
+  version "26.0.0"
+  resolved "https://registry.yarnpkg.com/stylelint-config-standard/-/stylelint-config-standard-26.0.0.tgz#4701b8d582d34120eec7d260ba779e4c2d953635"
+  integrity sha512-hUuB7LaaqM8abvkOO84wh5oYSkpXgTzHu2Zza6e7mY+aOmpNTjoFBRxSLlzY0uAOMWEFx0OMKzr+reG1BUtcqQ==
+  dependencies:
+    stylelint-config-recommended "^8.0.0"
+
+stylelint-scss@^4.0.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/stylelint-scss/-/stylelint-scss-4.2.0.tgz#e25fd390ee38a7e89fcfaec2a8f9dce2ec6ddee8"
+  integrity sha512-HHHMVKJJ5RM9pPIbgJ/XA67h9H0407G68Rm69H4fzFbFkyDMcTV1Byep3qdze5+fJ3c0U7mJrbj6S0Fg072uZA==
+  dependencies:
+    lodash "^4.17.21"
+    postcss-media-query-parser "^0.2.3"
+    postcss-resolve-nested-selector "^0.1.1"
+    postcss-selector-parser "^6.0.6"
+    postcss-value-parser "^4.1.0"
+
+stylelint@^14.9.1:
+  version "14.9.1"
+  resolved "https://registry.yarnpkg.com/stylelint/-/stylelint-14.9.1.tgz#6494ed38f148b1e75b402d678a3b6a8aae86dfda"
+  integrity sha512-RdAkJdPiLqHawCSnu21nE27MjNXaVd4WcOHA4vK5GtIGjScfhNnaOuWR2wWdfKFAvcWQPOYe311iveiVKSmwsA==
+  dependencies:
+    "@csstools/selector-specificity" "^2.0.1"
+    balanced-match "^2.0.0"
+    colord "^2.9.2"
+    cosmiconfig "^7.0.1"
+    css-functions-list "^3.1.0"
+    debug "^4.3.4"
+    execall "^2.0.0"
+    fast-glob "^3.2.11"
+    fastest-levenshtein "^1.0.12"
+    file-entry-cache "^6.0.1"
+    get-stdin "^8.0.0"
+    global-modules "^2.0.0"
+    globby "^11.1.0"
+    globjoin "^0.1.4"
+    html-tags "^3.2.0"
+    ignore "^5.2.0"
+    import-lazy "^4.0.0"
+    imurmurhash "^0.1.4"
+    is-plain-object "^5.0.0"
+    known-css-properties "^0.25.0"
+    mathml-tag-names "^2.1.3"
+    meow "^9.0.0"
+    micromatch "^4.0.5"
+    normalize-path "^3.0.0"
+    picocolors "^1.0.0"
+    postcss "^8.4.14"
+    postcss-media-query-parser "^0.2.3"
+    postcss-resolve-nested-selector "^0.1.1"
+    postcss-safe-parser "^6.0.0"
+    postcss-selector-parser "^6.0.10"
+    postcss-value-parser "^4.2.0"
+    resolve-from "^5.0.0"
+    string-width "^4.2.3"
+    strip-ansi "^6.0.1"
+    style-search "^0.1.0"
+    supports-hyperlinks "^2.2.0"
+    svg-tags "^1.0.0"
+    table "^6.8.0"
+    v8-compile-cache "^2.3.0"
+    write-file-atomic "^4.0.1"
 
 supports-color@^5.3.0:
   version "5.5.0"
@@ -5945,7 +6362,7 @@ supports-color@^8.0.0:
   dependencies:
     has-flag "^4.0.0"
 
-supports-hyperlinks@^2.0.0:
+supports-hyperlinks@^2.0.0, supports-hyperlinks@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/supports-hyperlinks/-/supports-hyperlinks-2.2.0.tgz#4f77b42488765891774b70c79babd87f9bd594bb"
   integrity sha512-6sXEzV5+I5j8Bmq9/vUphGRM/RJNT9SCURJLjwfOg51heRtguGWDzcaBlgAzKhQa0EVNpPEKzQuBwZ8S8WaCeQ==
@@ -5958,6 +6375,11 @@ supports-preserve-symlinks-flag@^1.0.0:
   resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
+svg-tags@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/svg-tags/-/svg-tags-1.0.0.tgz#58f71cee3bd519b59d4b2a843b6c7de64ac04764"
+  integrity sha512-ovssysQTa+luh7A5Weu3Rta6FJlFBBbInjOh722LIt6klpU2/HtdUbszju/G4devcvk8PGt7FCLv5wftu3THUA==
+
 symbol-tree@^3.2.4:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
@@ -5967,6 +6389,17 @@ sync-message@^0.0.10:
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/sync-message/-/sync-message-0.0.10.tgz#ef325fc67c62d24ab10bb0eea79b28d3ba6be403"
   integrity sha512-w4LF+xtmAtIqzMzwIRujitEd/lCnMrQ9rt0A0ZgQa5Vkt62GA4ZVf5s7A1l0QueBLdb5SyYb7VFWm6mTwu4YXQ==
+
+table@^6.8.0:
+  version "6.8.0"
+  resolved "https://registry.yarnpkg.com/table/-/table-6.8.0.tgz#87e28f14fa4321c3377ba286f07b79b281a3b3ca"
+  integrity sha512-s/fitrbVeEyHKFa7mFdkuQMWlH1Wgw/yEXMt5xACT4ZpzWFluehAxRtUUQKPuWhaLAWhFcVx6w3oC8VKaUfPGA==
+  dependencies:
+    ajv "^8.0.1"
+    lodash.truncate "^4.4.2"
+    slice-ansi "^4.0.0"
+    string-width "^4.2.3"
+    strip-ansi "^6.0.1"
 
 tapable@^2.1.1, tapable@^2.2.0:
   version "2.2.1"
@@ -6094,6 +6527,11 @@ tr46@^2.1.0:
   dependencies:
     punycode "^2.1.1"
 
+trim-newlines@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-3.0.1.tgz#260a5d962d8b752425b32f3a7db0dcacd176c144"
+  integrity sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==
+
 ts-jest@^26.5.6:
   version "26.5.6"
   resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-26.5.6.tgz#c32e0746425274e1dfe333f43cd3c800e014ec35"
@@ -6140,6 +6578,11 @@ type-detect@4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
   integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
+
+type-fest@^0.18.0:
+  version "0.18.1"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.18.1.tgz#db4bc151a4a2cf4eebf9add5db75508db6cc841f"
+  integrity sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==
 
 type-fest@^0.20.2:
   version "0.20.2"
@@ -6243,12 +6686,17 @@ use@^3.1.0:
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"
   integrity sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==
 
+util-deprecate@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
+  integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
+
 uuid@^8.3.0, uuid@^8.3.2:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
-v8-compile-cache@^2.0.3:
+v8-compile-cache@^2.0.3, v8-compile-cache@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz#2de19618c66dc247dcfb6f99338035d8245a2cee"
   integrity sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==
@@ -6416,7 +6864,7 @@ which-module@^2.0.0:
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
   integrity sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=
 
-which@^1.2.9:
+which@^1.2.9, which@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
   integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==
@@ -6464,6 +6912,14 @@ write-file-atomic@^3.0.0:
     signal-exit "^3.0.2"
     typedarray-to-buffer "^3.1.5"
 
+write-file-atomic@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-4.0.1.tgz#9faa33a964c1c85ff6f849b80b42a88c2c537c8f"
+  integrity sha512-nSKUxgAbyioruk6hU87QzVbY279oYT6uiwgDoujth2ju4mJ+TZau7SQBhtbTmUyuNYTuXnSyRn66FV0+eCgcrQ==
+  dependencies:
+    imurmurhash "^0.1.4"
+    signal-exit "^3.0.7"
+
 ws@^7.3.1:
   version "7.5.8"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.8.tgz#ac2729881ab9e7cbaf8787fe3469a48c5c7f636a"
@@ -6504,7 +6960,7 @@ yaml@^1.10.0:
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
   integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
 
-yargs-parser@20.x:
+yargs-parser@20.x, yargs-parser@^20.2.3:
   version "20.2.9"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.9.tgz#2eb7dc3b0289718fc295f362753845c41a0c94ee"
   integrity sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==


### PR DESCRIPTION
This pull request adds [Stylelint](https://github.com/stylelint/stylelint) as linter for scss.

I have disabled some rules from the default which did not really seem useful for our code base. But I am open for changes if someone has a strong opinion on certain linting rules.

I also added an extra github action for the css linting.

css linting can be run using `yarn lint:css`

This pr also applies al the linting rules.

