### PR TITLE
Use default text buttons for user selection in the evaluation wizard

### DIFF
--- a/app/assets/javascripts/evaluation.ts
+++ b/app/assets/javascripts/evaluation.ts
@@ -100,8 +100,8 @@ export function initEvaluationStepper(): void {
                 if (!running) {
                     running = true;
                     event.preventDefault();
-                    const button = option.querySelector(".button");
-                    const loader = option.querySelector(".loader");
+                    const button = option.querySelector(".btn");
+                    const loader = option.parentNode.querySelector(".loader");
                     button.classList.add("hidden");
                     loader.classList.remove("hidden");
                     const response = await fetch(option.getAttribute("href"), { method: "POST" });

--- a/app/assets/stylesheets/components/evaluations.css.scss
+++ b/app/assets/stylesheets/components/evaluations.css.scss
@@ -136,6 +136,7 @@
 
   .user-select-option:hover {
     border: 1px solid $divider;
+
     @include shadow-z4;
   }
 

--- a/app/assets/stylesheets/components/evaluations.css.scss
+++ b/app/assets/stylesheets/components/evaluations.css.scss
@@ -123,9 +123,6 @@
     border-radius: $border-radius-base;
     text-align: center;
     padding: 6px;
-    transition: box-shadow 0.1s cubic-bezier(0.4, 0, 0.2, 1);
-
-    @include shadow-z2;
 
     a {
       background-color: inherit;
@@ -136,8 +133,6 @@
 
   .user-select-option:hover {
     border: 1px solid $divider;
-
-    @include shadow-z4;
   }
 
   .user-select-option h1 small {

--- a/app/assets/stylesheets/components/evaluations.css.scss
+++ b/app/assets/stylesheets/components/evaluations.css.scss
@@ -123,6 +123,9 @@
     border-radius: $border-radius-base;
     text-align: center;
     padding: 6px;
+    transition: box-shadow 0.1s cubic-bezier(0.4, 0, 0.2, 1);
+
+    @include shadow-z2;
 
     a {
       background-color: inherit;
@@ -133,6 +136,7 @@
 
   .user-select-option:hover {
     border: 1px solid $divider;
+    @include shadow-z4;
   }
 
   .user-select-option h1 small {

--- a/app/views/evaluations/_add_users.html.erb
+++ b/app/views/evaluations/_add_users.html.erb
@@ -14,21 +14,21 @@
       <div class="row">
         <div class="col-6">
           <div class="user-select-option">
-            <%= link_to set_multi_user_evaluation_path(@evaluation, type: 'enrolled', format: :js) do %>
               <%= t('evaluations.add_users.users_in_course_html', count: @user_count_course) %>
               <div class="clearfix"></div>
               <i class="loader mdi mdi-spin mdi-loading hidden"></i>
-              <div class="button btn-text"><%= t('.select_users') %></div>
+            <%= link_to set_multi_user_evaluation_path(@evaluation, type: 'enrolled', format: :js) do %>
+              <div class="btn btn-text"><%= t('.select_users') %></div>
             <% end %>
           </div>
         </div>
         <div class="col-6">
           <div class="user-select-option">
-            <%= link_to set_multi_user_evaluation_path(@evaluation, type: 'submitted', format: :js) do %>
               <%= t('evaluations.add_users.users_submitted_html', count: @user_count_series) %>
               <div class="clearfix"></div>
               <i class="loader mdi mdi-spin mdi-loading hidden"></i>
-              <div class="button btn-text"><%= t('.select_users') %></div>
+            <%= link_to set_multi_user_evaluation_path(@evaluation, type: 'submitted', format: :js) do %>
+              <div class="btn btn-text"><%= t('.select_users') %></div>
             <% end %>
           </div>
         </div>


### PR DESCRIPTION
This pull request uses the default buttons styles for user selection. The whole card is no longer clickable as this is inconsistent with our general ux/ui.

Left button in the image is hovered:
![image](https://user-images.githubusercontent.com/21177904/182121800-a68600d1-d3d3-4c09-99b6-8570727961b9.png)
![image](https://user-images.githubusercontent.com/21177904/182122359-22b6d9c8-8ffd-49d9-b79b-383352abbc42.png)

Closes #3750 .
