### PR TITLE
Provide the correct activity id for submissions on an activity page

### DIFF
--- a/app/views/submissions/_submissions_table.html.erb
+++ b/app/views/submissions/_submissions_table.html.erb
@@ -24,7 +24,7 @@
 
 <%
   params = {}
-  params[:exercise_id] = local_assigns[:exercise].id if local_assigns[:exercise].present?
+  params[:activity_id] = local_assigns[:exercise].id if local_assigns[:exercise].present?
   params[:user_id] = local_assigns[:user].id if local_assigns[:user].present?
 %>
 


### PR DESCRIPTION
Fixes:

> 3. back in the original list of submissions, as soon as I visit the second page of submissions, I apparently end of in a list with all my submissions (for all exercises, not even submissions for the current exercise) 
![image](https://user-images.githubusercontent.com/5736113/180804498-64a54fcd-ffe2-4470-8639-55f74639344d.png)

Part of #3833
