### PR TITLE
Prevent default redirect after click on close token

### DIFF
--- a/app/assets/javascripts/components/search_token.ts
+++ b/app/assets/javascripts/components/search_token.ts
@@ -20,12 +20,17 @@ export class SearchToken extends FilterCollectionElement {
     @property()
     color: (l: Label) => string;
 
+    processClick(e: Event, label: Label): void {
+        this.unSelect(label);
+        e.preventDefault();
+    }
+
     render(): TemplateResult {
         return html`
             ${ this.getSelectedLabels().map( label => html`
                 <div class="token accent-${this.color(label)}">
                     <span class="token-label">${label.name}</span>
-                    <a href="#" class="close" tabindex="-1"  @click=${() => this.unSelect(label)}>×</a>
+                    <a href="#" class="close" tabindex="-1"  @click=${e => this.processClick(e, label) }>×</a>
                 </div>
             `)}
         `;

--- a/app/assets/javascripts/components/search_token.ts
+++ b/app/assets/javascripts/components/search_token.ts
@@ -30,7 +30,7 @@ export class SearchToken extends FilterCollectionElement {
             ${ this.getSelectedLabels().map( label => html`
                 <div class="token accent-${this.color(label)}">
                     <span class="token-label">${label.name}</span>
-                    <a href="#" class="close" tabindex="-1"  @click=${e => this.processClick(e, label) }>×</a>
+                    <a href="#" class="close" tabindex="-1"  @click=${e => this.processClick(e, label)}>×</a>
                 </div>
             `)}
         `;


### PR DESCRIPTION
This pull request fixes the search tokens. It allows them to be removed, which is currently broken in production.

I was not able to reproduce this issue locally or on naos, so not 100% sure it will fix the issue in production.
