### PR TITLE
Revert to legacy color css notation for browser support

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -8,4 +8,4 @@ rules:
   alpha-value-notation: number
   no-invalid-position-at-import-rule: null
   number-max-precision: null
-
+  color-function-notation: legacy

--- a/app/assets/stylesheets/components/btn.css.scss
+++ b/app/assets/stylesheets/components/btn.css.scss
@@ -142,7 +142,6 @@
     &:focus,
     &:active {
       opacity: 1;
-      /* stylelint-disable-next-line color-function-notation */
       background: rgba(white, 0.1);
     }
   }

--- a/app/assets/stylesheets/components/card.css.scss
+++ b/app/assets/stylesheets/components/card.css.scss
@@ -189,9 +189,9 @@ a.card-title-link:hover {
 }
 
 .card-title-image {
-  background: rgb(0 0 0 / 0.5);
+  background: rgba(0, 0, 0, 0.5);
   color: $on-primary;
-  text-shadow: 0 1px 3px rgb(0 0 0 / 0.6);
+  text-shadow: 0 1px 3px rgba(0, 0, 0, 0.6);
   height: 61px;
   margin-top: -61px;
   z-index: 1;
@@ -350,7 +350,7 @@ a.card-title-link:hover {
 }
 
 .card-nav .card-title .btn-icon:hover {
-  background-color: rgb(255 255 255 / 0.3);
+  background-color: rgba(255, 255, 255, 0.3);
 }
 
 .card-nav .badge {

--- a/app/assets/stylesheets/components/table-toolbar.css.scss
+++ b/app/assets/stylesheets/components/table-toolbar.css.scss
@@ -127,8 +127,8 @@
   background-image:
     linear-gradient(
       to right,
-      rgb(255 255 255 / 0.7),
-      rgb(255 255 255 / 0.7)
+      rgba(255, 255, 255, 0.7),
+      rgba(255, 255, 255, 0.7)
     ),
     linear-gradient(to right, $secondary, $secondary);
   z-index: 0;

--- a/app/assets/stylesheets/components/table.css.scss
+++ b/app/assets/stylesheets/components/table.css.scss
@@ -3,8 +3,8 @@
   background-image:
     linear-gradient(to right, $content-bg, $content-bg),
     linear-gradient(to right, $content-bg, $content-bg),
-    linear-gradient(to right, $divider, rgb(255 255 255 / 0)),
-    linear-gradient(to left, $divider, rgb(255 255 255 / 0));
+    linear-gradient(to right, $divider, rgba(255, 255, 255, 0)),
+    linear-gradient(to left, $divider, rgba(255, 255, 255, 0));
   background-position: left center, right center, left center, right center;
   background-repeat: no-repeat;
   background-color: $content-bg;

--- a/app/assets/stylesheets/components/tokenfield.css.scss
+++ b/app/assets/stylesheets/components/tokenfield.css.scss
@@ -16,8 +16,8 @@
   border-color: #66afe9;
   outline: 0;
   box-shadow:
-    inset 0 1px 1px rgb(0 0 0 / 0.075),
-    0 0 8px rgb(102 175 233 / 0.6);
+    inset 0 1px 1px rgba(0, 0, 0, 0.075),
+    0 0 8px rgba(102, 175, 233, 0.6);
 }
 
 .tokenfield .token-input {
@@ -59,17 +59,17 @@
 
 .has-warning .tokenfield.focus {
   border-color: #66512c;
-  box-shadow: inset 0 1px 1px rgb(0 0 0 / 0.075), 0 0 6px #c0a16b;
+  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #c0a16b;
 }
 
 .has-error .tokenfield.focus {
   border-color: #843534;
-  box-shadow: inset 0 1px 1px rgb(0 0 0 / 0.075), 0 0 6px #ce8483;
+  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #ce8483;
 }
 
 .has-success .tokenfield.focus {
   border-color: #2b542c;
-  box-shadow: inset 0 1px 1px rgb(0 0 0 / 0.075), 0 0 6px #67b168;
+  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #67b168;
 }
 
 .tokenfield.form-control-sm,

--- a/app/assets/stylesheets/mixins.css.scss
+++ b/app/assets/stylesheets/mixins.css.scss
@@ -3,21 +3,27 @@
 }
 
 @mixin shadow-z1 {
-  box-shadow: 0 3px 1px -2px rgb(0 0 0 / 0.14), 0 2px 2px 0 rgb(0 0 0 / 0.098), 0 1px 5px 0 rgb(0 0 0 / 0.084);
+  box-shadow: 0 3px 1px -2px rgba(0, 0, 0, 0.14), 0 2px 2px 0 rgba(0, 0, 0, 0.098), 0 1px 5px 0 rgba(0, 0, 0, 0.084);
 }
 
 @mixin shadow-z2 {
-  box-shadow: 0 2px 4px -1px rgb(0 0 0 / 0.14), 0 4px 5px 0 rgb(0 0 0 / 0.098), 0 1px 10px 0 rgb(0 0 0 / 0.084);
+  box-shadow: 0 2px 4px -1px rgba(0, 0, 0, 0.14), 0 4px 5px 0 rgba(0, 0, 0, 0.098), 0 1px 10px 0 rgba(0, 0, 0, 0.084);
 }
 
 @mixin shadow-z3 {
-  box-shadow: 0 3px 5px -1px rgb(0 0 0 / 0.14), 0 6px 10px 0 rgb(0 0 0 / 0.098), 0 1px 18px 0 rgb(0 0 0 / 0.084);
+  box-shadow: 0 3px 5px -1px rgba(0, 0, 0, 0.14), 0 6px 10px 0 rgba(0, 0, 0, 0.098), 0 1px 18px 0 rgba(0, 0, 0, 0.084);
 }
 
 @mixin shadow-z4 {
-  box-shadow: 0 5px 5px -3px rgb(0 0 0 / 0.14), 0 8px 10px 1px rgb(0 0 0 / 0.098), 0 3px 14px 2px rgb(0 0 0 / 0.084);
+  box-shadow:
+    0 5px 5px -3px rgba(0, 0, 0, 0.14),
+    0 8px 10px 1px rgba(0, 0, 0, 0.098),
+    0 3px 14px 2px rgba(0, 0, 0, 0.084);
 }
 
 @mixin shadow-z5 {
-  box-shadow: 0 8px 10px -5px rgb(0 0 0 / 0.14), 0 16px 24px 2px rgb(0 0 0 / 0.098), 0 6px 30px 5px rgb(0 0 0 / 0.084);
+  box-shadow:
+    0 8px 10px -5px rgba(0, 0, 0, 0.14),
+    0 16px 24px 2px rgba(0, 0, 0, 0.098),
+    0 6px 30px 5px rgba(0, 0, 0, 0.084);
 }


### PR DESCRIPTION
This pull request reverts to legacy color css notation for browser support. Specifically safari 12 does not yet support this notation.

See supported browsers at: https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/rgb
