### PR TITLE
Only show that the activity is not present to course admins

### DIFF
--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -86,7 +86,7 @@ class ActivitiesController < ApplicationController
     flash.now[:alert] = I18n.t('activities.show.not_a_member') if @course && !current_user&.member_of?(@course)
 
     # Double check if activity still exists within this course (And throw a 404 when it does not)
-    @course&.activities&.find_by!(id: @activity.id) if current_user.course_admin?(@course)
+    @course&.activities&.find_by!(id: @activity.id) if current_user&.course_admin?(@course)
     # We still need to check access because an unauthenticated user should be able to see public activities
     raise Pundit::NotAuthorizedError, 'Not allowed' unless @activity.accessible?(current_user, @course)
 

--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -86,7 +86,7 @@ class ActivitiesController < ApplicationController
     flash.now[:alert] = I18n.t('activities.show.not_a_member') if @course && !current_user&.member_of?(@course)
 
     # Double check if activity still exists within this course (And throw a 404 when it does not)
-    @course&.activities&.find_by!(id: @activity.id)
+    @course&.activities&.find_by!(id: @activity.id) if current_user.course_admin?(@course)
     # We still need to check access because an unauthenticated user should be able to see public activities
     raise Pundit::NotAuthorizedError, 'Not allowed' unless @activity.accessible?(current_user, @course)
 


### PR DESCRIPTION
This pull request fixes a potential enumeration attack introduced by #3851. Now only course admins get information on whether or not an activity is present within a course.

Zeus
![image](https://user-images.githubusercontent.com/21177904/182591918-6031639a-d05c-4e8a-9854-acae05c8e3bc.png)

Student:
![image](https://user-images.githubusercontent.com/21177904/182592013-b6a250f3-7af0-48a2-9d90-b9e26e1347cf.png)

