### PR TITLE
Add a setting to courses to allow registration with personal accounts

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -342,26 +342,14 @@ class CoursesController < ApplicationController
           success_method = method(:signup_succeeded_response)
         end
 
-        case @course.registration
-        when 'open_for_all'
+        if @course.open_for_user?(current_user)
           if try_to_subscribe_current_user status: status
             success_method.call(format)
           else
             subscription_failed_response format
           end
-        when 'open_for_institution'
-          if @course.institution == current_user.institution
-            if try_to_subscribe_current_user status: status
-              success_method.call(format)
-            else
-              subscription_failed_response format
-            end
-          else
-            format.html { redirect_to(course_url(@course, secret: params[:secret]), alert: I18n.t('courses.registration.closed')) }
-            format.json { render json: { errors: ['course closed'] }, status: :unprocessable_entity }
-          end
-        when 'closed'
-          format.html { redirect_to(@course, alert: I18n.t('courses.registration.closed')) }
+        else
+          format.html { redirect_to(course_url(@course, secret: params[:secret]), alert: I18n.t('courses.registration.closed')) }
           format.json { render json: { errors: ['course closed'] }, status: :unprocessable_entity }
         end
       end

--- a/app/helpers/courses_helper.rb
+++ b/app/helpers/courses_helper.rb
@@ -7,7 +7,7 @@ module CoursesHelper
     membership = args[:membership]
 
     if membership.nil? || membership.unsubscribed?
-      if course.open_for_all? || (course.open_for_institution? && (course.institution == current_user&.institution || current_user.nil?))
+      if course.open_for_user?(current_user) || current_user.nil?
         if course.moderated
           link_to t('courses.show.request_registration'),
                   subscribe_course_path(@course, secret: secret),

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -280,7 +280,7 @@ class Activity < ApplicationRecord
       return true if user&.member_of? course
       return false if course.moderated && access_private?
 
-      course.open_for_all? || (course.open_for_institution? && course.institution == user&.institution)
+      course.open_for_user?(user)
     else
       return true if user&.repository_admin? repository
 

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -215,6 +215,12 @@ class Course < ApplicationRecord
     activities.where(access: :private).where.not(repository_id: usable_repositories).count.zero?
   end
 
+  def open_for_user?(user)
+    (open_for_all? && user&.institutional?) ||
+      (open_for_institution? && institution == user&.institution) ||
+      (allow_personal_accounts? && user&.personal? && !closed?)
+  end
+
   def invalidate_subscribed_members_count_cache
     Rails.cache.delete(format(SUBSCRIBED_MEMBERS_COUNT_CACHE_STRING, id: id))
   end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -2,21 +2,22 @@
 #
 # Table name: courses
 #
-#  id                :integer          not null, primary key
-#  name              :string(255)
-#  year              :string(255)
-#  secret            :string(255)
-#  created_at        :datetime         not null
-#  updated_at        :datetime         not null
-#  description       :text(16777215)
-#  visibility        :integer
-#  registration      :integer
-#  teacher           :string(255)
-#  institution_id    :bigint
-#  search            :string(4096)
-#  moderated         :boolean          default(FALSE), not null
-#  enabled_questions :boolean          default(TRUE), not null
-#  featured          :boolean          default(FALSE), not null
+#  id                      :integer          not null, primary key
+#  name                    :string(255)
+#  year                    :string(255)
+#  secret                  :string(255)
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
+#  description             :text(16777215)
+#  visibility              :integer
+#  registration            :integer
+#  teacher                 :string(255)
+#  institution_id          :bigint
+#  search                  :string(4096)
+#  moderated               :boolean          default(FALSE), not null
+#  enabled_questions       :boolean          default(TRUE), not null
+#  featured                :boolean          default(FALSE), not null
+#  allow_personal_accounts :boolean          default(FALSE), not null
 #
 
 require 'securerandom'

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -272,6 +272,14 @@ class User < ApplicationRecord
     @repository_admin.include?(repository.id)
   end
 
+  def personal?
+    institution.nil?
+  end
+
+  def institutional?
+    institution.present?
+  end
+
   def attempted_exercises(options)
     s = submissions.judged
     s = s.in_course(options[:course]) if options[:course].present?

--- a/app/policies/course_policy.rb
+++ b/app/policies/course_policy.rb
@@ -156,9 +156,9 @@ class CoursePolicy < ApplicationPolicy
   def permitted_attributes
     # record is the Course class on create
     if zeus?
