### PR TITLE
Show an activity not found error for activities no longer present in a course

### DIFF
--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -86,7 +86,7 @@ class ActivitiesController < ApplicationController
     flash.now[:alert] = I18n.t('activities.show.not_a_member') if @course && !current_user&.member_of?(@course)
 
     # Double check if activity still exists within this course (And throw a 404 when it does not)
-    @course&.activities.find_by!(id: @activity.id)
+    @course&.activities&.find_by!(id: @activity.id)
     # We still need to check access because an unauthenticated user should be able to see public activities
     raise Pundit::NotAuthorizedError, 'Not allowed' unless @activity.accessible?(current_user, @course)
 

--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -84,6 +84,9 @@ class ActivitiesController < ApplicationController
 
   def show
     flash.now[:alert] = I18n.t('activities.show.not_a_member') if @course && !current_user&.member_of?(@course)
+
+    # Double check if activity still exists within this course (And throw a 404 when it does not)
+    @course&.activities.find_by!(id: @activity.id)
     # We still need to check access because an unauthenticated user should be able to see public activities
     raise Pundit::NotAuthorizedError, 'Not allowed' unless @activity.accessible?(current_user, @course)
 

--- a/bin/server
+++ b/bin/server
@@ -1,4 +1,5 @@
 #!/bin/bash
 bundle install
 yarn install
-bundle exec rails s -p 3000 & bundle exec rails jobs:work & yarn build:css --watch & NODE_ENV=development yarn build:js --watch
+#bundle exec rails s -p 3000 &
+bundle exec rails jobs:work & yarn build:css --watch & NODE_ENV=development yarn build:js --watch

--- a/bin/server
+++ b/bin/server
@@ -1,5 +1,4 @@
 #!/bin/bash
 bundle install
 yarn install
-#bundle exec rails s -p 3000 &
-bundle exec rails jobs:work & yarn build:css --watch & NODE_ENV=development yarn build:js --watch
+bundle exec rails s -p 3000 & bundle exec rails jobs:work & yarn build:css --watch & NODE_ENV=development yarn build:js --watch


### PR DESCRIPTION
This pull request shows an activity not found error for activities no longer present in a course

![image](https://user-images.githubusercontent.com/21177904/182160627-3a609b6a-3ee3-4806-831e-4c5e410c3c52.png)

Fixes:

> 2. if I visit one of the numbered submissions (scoped in course) and try to edit the submissions, I get an error message that indicates I can't edit my own submission 
![image](https://user-images.githubusercontent.com/5736113/180804097-452f64c7-b8a2-4e67-b30f-85e008b7aef6.png)

Part of #3833
