### PR TITLE
Handle errors when Dodona has no push rights to exercise repo

### DIFF
--- a/app/mailers/error_mailer.rb
+++ b/app/mailers/error_mailer.rb
@@ -42,7 +42,7 @@ class ErrorMailer < ApplicationMailer
              'error_mailer.git_error.body.greeting',
              name: @name
            ) + I18n.t(
-             'error_mailer.git_error.body.error_message_html',
+             'error_mailer.git_error.body.error_message',
              repository: error.repository.name,
              error: error.errorstring
            ) + I18n.t(

--- a/app/mailers/error_mailer.rb
+++ b/app/mailers/error_mailer.rb
@@ -36,19 +36,6 @@ class ErrorMailer < ApplicationMailer
            subject: I18n.t(
              'error_mailer.git_error.subject',
              repository: error.repository.name
-           ),
-           content_type: 'text/plain',
-           body: I18n.t(
-             'error_mailer.git_error.body.greeting',
-             name: @name
-           ) + I18n.t(
-             'error_mailer.git_error.body.error_message',
-             repository: error.repository.name,
-             error: error.errorstring
-           ) + I18n.t(
-             'error_mailer.git_error.body.regards'
-           ) + I18n.t(
-             'error_mailer.git_error.body.auto-generated'
            )
     end
   end

--- a/app/mailers/error_mailer.rb
+++ b/app/mailers/error_mailer.rb
@@ -28,7 +28,7 @@ class ErrorMailer < ApplicationMailer
   end
 
   def git_error(error, user: nil, name: nil, email: nil)
-    set_field(error, user, name, email)
+    set_fields(error, user, name, email)
 
     I18n.with_locale(@user&.lang) do
       mail to: %("#{@name}" <#{@email}>),

--- a/app/mailers/error_mailer.rb
+++ b/app/mailers/error_mailer.rb
@@ -39,10 +39,16 @@ class ErrorMailer < ApplicationMailer
            ),
            content_type: 'text/plain',
            body: I18n.t(
-             'error_mailer.git_error.body', # TODO: update with newest body
-             deep_interpolation: true, # used to make sure there is also interpolations on the levels "under" body
-             name: @name,
+             'error_mailer.git_error.body.greeting',
+             name: @name
+           ) + I18n.t(
+             'error_mailer.git_error.body.error_message_html',
+             repository: error.repository.name,
              error: error.errorstring
+           ) + I18n.t(
+             'error_mailer.git_error.body.regards'
+           ) + I18n.t(
+             'error_mailer.git_error.body.auto-generated'
            )
     end
   end

--- a/app/mailers/error_mailer.rb
+++ b/app/mailers/error_mailer.rb
@@ -1,10 +1,9 @@
 class ErrorMailer < ApplicationMailer
   helper :repository
 
-  def json_error(error, user: nil, name: nil, email: nil)
+  def set_fields(user, name, email)
     @error = error
     @user = user || User.find_by(email: email)
-
     if @user
       @name = @user.full_name
       @email = @user.email
@@ -12,6 +11,10 @@ class ErrorMailer < ApplicationMailer
       @name = name || ''
       @email = email
     end
+  end
+
+  def json_error(error, user: nil, name: nil, email: nil)
+    set_fields(user, name, email)
 
     I18n.with_locale(@user&.lang) do
       mail to: %("#{@name}" <#{@email}>),
@@ -20,6 +23,26 @@ class ErrorMailer < ApplicationMailer
              'error_mailer.json_error.subject',
              count: error.count,
              repository: error.repository.name
+           )
+    end
+  end
+
+  def git_error(error, user: nil, name: nil, email: nil)
+    set_field(user, name, email)
+
+    I18n.with_locale(@user&.lang) do
+      mail to: %("#{@name}" <#{@email}>),
+           cc: Rails.application.config.dodona_email,
+           subject: I18n.t(
+             'error_mailer.git_error.subject',
+             repository: error.repository.name
+           ),
+           content_type: 'text/plain',
+           body: I18n.t(
+             'error_mailer.git_error.body',
+             deep_interpolation: true, # used to make sure there is also interpolations on the levels "under" body
+             name: @name,
+             error: error.errorstring
            )
     end
   end

--- a/app/mailers/error_mailer.rb
+++ b/app/mailers/error_mailer.rb
@@ -1,7 +1,7 @@
 class ErrorMailer < ApplicationMailer
   helper :repository
 
-  def set_fields(user, name, email)
+  def set_fields(error, user, name, email)
     @error = error
     @user = user || User.find_by(email: email)
     if @user
@@ -14,7 +14,7 @@ class ErrorMailer < ApplicationMailer
   end
 
   def json_error(error, user: nil, name: nil, email: nil)
-    set_fields(user, name, email)
+    set_fields(error, user, name, email)
 
     I18n.with_locale(@user&.lang) do
       mail to: %("#{@name}" <#{@email}>),
@@ -28,7 +28,7 @@ class ErrorMailer < ApplicationMailer
   end
 
   def git_error(error, user: nil, name: nil, email: nil)
-    set_field(user, name, email)
+    set_field(error, user, name, email)
 
     I18n.with_locale(@user&.lang) do
       mail to: %("#{@name}" <#{@email}>),
@@ -39,7 +39,7 @@ class ErrorMailer < ApplicationMailer
            ),
            content_type: 'text/plain',
            body: I18n.t(
-             'error_mailer.git_error.body',
+             'error_mailer.git_error.body', # TODO: update with newest body
              deep_interpolation: true, # used to make sure there is also interpolations on the levels "under" body
              name: @name,
              error: error.errorstring

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -100,6 +100,8 @@ class Repository < ApplicationRecord
     process_activities
   rescue AggregatedConfigErrors => e
     ErrorMailer.json_error(e, **kwargs).deliver
+  rescue DodonaGitError => e
+    ErrorMailer.git_error(e, **kwargs).deliver
   end
 
   def process_activities
@@ -196,7 +198,7 @@ class Repository < ApplicationRecord
     unless new_activities.empty?
       status, err = commit 'stored tokens in new activities'
       # handle errors when commit fails
-      errors.push err unless status
+      raise DodonaGitError(self, err) unless status
     end
 
     raise AggregatedConfigErrors.new(self, errors) if errors.any?

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -192,7 +192,14 @@ class Repository < ApplicationRecord
       c['internals']['_info'] = 'These fields are used for internal bookkeeping in Dodona, please do not change them.'
       act.config_file.write(JSON.pretty_generate(c))
     end
-    commit 'stored tokens in new activities' unless new_activities.empty?
+
+    unless new_activities.empty?
+      status, err = commit 'stored tokens in new activities'
+      # handle errors when commit fails
+      unless status
+        errors.push err
+      end
+    end
 
     raise AggregatedConfigErrors.new(self, errors) if errors.any?
   end

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -196,9 +196,7 @@ class Repository < ApplicationRecord
     unless new_activities.empty?
       status, err = commit 'stored tokens in new activities'
       # handle errors when commit fails
-      unless status
-        errors.push err
-      end
+      errors.push err unless status
     end
 
     raise AggregatedConfigErrors.new(self, errors) if errors.any?

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -198,7 +198,7 @@ class Repository < ApplicationRecord
     unless new_activities.empty?
       status, err = commit 'stored tokens in new activities'
       # handle errors when commit fails
-      raise DodonaGitError(self, err) unless status
+      raise DodonaGitError.new(self, err) unless status
     end
 
     raise AggregatedConfigErrors.new(self, errors) if errors.any?

--- a/app/models/transient/dodona_git_error.rb
+++ b/app/models/transient/dodona_git_error.rb
@@ -1,0 +1,10 @@
+class DodonaGitError < StandardError
+  attr_reader :repository,
+              :errorstring
+
+  def initialize(repository, error)
+    super()
+    @repository = repository
+    @errorstring = error.to_s
+  end
+end

--- a/app/views/error_mailer/git_error.html.erb
+++ b/app/views/error_mailer/git_error.html.erb
@@ -1,8 +1,8 @@
 <div class="message">
   <%= content_tag :p, t('.greeting', name: @name) %>
   <%= content_tag :p, t(
-    '.error_message_html',
-    repository: github_link(@error.repository),
+    '.error_message',
+    repository: @error.repository.name,
     error: @error.errorstring
   ) %>
 

--- a/app/views/error_mailer/git_error.html.erb
+++ b/app/views/error_mailer/git_error.html.erb
@@ -1,0 +1,15 @@
+<div class="message">
+  <%= content_tag :p, t('.greeting', name: @name) %>
+  <%= content_tag :p, t(
+    '.error_message_html',
+    repository: github_link(@error.repository),
+    error: @error.errorstring
+  ) %>
+
+  <%= content_tag :p, t('.hint') %>
+
+  <%= content_tag :p, t('.regards') %>
+  <p>Team Dodona</p>
+
+  <%= content_tag :p, t('.auto-generated') %>
+</div>

--- a/app/views/error_mailer/git_error.text.erb
+++ b/app/views/error_mailer/git_error.text.erb
@@ -1,5 +1,5 @@
 <%= t '.greeting', name: @name %>
-<%= t '.error_message_html',
+<%= t '.error_message',
       repository: @error.repository.name,
       error: @error.errorstring %>
 

--- a/app/views/error_mailer/git_error.text.erb
+++ b/app/views/error_mailer/git_error.text.erb
@@ -1,0 +1,11 @@
+<%= t '.greeting', name: @name %>
+<%= t '.error_message_html',
+      repository: @error.repository.name,
+      error: @error.errorstring %>
+
+<%= t '.hint' %>
+
+<%= t '.regards' %>
+Team Dodona
+
+<%= t '.auto-generated' %>

--- a/config/locales/views/error_mailer/en.yml
+++ b/config/locales/views/error_mailer/en.yml
@@ -10,3 +10,10 @@ en:
         other: 'Something went wrong during the processing of the exercise repository "%{repository}". You probably made a syntax error in the config file. These were the generated error messages:'
       regards: "Kind regards,"
       auto-generated: This message was generated automatically.
+    git_error:
+      subject: "Failed to push to %{repository}"
+      body:
+        greeting: "Dear %{name},"
+        error_message_html: "While processing, Dodona was unable to push the edits to the processed exercises. The exact error was: %{error}.\n\nMake sure to give the Dodona user push rights to your repository."
+        regards: "Kind regards,"
+        auto-generated: This message was generated automatically.

--- a/config/locales/views/error_mailer/en.yml
+++ b/config/locales/views/error_mailer/en.yml
@@ -12,13 +12,8 @@ en:
       auto-generated: This message was generated automatically.
     git_error:
       subject: '[Dodona] Failed to push to "%{repository}"'
-      body:
-        greeting: |
-          Dear %{name},
-        error_message: |
-          While processing "%{repository}", Dodona was unable to push the edits to the processed exercises. The exact error was: %{error}.
-
-          Make sure to give the Dodona user push rights to your repository.
-        regards: |
-          Kind regards,
-        auto-generated: This message was generated automatically.
+      greeting: 'Dear %{name},'
+      error_message_html: 'While processing "%{repository}", Dodona was unable to push the edits to the processed exercises. The exact error was: %{error}.'
+      hint: 'Make sure to give the Dodona user push rights to your repository.'
+      regards: 'Kind regards,'
+      auto-generated: This message was generated automatically.

--- a/config/locales/views/error_mailer/en.yml
+++ b/config/locales/views/error_mailer/en.yml
@@ -11,9 +11,9 @@ en:
       regards: "Kind regards,"
       auto-generated: This message was generated automatically.
     git_error:
-      subject: "Failed to push to %{repository}"
+      subject: 'Failed to push to "%{repository}"'
       body:
-        greeting: "Dear %{name},"
-        error_message_html: "While processing, Dodona was unable to push the edits to the processed exercises. The exact error was: %{error}.\n\nMake sure to give the Dodona user push rights to your repository."
-        regards: "Kind regards,"
+        greeting: 'Dear %{name},\n'
+        error_message_html: 'While processing "%{repository}", Dodona was unable to push the edits to the processed exercises. The exact error was: %{error}.\n\nMake sure to give the Dodona user push rights to your repository.\n'
+        regards: 'Kind regards,\n'
         auto-generated: This message was generated automatically.

--- a/config/locales/views/error_mailer/en.yml
+++ b/config/locales/views/error_mailer/en.yml
@@ -13,7 +13,7 @@ en:
     git_error:
       subject: '[Dodona] Failed to push to "%{repository}"'
       greeting: 'Dear %{name},'
-      error_message_html: 'While processing "%{repository}", Dodona was unable to push the edits to the processed exercises. The exact error was: %{error}.'
+      error_message: 'While processing "%{repository}", Dodona was unable to push the edits to the processed exercises. The exact error was: %{error}.'
       hint: 'Make sure to give the Dodona user push rights to your repository.'
       regards: 'Kind regards,'
       auto-generated: This message was generated automatically.

--- a/config/locales/views/error_mailer/en.yml
+++ b/config/locales/views/error_mailer/en.yml
@@ -11,12 +11,12 @@ en:
       regards: "Kind regards,"
       auto-generated: This message was generated automatically.
     git_error:
-      subject: 'Failed to push to "%{repository}"'
+      subject: '[Dodona] Failed to push to "%{repository}"'
       body:
         greeting: |
           Dear %{name},
-        error_message_html: |
-          While processing "%{repository}", Dodona was unable to push the edits to the processed exercises. The exact error was: %{error}
+        error_message: |
+          While processing "%{repository}", Dodona was unable to push the edits to the processed exercises. The exact error was: %{error}.
 
           Make sure to give the Dodona user push rights to your repository.
         regards: |

--- a/config/locales/views/error_mailer/en.yml
+++ b/config/locales/views/error_mailer/en.yml
@@ -13,7 +13,12 @@ en:
     git_error:
       subject: 'Failed to push to "%{repository}"'
       body:
-        greeting: 'Dear %{name},\n'
-        error_message_html: 'While processing "%{repository}", Dodona was unable to push the edits to the processed exercises. The exact error was: %{error}.\n\nMake sure to give the Dodona user push rights to your repository.\n'
-        regards: 'Kind regards,\n'
+        greeting: |
+          Dear %{name},
+        error_message_html: |
+          While processing "%{repository}", Dodona was unable to push the edits to the processed exercises. The exact error was: %{error}
+
+          Make sure to give the Dodona user push rights to your repository.
+        regards: |
+          Kind regards,
         auto-generated: This message was generated automatically.

--- a/config/locales/views/error_mailer/nl.yml
+++ b/config/locales/views/error_mailer/nl.yml
@@ -11,9 +11,9 @@ nl:
       regards: 'Vriendelijke groeten,'
       auto-generated: ps. Dit bericht werd automatisch gegenereerd.
     git_error:
-      subject: "Pushen naar %{repository} mislukt"
+      subject: 'Pushen naar "%{repository}" mislukt'
       body:
-        greeting: "Beste %{name},"
-        error_message_html: "Tijdens het verwerken kon Dodona de aanpassingen van de verwerkte oefeningen niet pushen. De exacte error was: %{error}.\n\nZorg er zeker voor dat de Dodona gebruiker push rechten heeft op je repository."
-        regards: "Vriendelijke groeten,"
+        greeting: 'Beste %{name},\n'
+        error_message_html: 'Tijdens het verwerken "%{repository}" kon Dodona de aanpassingen van de verwerkte oefeningen niet pushen. De exacte error was: %{error}.\n\nZorg er zeker voor dat de Dodona gebruiker push rechten heeft op je repository.\n'
+        regards: 'Vriendelijke groeten,\n'
         auto-generated: ps. Dit bericht werd automatisch gegenereerd.

--- a/config/locales/views/error_mailer/nl.yml
+++ b/config/locales/views/error_mailer/nl.yml
@@ -13,7 +13,7 @@ nl:
     git_error:
       subject: '[Dodona] Pushen naar "%{repository}" mislukt'
       greeting: 'Beste %{name},'
-      error_message_html: 'Tijdens het verwerken van "%{repository}" kon Dodona de aanpassingen aan de verwerkte oefeningen niet pushen. De exacte error was: %{error}.'
+      error_message: 'Tijdens het verwerken van "%{repository}" kon Dodona de aanpassingen aan de verwerkte oefeningen niet pushen. De exacte error was: %{error}.'
       hint: 'Zorg er zeker voor dat de Dodona gebruiker pushrechten heeft op je repository.'
       regards: 'Vriendelijke groeten,'
       auto-generated: ps. Dit bericht werd automatisch gegenereerd.

--- a/config/locales/views/error_mailer/nl.yml
+++ b/config/locales/views/error_mailer/nl.yml
@@ -9,11 +9,11 @@ nl:
         one: 'Bij het automatisch verwerken van de oefeningenrepository "%{repository}" liep iets fout. Vermoedelijk zit er een syntaxfout in het configuratiebestand. Onderstaande foutmelding werd gegenereerd:'
         other: 'Bij het automatisch verwerken van de oefeningenrepository "%{repository}" liep iets fout. Vermoedelijk zit er een syntaxfout in het configuratiebestand. Onderstaande foutmeldingen werden gegenereerd:'
       regards: 'Vriendelijke groeten,'
-      auto-generated: ps. Dit bericht werd automatisch gegenereerd.
+      auto-generated: PS Dit bericht werd automatisch gegenereerd.
     git_error:
       subject: '[Dodona] Pushen naar "%{repository}" mislukt'
       greeting: 'Beste %{name},'
       error_message: 'Tijdens het verwerken van "%{repository}" kon Dodona de aanpassingen aan de verwerkte oefeningen niet pushen. De exacte error was: %{error}.'
-      hint: 'Zorg er zeker voor dat de Dodona gebruiker pushrechten heeft op je repository.'
+      hint: 'Zorg er zeker voor dat de Dodona-gebruiker pushrechten heeft op je repository.'
       regards: 'Vriendelijke groeten,'
-      auto-generated: ps. Dit bericht werd automatisch gegenereerd.
+      auto-generated: PS Dit bericht werd automatisch gegenereerd.

--- a/config/locales/views/error_mailer/nl.yml
+++ b/config/locales/views/error_mailer/nl.yml
@@ -12,13 +12,8 @@ nl:
       auto-generated: ps. Dit bericht werd automatisch gegenereerd.
     git_error:
       subject: '[Dodona] Pushen naar "%{repository}" mislukt'
-      body:
-        greeting: |
-          Beste %{name},
-        error_message: |
-          Tijdens het verwerken van "%{repository}" kon Dodona de aanpassingen aan de verwerkte oefeningen niet pushen. De exacte error was: %{error}.
-
-          Zorg er zeker voor dat de Dodona gebruiker pushrechten heeft op je repository.
-        regards: |
-          Vriendelijke groeten,
-        auto-generated: ps. Dit bericht werd automatisch gegenereerd.
+      greeting: 'Beste %{name},'
+      error_message_html: 'Tijdens het verwerken van "%{repository}" kon Dodona de aanpassingen aan de verwerkte oefeningen niet pushen. De exacte error was: %{error}.'
+      hint: 'Zorg er zeker voor dat de Dodona gebruiker pushrechten heeft op je repository.'
+      regards: 'Vriendelijke groeten,'
+      auto-generated: ps. Dit bericht werd automatisch gegenereerd.

--- a/config/locales/views/error_mailer/nl.yml
+++ b/config/locales/views/error_mailer/nl.yml
@@ -13,7 +13,12 @@ nl:
     git_error:
       subject: 'Pushen naar "%{repository}" mislukt'
       body:
-        greeting: 'Beste %{name},\n'
-        error_message_html: 'Tijdens het verwerken "%{repository}" kon Dodona de aanpassingen van de verwerkte oefeningen niet pushen. De exacte error was: %{error}.\n\nZorg er zeker voor dat de Dodona gebruiker push rechten heeft op je repository.\n'
-        regards: 'Vriendelijke groeten,\n'
+        greeting: |
+          Beste %{name},
+        error_message_html: |
+          Tijdens het verwerken "%{repository}" kon Dodona de aanpassingen van de verwerkte oefeningen niet pushen. De exacte error was: %{error}.
+
+          Zorg er zeker voor dat de Dodona gebruiker push rechten heeft op je repository.
+        regards: |
+          Vriendelijke groeten,
         auto-generated: ps. Dit bericht werd automatisch gegenereerd.

--- a/config/locales/views/error_mailer/nl.yml
+++ b/config/locales/views/error_mailer/nl.yml
@@ -11,14 +11,14 @@ nl:
       regards: 'Vriendelijke groeten,'
       auto-generated: ps. Dit bericht werd automatisch gegenereerd.
     git_error:
-      subject: 'Pushen naar "%{repository}" mislukt'
+      subject: '[Dodona] Pushen naar "%{repository}" mislukt'
       body:
         greeting: |
           Beste %{name},
-        error_message_html: |
-          Tijdens het verwerken "%{repository}" kon Dodona de aanpassingen van de verwerkte oefeningen niet pushen. De exacte error was: %{error}.
+        error_message: |
+          Tijdens het verwerken van "%{repository}" kon Dodona de aanpassingen aan de verwerkte oefeningen niet pushen. De exacte error was: %{error}.
 
-          Zorg er zeker voor dat de Dodona gebruiker push rechten heeft op je repository.
+          Zorg er zeker voor dat de Dodona gebruiker pushrechten heeft op je repository.
         regards: |
           Vriendelijke groeten,
         auto-generated: ps. Dit bericht werd automatisch gegenereerd.

--- a/config/locales/views/error_mailer/nl.yml
+++ b/config/locales/views/error_mailer/nl.yml
@@ -10,3 +10,10 @@ nl:
         other: 'Bij het automatisch verwerken van de oefeningenrepository "%{repository}" liep iets fout. Vermoedelijk zit er een syntaxfout in het configuratiebestand. Onderstaande foutmeldingen werden gegenereerd:'
       regards: 'Vriendelijke groeten,'
       auto-generated: ps. Dit bericht werd automatisch gegenereerd.
+    git_error:
+      subject: "Pushen naar %{repository} mislukt"
+      body:
+        greeting: "Beste %{name},"
+        error_message_html: "Tijdens het verwerken kon Dodona de aanpassingen van de verwerkte oefeningen niet pushen. De exacte error was: %{error}.\n\nZorg er zeker voor dat de Dodona gebruiker push rechten heeft op je repository."
+        regards: "Vriendelijke groeten,"
+        auto-generated: ps. Dit bericht werd automatisch gegenereerd.

--- a/config/locales/views/repositories/en.yml
+++ b/config/locales/views/repositories/en.yml
@@ -1,7 +1,7 @@
 en:
   repositories:
     form:
-      remote_help: "The SSH clone URL of the judge repository. Dodona needs access rights to the repository to be able to clone it."
+      remote_help: "The SSH clone URL of the exercise repository. Dodona needs read and write permissions to use the repository."
       judge_help: "This judge will be used when the exercise doesn't specify one."
       remote_cant_be_edited_html: The clone URL can't be edited after the repository was created. Contact <a href="mailto:dodona@ugent.be">dodona@ugent.be</a> if it needs to be changed.
     index:

--- a/config/locales/views/repositories/nl.yml
+++ b/config/locales/views/repositories/nl.yml
@@ -1,7 +1,7 @@
 nl:
   repositories:
     form:
-      remote_help: "De SSH 'clone url' van de repository waar de oefeningen te vinden zijn. Dodona heeft de juiste rechten nodig om de repository te kunnen clonen."
+      remote_help: "De SSH 'clone url' van de repository waar de oefeningen te vinden zijn. Dodona heeft lees- en schrijfrechten nodig om de repository te gebruiken."
       judge_help: "Deze judge zal gebruikt worden als de oefening zelf geen specifieert."
       remote_cant_be_edited_html: De clone URL kan niet aangepast worden nadat de repository werd aangemaakt. Contacteer <a href="mailto:dodona@ugent.be">dodona@ugent.be</a> als het toch aangepast moet worden.
     index:

--- a/test/models/repository_test.rb
+++ b/test/models/repository_test.rb
@@ -320,4 +320,19 @@ class EchoRepositoryTest < ActiveSupport::TestCase
       @repository.process_activities
     end
   end
+
+  test 'should send a mail chen commit fails' do
+    # make sure commit fails
+    @repository.stubs(:commit).returns([false, ['commit fail']])
+
+    # add an activity to make sure that commit will be executed inside @repository.process_activities
+    new_dir = 'echo2'
+    @remote.copy_dir(@echo.path, new_dir)
+    @remote.commit('copy exercise')
+
+    @repository.reset
+    assert_difference 'ActionMailer::Base.deliveries.size', +1 do
+      @repository.process_activities_email_errors
+    end
+  end
 end

--- a/test/models/repository_test.rb
+++ b/test/models/repository_test.rb
@@ -305,12 +305,17 @@ class EchoRepositoryTest < ActiveSupport::TestCase
     assert_equal 'not_valid', @echo.status
   end
 
-  test 'should send an email when commit fails' do
+  test 'should catch error when commit fails' do
     # make sure commit fails
-    @repository.stubs(:commit).returns([false, ['not empty']])
-    @repository.reset
+    @repository.stubs(:commit).returns([false, ['commit fail']])
+
+    # add an activity to make sure that commit will be executed inside @repository.process_activities
+    new_dir = 'echo2'
+    @remote.copy_dir(@echo.path, new_dir)
+    @remote.commit('copy exercise')
 
     # should raise AggregatedConfigErrors because commit fails
+    @repository.reset
     assert_raises(AggregatedConfigErrors) do
       @repository.process_activities
     end

--- a/test/models/repository_test.rb
+++ b/test/models/repository_test.rb
@@ -314,9 +314,9 @@ class EchoRepositoryTest < ActiveSupport::TestCase
     @remote.copy_dir(@echo.path, new_dir)
     @remote.commit('copy exercise')
 
-    # should raise AggregatedConfigErrors because commit fails
+    # should raise DodonaGitError because commit fails
     @repository.reset
-    assert_raises(AggregatedConfigErrors) do
+    assert_raises(DodonaGitError) do
       @repository.process_activities
     end
   end

--- a/test/models/repository_test.rb
+++ b/test/models/repository_test.rb
@@ -321,7 +321,7 @@ class EchoRepositoryTest < ActiveSupport::TestCase
     end
   end
 
-  test 'should send a mail chen commit fails' do
+  test 'should send a mail when commit fails' do
     # make sure commit fails
     @repository.stubs(:commit).returns([false, ['commit fail']])
 

--- a/test/models/repository_test.rb
+++ b/test/models/repository_test.rb
@@ -304,4 +304,15 @@ class EchoRepositoryTest < ActiveSupport::TestCase
     @echo.reload
     assert_equal 'not_valid', @echo.status
   end
+
+  test 'should send an email when commit fails' do
+    # make sure commit fails
+    @repository.stubs(:commit).returns([false, ['not empty']])
+    @repository.reset
+
+    # should raise AggregatedConfigErrors because commit fails
+    assert_raises(AggregatedConfigErrors) do
+      @repository.process_activities
+    end
+  end
 end


### PR DESCRIPTION
This pull request gives an error when Dodona has no push rights to an exercise repo.
This way we are notified when pushing fails

This is how the email looks like (in Dutch) when pushing fails

html:
<img width="1338" alt="image" src="https://user-images.githubusercontent.com/68779933/183048874-32c0dc3c-846c-460d-b56f-12c7f0430fd6.png">

plain text:
<img width="1425" alt="image" src="https://user-images.githubusercontent.com/68779933/183048935-46b99cc3-5950-4df0-a406-0229c3369cf7.png">


Closes #3298  .
