### PR TITLE
Clear all grades button

### DIFF
--- a/app/assets/javascripts/feedback/actions.ts
+++ b/app/assets/javascripts/feedback/actions.ts
@@ -268,7 +268,12 @@ export default class FeedbackActions {
                     f.markBusy();
                     f.data = "";
                 });
-                const values = this.scoreForms.map(f => f.getDataForNested(true));
+                const values = this.scoreForms
+                    .map(f => f.getDataForNested())
+                    .map(record => {
+                        record.score = null;
+                        return record;
+                    });
                 this.update({
                     // eslint-disable-next-line camelcase
                     scores_attributes: values

--- a/app/assets/javascripts/feedback/actions.ts
+++ b/app/assets/javascripts/feedback/actions.ts
@@ -102,11 +102,11 @@ export default class FeedbackActions {
         this.scoreForms.forEach(s => s.disableInputs());
     }
 
-    update(data: Record<string, unknown>, clearScores: boolean): Promise<void> {
+    update(data: Record<string, unknown>): Promise<void> {
         this.disableInputs();
         return fetch(this.options.currentURL, {
             method: "PATCH",
-            body: JSON.stringify({ feedback: data, clear_scores: clearScores }),
+            body: JSON.stringify({ feedback: data }),
             headers: {
                 "Content-Type": "application/json",
                 "Accept": "text/javascript"
@@ -187,7 +187,7 @@ export default class FeedbackActions {
             if (autoMark && hasAutoMark) {
                 await this.update({
                     completed: true,
-                }, false);
+                });
             }
             if (skipCompleted) {
                 window.location.href = this.options.nextUnseenURL;
@@ -239,7 +239,7 @@ export default class FeedbackActions {
             await this.update({
                 // eslint-disable-next-line camelcase
                 scores_attributes: values
-            }, false);
+            });
         });
         this.allScoresMaxButton?.addEventListener("click", async e => {
             e.preventDefault();
@@ -252,7 +252,7 @@ export default class FeedbackActions {
             await this.update({
                 // eslint-disable-next-line camelcase
                 scores_attributes: values
-            }, false);
+            });
         });
         this.deleteAllButton?.addEventListener("click", async e => {
             e.preventDefault();
@@ -262,7 +262,7 @@ export default class FeedbackActions {
                     f.markBusy();
                     f.data = "";
                 });
-                await this.update({}, true);
+                await this.update(null);
             }
         });
     }

--- a/app/assets/javascripts/feedback/actions.ts
+++ b/app/assets/javascripts/feedback/actions.ts
@@ -262,7 +262,11 @@ export default class FeedbackActions {
                     f.markBusy();
                     f.data = "";
                 });
-                await this.update(null);
+                const values = this.scoreForms.map(f => f.getDataForNested(true));
+                await this.update({
+                    // eslint-disable-next-line camelcase
+                    scores_attributes: values
+                });
             }
         });
     }

--- a/app/assets/javascripts/feedback/actions.ts
+++ b/app/assets/javascripts/feedback/actions.ts
@@ -256,12 +256,14 @@ export default class FeedbackActions {
         });
         this.deleteAllButton?.addEventListener("click", async e => {
             e.preventDefault();
-            this.disableInputs();
-            this.scoreForms.forEach(f => {
-                f.markBusy();
-                f.data = "";
-            });
-            await this.update({}, true);
+            if (window.confirm(I18n.t("js.score.confirm"))) {
+                this.disableInputs();
+                this.scoreForms.forEach(f => {
+                    f.markBusy();
+                    f.data = "";
+                });
+                await this.update({}, true);
+            }
         });
     }
 }

--- a/app/assets/javascripts/feedback/actions.ts
+++ b/app/assets/javascripts/feedback/actions.ts
@@ -102,11 +102,11 @@ export default class FeedbackActions {
         this.scoreForms.forEach(s => s.disableInputs());
     }
 
