### PR TITLE
Automatically filter on courses for which you can register when relevant

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -16,6 +16,10 @@ class CoursesController < ApplicationController
     scope.by_course_labels(value, controller.params[:id])
   end
 
+  has_scope :can_register, type: :boolean, only: :index do |controller, scope|
+    scope.can_register(controller.current_user)
+  end
+
   has_scope :order_by, using: %i[column direction], only: :scoresheet, type: :hash do |controller, scope, value|
     column, direction = value
     if %w[ASC DESC].include?(direction)
@@ -63,7 +67,7 @@ class CoursesController < ApplicationController
     end
 
     @courses = @courses.paginate(page: parse_pagination_param(params[:page]))
-    @membership_status = current_user&.course_memberships.where(course_id: @courses.pluck(:id))&.map { |c| [c.course_id, c.status] }&.to_h || {}
+    @membership_status = current_user&.course_memberships&.where(course_id: @courses.pluck(:id))&.map { |c| [c.course_id, c.status] }&.to_h || {}
     @repository = Repository.find(params[:repository_id]) if params[:repository_id]
     @institution = Institution.find(params[:institution_id]) if params[:institution_id]
     @copy_courses = params[:copy_courses]

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -63,6 +63,7 @@ class CoursesController < ApplicationController
     end
 
     @courses = @courses.paginate(page: parse_pagination_param(params[:page]))
+    @membership_status = current_user&.course_memberships.where(course_id: @courses.pluck(:id))&.map { |c| [c.course_id, c.status] }&.to_h || {}
     @repository = Repository.find(params[:repository_id]) if params[:repository_id]
     @institution = Institution.find(params[:institution_id]) if params[:institution_id]
     @copy_courses = params[:copy_courses]

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -168,7 +168,7 @@ class Course < ApplicationRecord
         .or(where(id: user.subscribed_courses.pluck(:id)))
     else
       where(registration: :open_for_all)
-        .or(where(id: user&.subscribed_courses.pluck(:id)))
+        .or(where(id: user&.subscribed_courses&.pluck(:id)))
     end
   }
   default_scope { order(year: :desc, name: :asc) }

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -163,7 +163,7 @@ class Course < ApplicationRecord
   scope :by_institution, ->(institution) { where(institution: institution) }
   scope :can_register, lambda { |user|
     if user&.institutional?
-      where(registration: %i[open_for_all open_for_institutional])
+      where(registration: %i[open_for_all open_for_institutional_users])
         .or(where(registration: :open_for_institution, institution_id: user.institution_id))
     else
       where(registration: :open_for_all)

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -161,6 +161,14 @@ class Course < ApplicationRecord
   scope :by_name, ->(name) { where('name LIKE ?', "%#{name}%") }
   scope :by_teacher, ->(teacher) { where('teacher LIKE ?', "%#{teacher}%") }
   scope :by_institution, ->(institution) { where(institution: institution) }
+  scope :can_register, lambda { |user|
+    if user&.institutional?
+      where(registration: %i[open_for_all open_for_institutional])
+        .or(where(registration: :open_for_institution, institution_id: user.institution_id))
+    else
+      where(registration: :open_for_all)
+    end
+  }
   default_scope { order(year: :desc, name: :asc) }
 
   token_generator :secret, unique: false, length: 5

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -165,8 +165,10 @@ class Course < ApplicationRecord
     if user&.institutional?
       where(registration: %i[open_for_all open_for_institutional_users])
         .or(where(registration: :open_for_institution, institution_id: user.institution_id))
+        .or(where(id: user.subscribed_courses.pluck(:id)))
     else
       where(registration: :open_for_all)
+        .or(where(id: user&.subscribed_courses.pluck(:id)))
     end
   }
   default_scope { order(year: :desc, name: :asc) }

--- a/app/views/courses/_courses_table.html.erb
+++ b/app/views/courses/_courses_table.html.erb
@@ -16,8 +16,14 @@
     <% courses.each do |course| %>
       <tr>
         <td>
-          <% if current_user&.admin_of?(course) %>
+          <% if @membership_status[course.id] == 'course_admin' %>
             <span title='<%= t "pages.course_card.course-admin" %>'><i class='mdi mdi-school'></i></span>
+          <% elsif @membership_status[course.id] == 'student' %>
+            <span title='<%= t "courses.registration.already_a_member" %>'><i class='mdi mdi-account-check-outline'></i></span>
+          <% elsif @membership_status[course.id] == 'pending' %>
+            <span title='<%= t "courses.registration.pending" %>'><i class='mdi mdi-account-clock-outline'></i></span>
+          <% elsif current_user.present? && !course.open_for_user?(current_user) %>
+            <span title='<%= t("courses.show.registration-#{course.registration}-info", institution: course.institution&.name) %>'><i class='mdi mdi-account-remove-outline'></i></span>
           <% end %>
           <% if course.featured %>
             <span title='<%= Course.human_attribute_name("featured") %>'><i class='mdi mdi-star-outline'></i></span>