-      %i[name year description visibility registration teacher institution_id moderated enabled_questions featured]
+      %i[name year description visibility registration teacher institution_id moderated enabled_questions allow_personal_accounts featured]
     elsif course_admin? || (record == Course && user&.admin?)
-      %i[name year description visibility registration teacher institution_id moderated enabled_questions]
+      %i[name year description visibility registration teacher institution_id moderated enabled_questions allow_personal_accounts]
     else
       []
     end

--- a/app/views/courses/_form.html.erb
+++ b/app/views/courses/_form.html.erb
@@ -140,11 +140,10 @@
         <span class="help-block offset-sm-3 col-sm-6"><%= t ".registration-#{r}-help_html" %></span>
       <% end %>
     </div>
-
     <div class="field form-group row">
       <%= f.label :allow_personal_accounts, t(".allow_personal_accounts.title"), class: 'col-sm-3 col-form-label' %>
       <div class="col-sm-6 pt-2">
-        <div class="form-check <%= "form-switch" unless course.new_record? %>">
+        <div class="form-check">
           <%= f.check_box :allow_personal_accounts, class: 'form-check-input' %>
           <%= f.label :allow_personal_accounts, t(".allow_personal_accounts.toggle-label"), class: 'form-check-label' %>
         </div>

--- a/app/views/courses/_form.html.erb
+++ b/app/views/courses/_form.html.erb
@@ -148,6 +148,7 @@
           <%= f.label :allow_personal_accounts, t(".allow_personal_accounts.toggle-label"), class: 'form-check-label' %>
         </div>
       </div>
+      <span class="help-block offset-sm-3 col-sm-6"><%= t ".allow_personal_accounts.help" %></span>
     </div>
     <div class="form-group">
       <strong class="col-12"><%= t('.moderated-label') %></strong>

--- a/app/views/courses/_form.html.erb
+++ b/app/views/courses/_form.html.erb
@@ -140,6 +140,16 @@
         <span class="help-block offset-sm-3 col-sm-6"><%= t ".registration-#{r}-help_html" %></span>
       <% end %>
     </div>
+
+    <div class="field form-group row">
+      <%= f.label :allow_personal_accounts, t(".allow_personal_accounts.title"), class: 'col-sm-3 col-form-label' %>
+      <div class="col-sm-6 pt-2">
+        <div class="form-check <%= "form-switch" unless course.new_record? %>">
+          <%= f.check_box :allow_personal_accounts, class: 'form-check-input' %>
+          <%= f.label :allow_personal_accounts, t(".allow_personal_accounts.toggle-label"), class: 'form-check-label' %>
+        </div>
+      </div>
+    </div>
     <div class="form-group">
       <strong class="col-12"><%= t('.moderated-label') %></strong>
     </div>

--- a/config/locales/views/courses/en.yml
+++ b/config/locales/views/courses/en.yml
@@ -51,6 +51,9 @@ en:
       featured:
         title: Featured course
         toggle-label: Feature this course
+      allow_personal_accounts:
+        title: Personal accounts
+        toggle-label: Allow users to register with a personal account
     index:
       title: Courses
       users: "Users"

--- a/config/locales/views/courses/en.yml
+++ b/config/locales/views/courses/en.yml
@@ -52,8 +52,9 @@ en:
         title: Featured course
         toggle-label: Feature this course
       allow_personal_accounts:
-        title: Personal accounts
-        toggle-label: Allow users to register with a personal account
+        title: Private accounts
+        toggle-label: Allow users to register with a private account
+        help: Private accounts are user accounts that are not linked to an institution. For example users that signed in using a personal gmail or outlook account.
     index:
       title: Courses
       users: "Users"

--- a/config/locales/views/courses/nl.yml
+++ b/config/locales/views/courses/nl.yml
@@ -51,6 +51,9 @@ nl:
       featured:
         title: Uitgelichte cursus
         toggle-label: Deze cursus uitlichten
+      allow_personal_accounts:
+        title: Persoonlijke accounts
+        toggle-label: Sta toe dat gebruikers registreren met een persoonlijke account
     index:
       title: Cursussen
       users: "Gebruikers"

--- a/config/locales/views/courses/nl.yml
+++ b/config/locales/views/courses/nl.yml
@@ -52,8 +52,9 @@ nl:
         title: Uitgelichte cursus
         toggle-label: Deze cursus uitlichten
       allow_personal_accounts:
