### PR TITLE
Merge announcement views when merging users

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -49,6 +49,7 @@ class User < ApplicationRecord
   has_many :notifications, dependent: :destroy
   has_many :evaluation_users, inverse_of: :user, dependent: :restrict_with_error
   has_one  :rights_request, dependent: :destroy
+  has_many :announcement_views, dependent: :destroy
 
   has_many :subscribed_courses,
            lambda {
@@ -433,6 +434,14 @@ class User < ApplicationRecord
           ra.destroy!
         else
           ra.update!(user: other)
+        end
+      end
+
+      announcement_views.each do |av|
+        if other.announcement_views.find { |oav| oav.announcement_id == av.announcement_id }
+          av.destroy!
+        else
+          av.update!(user: other)
         end
       end
 

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -787,4 +787,21 @@ class UserHasManyTest < ActiveSupport::TestCase
     assert_equal true, s2.started?(user: u2)
     assert_equal true, s2.wrong?(user: u2)
   end
+
+  test 'merge should only transfer unique announcement views to the other user' do
+    u1 = create :user
+    u2 = create :user
+
+    a1 = create :announcement
+    a2 = create :announcement
+    AnnouncementView.create user: u1, announcement: a1
+    AnnouncementView.create user: u1, announcement: a2
+    AnnouncementView.create user: u2, announcement: a1
+
+    result = u1.merge_into(u2)
+
+    assert result
+    assert_not u1.persisted?
+    assert_equal 2, u2.announcement_views.count
+  end
 end


### PR DESCRIPTION
This pull request assures that announcement views are also merged when users are merged.

The current build broke if the user being merged had announcement views as it blocked the user from being destroyed.

- [x] Tests were added

