### PR TITLE
Increase contrast checkboxes in dark mode

### DIFF
--- a/app/assets/stylesheets/bootstrap_variable_overrides.css.scss
+++ b/app/assets/stylesheets/bootstrap_variable_overrides.css.scss
@@ -31,6 +31,7 @@ $pagination-disabled-bg: $background;
 $modal-content-bg: $surface;
 
 $form-check-input-checked-bg-color: $secondary;
+$form-check-input-border: 1px solid rgba($text-disabled, .25);
 
 $table-border-color: $divider;
 


### PR DESCRIPTION
This pull request increases the contrast of the border of the checkboxes in darkmode

screenshots (in both dark and light mode)
<img width="1031" alt="image" src="https://user-images.githubusercontent.com/68779933/186615390-5e11a59b-5870-4906-8463-4a3362d6542b.png">
<img width="1007" alt="image" src="https://user-images.githubusercontent.com/68779933/186615444-98091a88-956a-47fd-9403-4c41671853df.png">
<img width="1084" alt="image" src="https://user-images.githubusercontent.com/68779933/186615585-94e007c1-ae0e-405c-9773-7cda35114010.png">
<img width="1024" alt="image" src="https://user-images.githubusercontent.com/68779933/186615529-881351aa-f718-4823-9d79-0fc476025e15.png">

Closes #3837  .
