### PR TITLE
Give users a friendlier message about why they cannot register for a course

### DIFF
--- a/app/helpers/courses_helper.rb
+++ b/app/helpers/courses_helper.rb
@@ -22,7 +22,7 @@ module CoursesHelper
                   class: 'btn btn-filled'
         end
       else
-        tag.p t('courses.registration.registration_closed')
+        tag.p t("courses.show.registration-#{@course.registration}-info", institution: @course.institution&.name)
       end
     elsif membership.pending?
       link_to t('courses.registration.remove_from_pending'),

--- a/app/views/courses/_not_a_member_card.html.erb
+++ b/app/views/courses/_not_a_member_card.html.erb
@@ -1,6 +1,6 @@
 <div class="col-sm-6 col-12">
   <div class="callout callout-info">
-    <% if @course.closed? %>
+    <% if !@course.open_for_user?(current_user) %>
       <p><%= t 'courses.registration.closed' %></p>
     <% else %>
       <% if @current_membership&.pending? %>
@@ -12,8 +12,6 @@
         <p><%= t 'courses.registration.moderated' %></p>
       <% end %>
     <% end %>
-    <% unless @course.closed? %>
-      <%= registration_action_for course: @course, membership: @current_membership, secret: (@course.secret if @course.secret_required?(current_user)) %>
-    <% end %>
+    <%= registration_action_for course: @course, membership: @current_membership, secret: (@course.secret if @course.secret_required?(current_user)) %>
   </div>
 </div>


### PR DESCRIPTION
This pull request reuses the hidden icon title text in the callout, to give a better explanation of why they cannot register.

![image](https://user-images.githubusercontent.com/21177904/185567041-f5186a0c-1b9b-43c1-8b99-f080f17a72f8.png)

![image](https://user-images.githubusercontent.com/21177904/185567052-b38ad0e9-7c95-4e5f-9d13-c8e94aea6dee.png)
![image](https://user-images.githubusercontent.com/21177904/185567065-bd11001a-962f-47b6-b9de-dc60f86da027.png)