-    update(data: Record<string, unknown>): Promise<void> {
+    update(data: Record<string, unknown>, clearScores: boolean): Promise<void> {
         this.disableInputs();
         return fetch(this.options.currentURL, {
             method: "PATCH",
-            body: JSON.stringify({ feedback: data }),
+            body: JSON.stringify({ feedback: data, clear_scores: clearScores }),
             headers: {
                 "Content-Type": "application/json",
                 "Accept": "text/javascript"
@@ -114,28 +114,6 @@ export default class FeedbackActions {
         }).then(async response => {
             if (response.ok) {
                 eval(await response.text());
-            } else if ([403, 404, 422].includes(response.status)) {
-                new dodona.Toast(I18n.t("js.score.conflict"));
-                await this.refresh();
-            } else {
-                new dodona.Toast(I18n.t("js.score.unknown"));
-                await this.refresh();
-            }
-        });
-    }
-
-    delete(): Promise<void> {
-        this.disableInputs();
-        return fetch(this.options.currentURL, {
-            method: "DELETE",
-            headers: {
-                "Content-Type": "application/json",
-                "Accept": "text/javascript"
-            }
-        }).then(async response => {
-            if (response.ok) {
-                const res = await response.text();
-                eval(res);
             } else if ([403, 404, 422].includes(response.status)) {
                 new dodona.Toast(I18n.t("js.score.conflict"));
                 await this.refresh();
@@ -208,8 +186,8 @@ export default class FeedbackActions {
         this.nextFeedbackAction = async () => {
             if (autoMark && hasAutoMark) {
                 await this.update({
-                    completed: true
-                });
+                    completed: true,
+                }, false);
             }
             if (skipCompleted) {
                 window.location.href = this.options.nextUnseenURL;
@@ -261,7 +239,7 @@ export default class FeedbackActions {
             await this.update({
                 // eslint-disable-next-line camelcase
                 scores_attributes: values
-            });
+            }, false);
         });
         this.allScoresMaxButton?.addEventListener("click", async e => {
             e.preventDefault();
@@ -274,7 +252,7 @@ export default class FeedbackActions {
             await this.update({
                 // eslint-disable-next-line camelcase
                 scores_attributes: values
-            });
+            }, false);
         });
         this.deleteAllButton?.addEventListener("click", async e => {
             e.preventDefault();
@@ -283,7 +261,7 @@ export default class FeedbackActions {
                 f.markBusy();
                 f.data = "";
             });
-            await this.delete();
+            await this.update({}, true);
         });
     }
 }

--- a/app/assets/javascripts/feedback/actions.ts
+++ b/app/assets/javascripts/feedback/actions.ts
@@ -51,7 +51,7 @@ export default class FeedbackActions {
         this.skipCompletedCheckBox = document.getElementById("skip-completed") as HTMLInputElement;
 
         this.scoreSumElement = document.getElementById("score-sum") as HTMLInputElement;
-        this.completedIcon = document.getElementById("completed-checkmark") as HTMLButtonElement;
+        this.completedIcon = document.getElementById("completed-icon") as HTMLButtonElement;
         this.deleteAllButton = document.getElementById("delete-all-button") as HTMLButtonElement;
 
         // Score forms
@@ -164,7 +164,13 @@ export default class FeedbackActions {
         }
 
         if (this.completedIcon) {
-            this.completedIcon.hidden = !completed;
+            if (completed) {
+                this.completedIcon.classList.add("mdi-check");
+                this.completedIcon.classList.remove("mdi-circle-slice-3");
+            } else {
+                this.completedIcon.classList.add("mdi-circle-slice-3");
+                this.completedIcon.classList.remove("mdi-check");
+            }
         }
     }
 

--- a/app/assets/javascripts/feedback/actions.ts
+++ b/app/assets/javascripts/feedback/actions.ts
@@ -3,6 +3,7 @@ import ScoreForm from "feedback/score";
 
 interface ActionOptions {
     currentURL: string;
+    deleteScoresURL: string;
     feedbackId: string;
     nextURL: string | null;
     nextUnseenURL: string | null;
@@ -102,10 +103,10 @@ export default class FeedbackActions {
         this.scoreForms.forEach(s => s.disableInputs());
     }
 
-    update(data: Record<string, unknown>): Promise<void> {
+    doRequest(method: string, url: string, data: Record<string, unknown>): Promise<void> {
         this.disableInputs();
-        return fetch(this.options.currentURL, {
-            method: "PATCH",
+        return fetch(url, {
+            method: method,
             body: JSON.stringify({ feedback: data }),
             headers: {
                 "Content-Type": "application/json",
@@ -122,6 +123,14 @@ export default class FeedbackActions {
                 await this.refresh();
             }
         });
+    }
+
+    update(data: Record<string, unknown>): Promise<void> {
+        return this.doRequest("PATCH", this.options.currentURL, data);
+    }
+
+    delete(data: Record<string, unknown>): Promise<void> {
+        return this.doRequest("DELETE", this.options.deleteScoresURL, data);
     }
 
     async refresh(warning = ""): Promise<void> {
@@ -274,7 +283,7 @@ export default class FeedbackActions {
                         record.score = null;
                         return record;
                     });
-                this.update({
+                this.delete({
                     // eslint-disable-next-line camelcase
                     scores_attributes: values
                 });

--- a/app/assets/javascripts/feedback/actions.ts
+++ b/app/assets/javascripts/feedback/actions.ts
@@ -160,7 +160,7 @@ export default class FeedbackActions {
         // Only update the total if we have a total.
         if (this.scoreSumElement) {
             this.scoreSumElement.value = newTotal;
-            this.deleteAllButton.disabled = this.scoreSumElement.value === "-"; // '-' is the placeholder if no score items are filled in yet
+            this.deleteAllButton.disabled = this.scoreForms.every(form => form.data === "");
         }
 
         if (this.completedIcon) {

--- a/app/assets/javascripts/feedback/actions.ts
+++ b/app/assets/javascripts/feedback/actions.ts
@@ -277,16 +277,7 @@ export default class FeedbackActions {
                     f.markBusy();
                     f.data = "";
                 });
-                const values = this.scoreForms
-                    .map(f => f.getDataForNested())
-                    .map(record => {
-                        record.score = null;
-                        return record;
-                    });
-                this.delete({
-                    // eslint-disable-next-line camelcase
-                    scores_attributes: values
-                });
+                this.delete({});
             }
         });
     }

--- a/app/assets/javascripts/feedback/actions.ts
+++ b/app/assets/javascripts/feedback/actions.ts
@@ -236,7 +236,7 @@ export default class FeedbackActions {
                 f.data = "0";
             });
             const values = this.scoreForms.map(f => f.getDataForNested());
-            await this.update({
+            this.update({
                 // eslint-disable-next-line camelcase
                 scores_attributes: values
             });
@@ -249,7 +249,7 @@ export default class FeedbackActions {
                 f.data = f.getMax();
             });
             const values = this.scoreForms.map(f => f.getDataForNested());
-            await this.update({
+            this.update({
                 // eslint-disable-next-line camelcase
                 scores_attributes: values
             });
@@ -263,7 +263,7 @@ export default class FeedbackActions {
                     f.data = "";
                 });
                 const values = this.scoreForms.map(f => f.getDataForNested(true));
-                await this.update({
+                this.update({
                     // eslint-disable-next-line camelcase
                     scores_attributes: values
                 });

--- a/app/assets/javascripts/feedback/score.ts
+++ b/app/assets/javascripts/feedback/score.ts
@@ -119,18 +119,16 @@ export default class ScoreForm {
         return this.input.value;
     }
 
-    public getDataForNested(setNullScore=false): Record<string, unknown> {
-        const newScore = setNullScore ? null : this.input.value;
-
+    public getDataForNested(): Record<string, unknown> {
         // If not existing, include ID.
         if (this.existing) {
             return {
                 id: this.id,
-                score: newScore,
+                score: this.input.value,
             };
         } else {
             return {
-                score: newScore,
+                score: this.input.value,
                 // eslint-disable-next-line camelcase
                 score_item_id: this.scoreItemId
             };

--- a/app/assets/javascripts/feedback/score.ts
+++ b/app/assets/javascripts/feedback/score.ts
@@ -120,7 +120,7 @@ export default class ScoreForm {
     }
 
     public getDataForNested(setNullScore=false): Record<string, unknown> {
-        const newScore = setNullScore? null: this.input.value;
+        const newScore = setNullScore ? null : this.input.value;
 
         // If not existing, include ID.
         if (this.existing) {

--- a/app/assets/javascripts/feedback/score.ts
+++ b/app/assets/javascripts/feedback/score.ts
@@ -119,16 +119,18 @@ export default class ScoreForm {
         return this.input.value;
     }
 
-    public getDataForNested(): Record<string, unknown> {
+    public getDataForNested(setNullScore=false): Record<string, unknown> {
+        const newScore = setNullScore? null: this.input.value;
+
         // If not existing, include ID.
         if (this.existing) {
             return {
                 id: this.id,
-                score: this.input.value,
+                score: newScore,
             };
         } else {
             return {
-                score: this.input.value,
+                score: newScore,
                 // eslint-disable-next-line camelcase
                 score_item_id: this.scoreItemId
             };

--- a/app/assets/stylesheets/components/btn.css.scss
+++ b/app/assets/stylesheets/components/btn.css.scss
@@ -126,7 +126,13 @@
   padding: 0;
   color: $on-surface-variant;
 
-  &:not(.btn-icon-filled) {
+  // enable pointer events to enable tooltips to be shown on disabled buttons
+  &.disabled-with-tooltip {
+    pointer-events: auto;
+    cursor: default;
+  }
+
+  &:not(.btn-icon-filled) &:not(.disabled-with-tooltip) {
     &:hover,
     &:focus,
     &:active {

--- a/app/controllers/feedbacks_controller.rb
+++ b/app/controllers/feedbacks_controller.rb
@@ -64,8 +64,8 @@ class FeedbacksController < ApplicationController
   end
 
   def update
-    # the feedback value from params is nil if we want to delete all the currently set scores
-    if params[:feedback].nil?
+    # the set scores are nil if we want to delete all the currently set scores
+    if params[:feedback][:scores_attributes]&.all? { |item| item[:score].nil? }
       # destroy all the scores
       @feedback.scores.each(&:destroy)
 

--- a/app/controllers/feedbacks_controller.rb
+++ b/app/controllers/feedbacks_controller.rb
@@ -1,7 +1,7 @@
 class FeedbacksController < ApplicationController
   include SeriesHelper
 
-  before_action :set_feedback, only: %i[show edit update]
+  before_action :set_feedback, only: %i[show edit update destroy_scores]
 
   has_scope :by_filter, as: 'filter' do |_controller, scope, value|
     scope.by_filter(value, skip_user: true, skip_exercise: true)
@@ -64,40 +64,38 @@ class FeedbacksController < ApplicationController
   end
 
   def update
-    # the set scores are nil if we want to delete all the currently set scores
-    if params[:feedback][:scores_attributes]&.all? { |item| item[:score].nil? }
-      # destroy all the scores
-      @feedback.scores.each(&:destroy)
+    attrs = permitted_attributes(@feedback)
+    attrs['scores_attributes'].each { |s| s['last_updated_by_id'] = current_user.id } if attrs['scores_attributes'].present?
 
-      # update the data for the view to render
-      @feedback = Feedback.find(params[:id])
-      @score_map = @feedback.scores.index_by(&:score_item_id)
+    updated = @feedback.update(attrs)
+    # We might have updated scores, so recalculate the map.
+    @score_map = @feedback.scores.index_by(&:score_item_id)
 
-      # render the view
-      respond_to do |format|
+    respond_to do |format|
+      if updated
         format.html { redirect_to evaluation_feedback_path(@feedback.evaluation, @feedback) }
         format.json { render :show, status: :ok, location: @feedback }
         format.js { render :show }
+      else
+        format.json { render json: @feedback.errors, status: :unprocessable_entity }
+        format.js { render :show, status: :unprocessable_entity }
       end
+    end
+  end
 
-    else # we want to change the current scores to the min or max value
-      attrs = permitted_attributes(@feedback)
-      attrs['scores_attributes'].each { |s| s['last_updated_by_id'] = current_user.id } if attrs['scores_attributes'].present?
+  def destroy_scores
+    # destroy all the scores
+    @feedback.scores.each(&:destroy)
 
-      updated = @feedback.update(attrs)
-      # We might have updated scores, so recalculate the map.
-      @score_map = @feedback.scores.index_by(&:score_item_id)
+    # update the data for the view to render
+    @feedback = Feedback.find(params[:id])
+    @score_map = @feedback.scores.index_by(&:score_item_id)
 
-      respond_to do |format|
-        if updated
-          format.html { redirect_to evaluation_feedback_path(@feedback.evaluation, @feedback) }
-          format.json { render :show, status: :ok, location: @feedback }
-          format.js { render :show }
-        else
-          format.json { render json: @feedback.errors, status: :unprocessable_entity }
-          format.js { render :show, status: :unprocessable_entity }
-        end
-      end
+    # render the view
+    respond_to do |format|
+      format.html { redirect_to evaluation_feedback_path(@feedback.evaluation, @feedback) }
+      format.json { render :show, status: :ok, location: @feedback }
+      format.js { render :show }
     end
   end
 

--- a/app/controllers/feedbacks_controller.rb
+++ b/app/controllers/feedbacks_controller.rb
@@ -64,10 +64,8 @@ class FeedbacksController < ApplicationController
   end
 
   def update
-    clear_scores = params[:clear_scores]
-
-    # clear_scores is true if we want to delete all the currently set scores
-    if clear_scores
+    # the feedback value from params is nil if we want to delete all the currently set scores
+    if params[:feedback].nil?
       # destroy all the scores
       @feedback.scores.each(&:destroy)
 
@@ -78,7 +76,7 @@ class FeedbacksController < ApplicationController
       # render the view
       respond_to do |format|
         format.html { redirect_to evaluation_feedback_path(@feedback.evaluation, @feedback) }
-        format.json { render :show, status: :no_content, location: @feedback }
+        format.json { render :show, status: :ok, location: @feedback }
         format.js { render :show }
       end
 

--- a/app/controllers/feedbacks_controller.rb
+++ b/app/controllers/feedbacks_controller.rb
@@ -1,7 +1,7 @@
 class FeedbacksController < ApplicationController
   include SeriesHelper
 
-  before_action :set_feedback, only: %i[show edit update]
+  before_action :set_feedback, only: %i[show edit update destroy] # TODO: use destroy or update with extra param to reset all scores
 
   has_scope :by_filter, as: 'filter' do |_controller, scope, value|
     scope.by_filter(value, skip_user: true, skip_exercise: true)
@@ -80,6 +80,22 @@ class FeedbacksController < ApplicationController
         format.json { render json: @feedback.errors, status: :unprocessable_entity }
         format.js { render :show, status: :unprocessable_entity }
       end
+    end
+  end
+
+  def destroy
+    # destroy all the scores
+    @feedback.scores.each(&:destroy)
+
+    # update the data for the view to render
+    @feedback = Feedback.find(params[:id])
+    @score_map = @feedback.scores.index_by(&:score_item_id)
+
+    # render the view
+    respond_to do |format|
+      format.html { redirect_to evaluation_feedback_path(@feedback.evaluation, @feedback) }
+      format.json { render :show, status: :no_content, location: @feedback }
+      format.js { render :show }
     end
   end
 

--- a/app/policies/feedback_policy.rb
+++ b/app/policies/feedback_policy.rb
@@ -26,10 +26,6 @@ class FeedbackPolicy < ApplicationPolicy
     course_admin?
   end
 
-  def destroy?
-    course_admin?
-  end
-
   def permitted_attributes
     attrs = %i[submission_id completed]
     attrs << { scores_attributes: %i[score id score_item_id] }

--- a/app/policies/feedback_policy.rb
+++ b/app/policies/feedback_policy.rb
@@ -26,6 +26,10 @@ class FeedbackPolicy < ApplicationPolicy
     course_admin?
   end
 
+  def destroy?
+    course_admin?
+  end
+
   def permitted_attributes
     attrs = %i[submission_id completed]
     attrs << { scores_attributes: %i[score id score_item_id] }

--- a/app/policies/feedback_policy.rb
+++ b/app/policies/feedback_policy.rb
@@ -26,6 +26,10 @@ class FeedbackPolicy < ApplicationPolicy
     course_admin?
   end
 
+  def destroy_scores?
+    course_admin?
+  end
+
   def permitted_attributes
     attrs = %i[submission_id completed]
     attrs << { scores_attributes: %i[score id score_item_id] }

--- a/app/views/feedbacks/_feedback_actions.html.erb
+++ b/app/views/feedbacks/_feedback_actions.html.erb
@@ -66,7 +66,12 @@
               <% end %>
               <input id="score-sum" class="form-control score-input" disabled="disabled" value="<%= format_score @feedback.score %>">
               <%= button_tag class: "btn btn-icon score-state", disabled: true, type: :button do %>
-                <i id="completed-checkmark" class="mdi mdi-check colored-info" aria-hidden='true' <%= 'hidden' unless @feedback.completed %>></i>
+<!--                <i id="completed-checkmark" class="mdi mdi-check colored-info" aria-hidden='true' <%#= 'hidden' unless @feedback.completed %>></i>-->
+                <% if @feedback.completed %>
+                  <i id="completed-icon" class="mdi mdi-check" aria-hidden='true'></i>
+                <% else %>
+                  <i id="completed-icon" class="mdi mdi-circle-slice-3" aria-hidden='true'></i>
+                <% end %>
               <% end %>
               <%= button_tag class: "btn btn-icon max-text", disabled: true, type: :button do %>
                 / <%= format_score(@feedback.maximum_score) %>

--- a/app/views/feedbacks/_feedback_actions.html.erb
+++ b/app/views/feedbacks/_feedback_actions.html.erb
@@ -132,6 +132,7 @@
     <% siblings = @feedback.siblings %>
     window.dodona.feedbackActions = new window.dodona.FeedbackActions({
         currentURL: <%= raw feedback_url(@feedback).to_json %>,
+        deleteScoresURL: <%= raw scores_feedback_url(@feedback).to_json %>,
         feedbackId: <%= @feedback.id %>,
         nextURL: <%= raw (siblings[:next].present? ? feedback_url(siblings[:next]) : nil).to_json %>,
         nextUnseenURL: <%= raw (siblings[:next_unseen].present? ? feedback_url(siblings[:next_unseen]) : nil).to_json %>,

--- a/app/views/feedbacks/_feedback_actions.html.erb
+++ b/app/views/feedbacks/_feedback_actions.html.erb
@@ -65,8 +65,10 @@
                 <i class="mdi mdi-delete-outline" aria-hidden='true'></i>
               <% end %>
               <input id="score-sum" class="form-control score-input" disabled="disabled" value="<%= format_score @feedback.score %>">
-              <%= button_tag class: "btn btn-icon score-state", disabled: true, type: :button do %>
-<!--                <i id="completed-checkmark" class="mdi mdi-check colored-info" aria-hidden='true' <%#= 'hidden' unless @feedback.completed %>></i>-->
+              <%= button_tag class: "btn btn-icon score-state disabled-with-tooltip",
+                             disabled: true,
+                             type: :button,
+                             title: @feedback.completed ? t('.score_complete_tooltip') : t('.score_incomplete_tooltip') do %>
                 <% if @feedback.completed %>
                   <i id="completed-icon" class="mdi mdi-check" aria-hidden='true'></i>
                 <% else %>

--- a/app/views/feedbacks/_feedback_actions.html.erb
+++ b/app/views/feedbacks/_feedback_actions.html.erb
@@ -61,14 +61,13 @@
         <div class="form-group input">
           <div class="control-wrapper">
             <div class="input-group input-group-small">
-              <%= button_tag class: "btn btn-icon", type: :button, disabled: true do %>
-                <% if @feedback.completed %>
-                  <i id="completed-button" class="mdi mdi-check" aria-hidden='true'></i>
-                <% else %>
-                  <i id="completed-button" class="mdi mdi-circle-slice-3" aria-hidden='true'></i>
-                <% end %>
+              <%= button_tag id: "delete-all-button", class: "btn btn-icon delete-button", type: :button, disabled: @feedback.scores.count == 0 do %>
+                <i class="mdi mdi-delete-outline" aria-hidden='true'></i>
               <% end %>
-              <input id="score-sum" class="form-control" disabled="disabled" value="<%= format_score @feedback.score %>">
+              <input id="score-sum" class="form-control score-input" disabled="disabled" value="<%= format_score @feedback.score %>">
+              <%= button_tag class: "btn btn-icon score-state", disabled: true, type: :button do %>
+                <i id="completed-checkmark" class="mdi mdi-check colored-info" aria-hidden='true' <%= 'hidden' unless @feedback.completed %>></i>
+              <% end %>
               <%= button_tag class: "btn btn-icon max-text", disabled: true, type: :button do %>
                 / <%= format_score(@feedback.maximum_score) %>
               <% end %>

--- a/app/views/feedbacks/_score_actions.html.erb
+++ b/app/views/feedbacks/_score_actions.html.erb
@@ -18,9 +18,9 @@
                              max: score_item.maximum,
                              value: format_score(f.object.score, lang='en', numeric_only=true) %>
 
-          <%= button_tag class: "btn btn-icon score-state", disabled: true, type: :button do %>
+          <%= button_tag class: "btn btn-icon score-state disabled-with-tooltip", disabled: true, type: :button do %>
             <% unless score.score.nil? %>
-              <i class="mdi mdi-check colored-info" aria-hidden='true'></i>
+              <i class="mdi mdi-check colored-info" aria-hidden='true' title="<%= t '.score_saved' %>"></i>
             <% end %>
           <% end %>
           <%= button_tag class: "btn btn-icon max-text", disabled: true, type: :button, data: { max: format_score(score_item.maximum, lang='en', numeric_only=true) } do %>

--- a/config/locales/views/feedbacks/en.yml
+++ b/config/locales/views/feedbacks/en.yml
@@ -30,6 +30,8 @@ en:
       evaluation_done: Evaluation completed
       undo: Undo
       waiting_on_score: This solution is not fully graded
+      score_complete_tooltip: All score items have been filled in
+      score_incomplete_tooltip: Not all score items have been filled in
       completed:
         failure: "Could not set state"
       total: "Total"
@@ -38,6 +40,7 @@ en:
     progress_row:
       exercise_progress: "%{feedback_count} / %{feedback_total} evaluations completed"
     score_actions:
+      score_saved: Score is saved
       give_max_one: "Assign %{score} to this score item"
       give_zero_one: "Assign 0 to this score item"
     overview:

--- a/config/locales/views/feedbacks/nl.yml
+++ b/config/locales/views/feedbacks/nl.yml
@@ -30,6 +30,8 @@ nl:
       evaluation_done: Evaluatie afgewerkt
       undo: Ongedaan maken
       waiting_on_score: Deze oplossing heeft nog niet alle punten gekregen
+      score_complete_tooltip: Alle scoreonderdelen zijn ingevuld
+      score_incomplete_tooltip: Niet alle scoreonderdelen zijn ingevuld
       completed:
         failure: "De status kon niet ingesteld worden"
       total: "Totaal"
@@ -38,6 +40,7 @@ nl:
     progress_row:
       exercise_progress: "%{feedback_count} / %{feedback_total} evaluaties afgewerkt"
     score_actions:
+      score_saved: Score is opgeslagen
       give_max_one: "Geef %{score} aan dit scoreonderdeel"
       give_zero_one: "Geef 0 aan dit scoreonderdeel"
     overview:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -231,7 +231,7 @@ Rails.application.routes.draw do
       end
       resources :scores, only: %i[show create update destroy]
     end
-    resources :feedbacks, only: %i[show edit update]
+    resources :feedbacks, only: %i[show edit update destroy]
     resources :evaluation_exercise, only: %i[update]
 
     resources :rights_requests, only: %i[index new create] do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -231,7 +231,7 @@ Rails.application.routes.draw do
       end
       resources :scores, only: %i[show create update destroy]
     end
-    resources :feedbacks, only: %i[show edit update destroy]
+    resources :feedbacks, only: %i[show edit update]
     resources :evaluation_exercise, only: %i[update]
 
     resources :rights_requests, only: %i[index new create] do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -231,7 +231,9 @@ Rails.application.routes.draw do
       end
       resources :scores, only: %i[show create update destroy]
     end
-    resources :feedbacks, only: %i[show edit update]
+    resources :feedbacks, only: %i[show edit update] do
+      delete 'scores', action: :destroy_scores, controller: :feedbacks, on: :member
+    end
     resources :evaluation_exercise, only: %i[update]
 
     resources :rights_requests, only: %i[index new create] do

--- a/test/controllers/feedbacks_controller_test.rb
+++ b/test/controllers/feedbacks_controller_test.rb
@@ -80,4 +80,24 @@ class FeedbacksControllerTest < ActionDispatch::IntegrationTest
     assert_equal s.id, @feedback.submission_id
     assert_equal 0, @feedback.scores.count
   end
+
+  test 'using the clear_grades parameter deletes the existing scores' do
+    create :score, feedback: @feedback, score_item: @score_item1
+    @feedback.reload
+    assert_equal 1, @feedback.scores.count
+
+    s = create :submission, exercise: @feedback.exercise, user: @feedback.user, course: @feedback.evaluation.series.course
+
+    patch evaluation_feedback_path(@evaluation, @feedback), params: {
+      feedback: {
+        submission_id: s.id
+      },
+      clear_scores: true
+    }
+
+    @feedback.reload
+
+    assert @feedback.scores.empty?
+
+  end
 end

--- a/test/controllers/feedbacks_controller_test.rb
+++ b/test/controllers/feedbacks_controller_test.rb
@@ -86,21 +86,7 @@ class FeedbacksControllerTest < ActionDispatch::IntegrationTest
     @feedback.reload
     assert_equal 1, @feedback.scores.count
 
-    delete scores_feedback_path(@feedback), params: {
-      feedback: {
-        scores_attributes:
-          [
-            {
-              id: 0,
-              score: nil
-            },
-            {
-              id: 1,
-              score: nil
-            }
-          ]
-      }
-    }
+    delete scores_feedback_path(@feedback)
 
     @feedback.reload
 

--- a/test/controllers/feedbacks_controller_test.rb
+++ b/test/controllers/feedbacks_controller_test.rb
@@ -98,6 +98,5 @@ class FeedbacksControllerTest < ActionDispatch::IntegrationTest
     @feedback.reload
 
     assert @feedback.scores.empty?
-
   end
 end

--- a/test/controllers/feedbacks_controller_test.rb
+++ b/test/controllers/feedbacks_controller_test.rb
@@ -81,12 +81,12 @@ class FeedbacksControllerTest < ActionDispatch::IntegrationTest
     assert_equal 0, @feedback.scores.count
   end
 
-  test 'using nil as score value deletes the existing scores' do
+  test 'deleting all the scores of an evaluation works' do
     create :score, feedback: @feedback, score_item: @score_item1
     @feedback.reload
     assert_equal 1, @feedback.scores.count
 
-    patch evaluation_feedback_path(@evaluation, @feedback), params: {
+    delete scores_feedback_path(@feedback), params: {
       feedback: {
         scores_attributes:
           [

--- a/test/controllers/feedbacks_controller_test.rb
+++ b/test/controllers/feedbacks_controller_test.rb
@@ -81,13 +81,25 @@ class FeedbacksControllerTest < ActionDispatch::IntegrationTest
     assert_equal 0, @feedback.scores.count
   end
 
-  test 'using nil as feedback value deletes the existing scores' do
+  test 'using nil as score value deletes the existing scores' do
     create :score, feedback: @feedback, score_item: @score_item1
     @feedback.reload
     assert_equal 1, @feedback.scores.count
 
     patch evaluation_feedback_path(@evaluation, @feedback), params: {
-      feedback: nil
+      feedback: {
+        scores_attributes:
+          [
+            {
+              id: 0,
+              score: nil
+            },
+            {
+              id: 1,
+              score: nil
+            }
+          ]
+      }
     }
 
     @feedback.reload

--- a/test/controllers/feedbacks_controller_test.rb
+++ b/test/controllers/feedbacks_controller_test.rb
@@ -81,18 +81,13 @@ class FeedbacksControllerTest < ActionDispatch::IntegrationTest
     assert_equal 0, @feedback.scores.count
   end
 
-  test 'using the clear_grades parameter deletes the existing scores' do
+  test 'using nil as feedback value deletes the existing scores' do
     create :score, feedback: @feedback, score_item: @score_item1
     @feedback.reload
     assert_equal 1, @feedback.scores.count
 
-    s = create :submission, exercise: @feedback.exercise, user: @feedback.user, course: @feedback.evaluation.series.course
-
     patch evaluation_feedback_path(@evaluation, @feedback), params: {
-      feedback: {
-        submission_id: s.id
-      },
-      clear_scores: true
+      feedback: nil
     }
 
     @feedback.reload


### PR DESCRIPTION
This pull request adds a button to clear all score items in the feedback panel
The change to the top level 👍 and 👎 is not (yet) implemented since we weren't sure if we wanted this.

screenshots:

<img width="290" alt="image" src="https://user-images.githubusercontent.com/68779933/185933559-40f9d953-3dd8-4b1c-a99c-47453d33397c.png">

<img width="332" alt="image" src="https://user-images.githubusercontent.com/68779933/187454667-3ab78b1b-cd9f-4fb7-b215-f143afb80f81.png">

Closes #2716 (partially) .