--- a/app/views/courses/index.html.erb
+++ b/app/views/courses/index.html.erb
@@ -29,7 +29,7 @@
             <% end %>
           </ul>
         </div>
-        <%= render partial: 'layouts/searchbar', locals: {institutions: Institution.all, eager: false, no_dropdown_for: ["institutions"] } %>
+        <%= render partial: 'layouts/searchbar', locals: {institutions: Institution.all, eager: false, no_dropdown_for: ["institutions"], actions: [{search: {can_register: true}, type: 'can-register', text: "#{t(".only_show_can_register")}"}]  } %>
         <div id="courses-table-wrapper"></div>
       </div>
     </div>

--- a/app/views/pages/_getting_started_card.html.erb
+++ b/app/views/pages/_getting_started_card.html.erb
@@ -6,7 +6,7 @@
     <div class="card-title col-6">
       <h1 class="card-title-text getting-started-title"><%= t ".title" %></h1>
       <p class="getting-started-text"><%= t ".text" %></p>
-      <%= link_to t(".action"), courses_path, class: "btn btn-text getting-started-action" %>
+      <%= link_to t(".action"), courses_path(:can_register => :true), class: "btn btn-text getting-started-action" %>
     </div>
   </div>
 </div>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -51,7 +51,7 @@
         <% end %>
         <div class="card home-summary-card">
           <div class="card-supporting-text">
-            <%= link_to (t('.more-courses') + ' …'), courses_path, class: "btn btn-text" %>
+            <%= link_to (t('.more-courses') + ' …'), courses_path(:can_register => :true), class: "btn btn-text" %>
           </div>
         </div>
       </div>

--- a/config/locales/views/courses/en.yml
+++ b/config/locales/views/courses/en.yml
@@ -61,6 +61,7 @@ en:
       featured_courses: Featured courses
       all_courses: "All courses"
       my_courses: "My courses"
+      only_show_can_register: "Only show courses for which you can register"
     new:
       title: Create course
       empty: "Empty course"

--- a/config/locales/views/courses/nl.yml
+++ b/config/locales/views/courses/nl.yml
@@ -61,6 +61,7 @@ nl:
       featured_courses: Uitgelichte cursussen
       all_courses: "Alle cursussen"
       my_courses: "Mijn cursussen"
+      only_show_can_register: "Toon enkel cursusen waarvoor je kan registreren"
     new:
       title: Cursus aanmaken
       empty: "Lege cursus"

--- a/test/models/course_test.rb
+++ b/test/models/course_test.rb
@@ -277,7 +277,7 @@ class CourseTest < ActiveSupport::TestCase
   test 'can_register should only return course if the user can register for it' do
     i = create :institution
     Course.registrations.each do |r|
-      c = create :course, registration: r[1], institution: i
+      create :course, registration: r[1], institution: i
     end
     [create(:institution), i, nil].each do |institution|
       u = create :user, institution: institution

--- a/test/models/course_test.rb
+++ b/test/models/course_test.rb
@@ -259,4 +259,31 @@ class CourseTest < ActiveSupport::TestCase
     course.usable_repositories << ex.repository
     assert course.all_activities_accessible?
   end
+
+  test 'can_register scope should always contain own courses' do
+    i = create :institution
+    [create(:institution), i, nil].each do |institution|
+      u = create :user, institution: institution
+      CourseMembership.statuses.each do |s|
+        Course.registrations.each do |r|
+          c = create :course, registration: r[1], institution: i
+          CourseMembership.create user: u, course: c, status: s[1]
+        end
+      end
+      assert_equal u.subscribed_courses.count, u.subscribed_courses.can_register(u).count
+    end
+  end
+
+  test 'can_register should only return course if the user can register for it' do
+    i = create :institution
+    Course.registrations.each do |r|
+      c = create :course, registration: r[1], institution: i
+    end
+    [create(:institution), i, nil].each do |institution|
+      u = create :user, institution: institution
+      Course.all.each do |c|
+        assert_equal c.open_for_user?(u), Course.can_register(u).exists?(c.id)
+      end
+    end
+  end
 end


### PR DESCRIPTION
This pull request filters the courses list on courses for which the user can register. It also adds some extra icons to visualize whether you are already registered.

The filter is optional. It it automatically activated when accessing the courses list from the home page. (Either 'more courses' or 'view courses') But it can be disabled through the search options.

![image](https://user-images.githubusercontent.com/21177904/185597117-95128aba-8ea1-4629-ae53-416444e24fa7.png)
![image](https://user-images.githubusercontent.com/21177904/185597775-3a2de766-7003-46f3-b017-e428385caf6a.png)

- [x] test where added