-        title: Persoonlijke accounts
-        toggle-label: Sta toe dat gebruikers registreren met een persoonlijke account
+        title: Private accounts
+        toggle-label: Sta toe dat gebruikers registreren met een private account
+        help: Private accounts zijn gebruikers accounts die niet verbonden zijn aan een onderwijsinstelling, zoals bijvoorbeeld gebruikers die inloggen met een persoonlijke gmail of outlook account.
     index:
       title: Cursussen
       users: "Gebruikers"

--- a/db/migrate/20220712085958_add_allow_personal_accounts_to_courses.rb
+++ b/db/migrate/20220712085958_add_allow_personal_accounts_to_courses.rb
@@ -1,0 +1,5 @@
+class AddAllowPersonalAccountsToCourses < ActiveRecord::Migration[7.0]
+  def change
+    add_column :courses, :allow_personal_accounts, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_05_24_123721) do
+ActiveRecord::Schema[7.0].define(version: 2022_07_12_085958) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -209,6 +209,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_05_24_123721) do
     t.boolean "moderated", default: false, null: false
     t.boolean "enabled_questions", default: true, null: false
     t.boolean "featured", default: false, null: false
+    t.boolean "allow_personal_accounts", default: false, null: false
     t.index ["featured"], name: "index_courses_on_featured"
     t.index ["institution_id"], name: "index_courses_on_institution_id"
   end

--- a/test/controllers/activities_controller_test.rb
+++ b/test/controllers/activities_controller_test.rb
@@ -712,6 +712,7 @@ class ExerciseDescriptionTest < ActionDispatch::IntegrationTest
   end
 
   test 'exercise page within series should contain extra navigation' do
+    sign_in users(:student)
     course = courses(:course1)
     exercise = exercises(:python_exercise)
     other_exercise = create :exercise

--- a/test/controllers/courses_controller_test.rb
+++ b/test/controllers/courses_controller_test.rb
@@ -712,6 +712,38 @@ class CoursesPermissionControllerTest < ActionDispatch::IntegrationTest
     assert_not response.body.include?(subscribe_course_path(@course, secret: @course.secret))
   end
 
+  test 'personal user should not be able to subscribe to a course which does not allow_personal_accounts' do
+    add_externals
+    @course.update(allow_personal_accounts: false)
+    user = @externals.first
+    user.update(institution: nil)
+    sign_in user
+    post subscribe_course_url(@course)
+    assert_not @course.subscribed_members.include?(user)
+    post subscribe_course_url(@course, secret: @course.secret)
+    assert_not @course.subscribed_members.include?(user)
+  end
+
+  test 'institutional user should be able to subscribe to a course which does not allow_personal_accounts' do
+    add_externals
+    @course.update(allow_personal_accounts: false)
+    user = @externals.first
+    user.update(institution: (create :institution))
+    sign_in user
+    post subscribe_course_url(@course)
+    assert @course.subscribed_members.include?(user)
+  end
+
+  test 'personal user should be able to subscribe to a course which does allow_personal_accounts' do
+    add_externals
+    @course.update(allow_personal_accounts: true)
+    user = @externals.first
+    user.update(institution: nil)
+    sign_in user
+    post subscribe_course_url(@course)
+    assert @course.subscribed_members.include?(user)
+  end
+
   test 'should not destroy course as student' do
     add_students
     sign_in @students.first

--- a/test/factories/courses.rb
+++ b/test/factories/courses.rb
@@ -28,6 +28,7 @@ FactoryBot.define do
     registration { 'open_for_all' }
     moderated { false }
     teacher { "Prof. #{Faker::Name.first_name} #{Faker::Name.last_name}" }
+    allow_personal_accounts { true }
 
     transient do
       series_count { 0 }

--- a/test/factories/courses.rb
+++ b/test/factories/courses.rb
@@ -2,21 +2,22 @@
 #
 # Table name: courses
 #
-#  id                :integer          not null, primary key
-#  name              :string(255)
-#  year              :string(255)
-#  secret            :string(255)
-#  created_at        :datetime         not null
-#  updated_at        :datetime         not null
-#  description       :text(16777215)
-#  visibility        :integer
-#  registration      :integer
-#  teacher           :string(255)
-#  institution_id    :bigint
-#  search            :string(4096)
-#  moderated         :boolean          default(FALSE), not null
-#  enabled_questions :boolean          default(TRUE), not null
-#  featured          :boolean          default(FALSE), not null
+#  id                      :integer          not null, primary key
+#  name                    :string(255)
+#  year                    :string(255)
+#  secret                  :string(255)
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
+#  description             :text(16777215)
+#  visibility              :integer
+#  registration            :integer
+#  teacher                 :string(255)
+#  institution_id          :bigint
+#  search                  :string(4096)
+#  moderated               :boolean          default(FALSE), not null
+#  enabled_questions       :boolean          default(TRUE), not null
+#  featured                :boolean          default(FALSE), not null
+#  allow_personal_accounts :boolean          default(FALSE), not null
 #
 
 FactoryBot.define do

