### PR TITLE
Don't update search bar on page changes when the search bar does not use the page url

### DIFF
--- a/app/assets/javascripts/search.ts
+++ b/app/assets/javascripts/search.ts
@@ -113,7 +113,11 @@ export class SearchQuery {
         this.queryParams.subscribe(k => this.paramChange(k));
         this.queryParams.subscribeByKey("refresh", (k, o, n) => this.refresh(n));
 
-        window.onpopstate = () => this.setBaseUrl();
+        window.onpopstate = () => {
+            if (this.updateAddressBar) {
+                this.setBaseUrl();
+            }
+        };
 
         this.setRefreshElement(refreshElement);
     }


### PR DESCRIPTION
This pull request adds an extra check to the onpopstate event handler. This check prevents the search url being set to the navbar url if this is not the url currently in use by the search bar.

Fixes searching exercises on the evaluation page after clicking `#add-activities`.

Related to #3878
Caused by changes in https://github.com/dodona-edu/dodona/pull/3857