### PR TITLE
Fix readable_name error for Google Workspace accounts

### DIFF
--- a/app/models/provider/g_suite.rb
+++ b/app/models/provider/g_suite.rb
@@ -51,6 +51,6 @@ class Provider::GSuite < Provider
     # We want to display gmail for private accounts
     return 'Gmail' if institution.nil?
 
-    super.readable_name
+    super
   end
 end

--- a/test/models/provider_test.rb
+++ b/test/models/provider_test.rb
@@ -71,7 +71,7 @@ class ProviderTest < ActiveSupport::TestCase
 
   test 'gsuite readable_name gives Google Workspace as name when account is NOT private' do
     provider = build :gsuite_provider, institution: @institution
-    assert_equal 'Google Workspace', provider.readable_name
+    assert_equal Provider::GSuite.readable_name, provider.readable_name
   end
 
   test 'smartschool extracts name of institution' do

--- a/test/models/provider_test.rb
+++ b/test/models/provider_test.rb
@@ -71,7 +71,7 @@ class ProviderTest < ActiveSupport::TestCase
 
   test 'gsuite readable_name gives Google Workspace as name when account is NOT private' do
     provider = build :gsuite_provider, institution: @institution
-    assert_equal "Google Workspace", provider.readable_name
+    assert_equal 'Google Workspace', provider.readable_name
   end
 
   test 'smartschool extracts name of institution' do

--- a/test/models/provider_test.rb
+++ b/test/models/provider_test.rb
@@ -69,6 +69,11 @@ class ProviderTest < ActiveSupport::TestCase
     assert_equal DEFAULT_NAMES, provider.extract_institution_name(OmniAuth::AuthHash.new({ info: {} }))
   end
 
+  test 'gsuite readable_name gives Google Workspace as name when account is NOT private' do
+    provider = build :gsuite_provider, institution: @institution
+    assert_equal "Google Workspace", provider.readable_name
+  end
+
   test 'smartschool extracts name of institution' do
     provider = Provider::Smartschool
     # This hash is extracted from the one we receive when logging in.


### PR DESCRIPTION
This pull request should fix the Google Workspace readable_name error for accounts that are NOT private

Closes #3920  .