--- a/test/fixtures/courses.yml
+++ b/test/fixtures/courses.yml
@@ -2,21 +2,22 @@
 #
 # Table name: courses
 #
-#  id                :integer          not null, primary key
-#  name              :string(255)
-#  year              :string(255)
-#  secret            :string(255)
-#  created_at        :datetime         not null
-#  updated_at        :datetime         not null
-#  description       :text(16777215)
-#  visibility        :integer
-#  registration      :integer
-#  teacher           :string(255)
-#  institution_id    :bigint
-#  search            :string(4096)
-#  moderated         :boolean          default(FALSE), not null
-#  enabled_questions :boolean          default(TRUE), not null
-#  featured          :boolean          default(FALSE), not null
+#  id                      :integer          not null, primary key
+#  name                    :string(255)
+#  year                    :string(255)
+#  secret                  :string(255)
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
+#  description             :text(16777215)
+#  visibility              :integer
+#  registration            :integer
+#  teacher                 :string(255)
+#  institution_id          :bigint
+#  search                  :string(4096)
+#  moderated               :boolean          default(FALSE), not null
+#  enabled_questions       :boolean          default(TRUE), not null
+#  featured                :boolean          default(FALSE), not null
+#  allow_personal_accounts :boolean          default(FALSE), not null
 #
 
 course1:

--- a/test/fixtures/courses.yml
+++ b/test/fixtures/courses.yml
@@ -28,3 +28,5 @@ course1:
   visibility: 0 # visible for all
   registration: 0 # open for all
   teacher: Prof. Zonnebloem
+  secret: "PuDCHk3A7qCEAbxKXPpz"
+  allow_personal_accounts: true

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -30,6 +30,7 @@ zeus:
   token: nil
   time_zone: Brussels
   search: zeus
+  institution_id: 1
 
 staff:
   id: 2
@@ -42,6 +43,7 @@ staff:
   token: nil
   time_zone: Brussels
   search: staff
+  institution_id: 1
 
 student:
   id: 3
@@ -54,3 +56,4 @@ student:
   token: nil
   time_zone: Brussels
   search: student
+  institution_id: 1

--- a/test/models/course_test.rb
+++ b/test/models/course_test.rb
@@ -2,21 +2,22 @@
 #
 # Table name: courses
 #
-#  id                :integer          not null, primary key
-#  name              :string(255)
-#  year              :string(255)
-#  secret            :string(255)
-#  created_at        :datetime         not null
-#  updated_at        :datetime         not null
-#  description       :text(16777215)
-#  visibility        :integer
-#  registration      :integer
-#  teacher           :string(255)
-#  institution_id    :bigint
-#  search            :string(4096)
-#  moderated         :boolean          default(FALSE), not null
-#  enabled_questions :boolean          default(TRUE), not null
-#  featured          :boolean          default(FALSE), not null
+#  id                      :integer          not null, primary key
+#  name                    :string(255)
+#  year                    :string(255)
+#  secret                  :string(255)
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
+#  description             :text(16777215)
+#  visibility              :integer
+#  registration            :integer
+#  teacher                 :string(255)
+#  institution_id          :bigint
+#  search                  :string(4096)
+#  moderated               :boolean          default(FALSE), not null
+#  enabled_questions       :boolean          default(TRUE), not null
+#  featured                :boolean          default(FALSE), not null
+#  allow_personal_accounts :boolean          default(FALSE), not null
 #
 
 require 'test_helper'


### PR DESCRIPTION
This pull request is a replacement of #3752. It introduces a single extra toggle option to allow personal users to register for a course.

![image](https://user-images.githubusercontent.com/21177904/182602917-e9b81c17-6f52-41b8-915f-6ab52cf0347a.png)

It is not very clear to me how this separate setting should interact with `open_for_institution`. Right now I take a union: everyone in this institution or without an institution. But this is an odd combination which I do not expect to see in practice.


- [x] Tests were added

Part of https://github.com/dodona-edu/dodona/issues/2597
