### PR TITLE
Improve buttons in choose submission screen for evaluation

### DIFF
--- a/app/assets/stylesheets/components/btn.css.scss
+++ b/app/assets/stylesheets/components/btn.css.scss
@@ -109,12 +109,6 @@
       padding-left: 8px;
     }
   }
-
-  // shift the button to make it match the alignment of buttons with btn-outline style
-  &.outline-btn-alignment {
-    padding-left: 8px;
-    padding-right: 18px;
-  }
 }
 
 .btn.btn-outline {
@@ -124,6 +118,17 @@
   &:focus,
   &:active {
     border-color: $primary;
+  }
+
+  // add margin to right to "center" with the disabled button
+  &.align-action-disabled-btn {
+    margin-right: 8px
+  }
+
+  &:disabled {
+    color: $on-surface;
+    border: 1px solid rgba($on-surface, 0.12);
+    opacity: 0.38;
   }
 }
 

--- a/app/assets/stylesheets/components/btn.css.scss
+++ b/app/assets/stylesheets/components/btn.css.scss
@@ -109,6 +109,12 @@
       padding-left: 8px;
     }
   }
+
+  // shift the button to make it match the alignment of buttons with btn-outline style
+  &.outline-btn-alignment {
+    padding-left: 8px;
+    padding-right: 18px;
+  }
 }
 
 .btn.btn-outline {

--- a/app/assets/stylesheets/components/btn.css.scss
+++ b/app/assets/stylesheets/components/btn.css.scss
@@ -120,11 +120,6 @@
     border-color: $primary;
   }
 
-  // add margin to right to "center" with the disabled button
-  &.align-action-disabled-btn {
-    margin-right: 8px
-  }
-
   &:disabled {
     color: $on-surface;
     border: 1px solid rgba($on-surface, 0.12);

--- a/app/assets/stylesheets/components/table.css.scss
+++ b/app/assets/stylesheets/components/table.css.scss
@@ -56,7 +56,7 @@
 
 .table-resource .actions {
   text-align: center;
-  width: 1px;
+  width: 1px; // by default the size of the element in the col is used as width if width is smaller than that element. This width is just here to force everything to the right
 }
 
 tr.gu-mirror {

--- a/app/assets/stylesheets/components/table.css.scss
+++ b/app/assets/stylesheets/components/table.css.scss
@@ -59,9 +59,11 @@
 
   &.submissions-table {
     text-align: center;
-    width: 1px; // by default the size of the element in the col is used as width if width is smaller than that element. This width is just here to force everything to the right
-  }
 
+    // by default the size of the element in the col is used as width if width is smaller than that element.
+    // This width is just here to force everything to the right
+    width: 1px;
+  }
 }
 
 tr.gu-mirror {

--- a/app/assets/stylesheets/components/table.css.scss
+++ b/app/assets/stylesheets/components/table.css.scss
@@ -55,8 +55,13 @@
 }
 
 .table-resource .actions {
-  text-align: center;
-  width: 1px; // by default the size of the element in the col is used as width if width is smaller than that element. This width is just here to force everything to the right
+  text-align: right;
+
+  &.submissions-table {
+    text-align: center;
+    width: 1px; // by default the size of the element in the col is used as width if width is smaller than that element. This width is just here to force everything to the right
+  }
+
 }
 
 tr.gu-mirror {

--- a/app/assets/stylesheets/components/table.css.scss
+++ b/app/assets/stylesheets/components/table.css.scss
@@ -55,7 +55,8 @@
 }
 
 .table-resource .actions {
-  text-align: right;
+  text-align: center;
+  width: 1px;
 }
 
 tr.gu-mirror {

--- a/app/views/feedbacks/_submissions_table.html.erb
+++ b/app/views/feedbacks/_submissions_table.html.erb
@@ -29,7 +29,7 @@
           </td>
           <td class="actions">
             <% if @feedback.submission&.id == submission.id %>
-              <button class="btn btn-text" disabled>
+              <button class="btn btn-text outline-btn-alignment" disabled>
                 <%= t 'submissions.submissions_table.selected' %>
               </button>
             <% else %>

--- a/app/views/feedbacks/_submissions_table.html.erb
+++ b/app/views/feedbacks/_submissions_table.html.erb
@@ -27,7 +27,7 @@
           <td>
             <%= submission.summary %>
           </td>
-          <td class="actions">
+          <td class="actions submissions-table">
             <% if @feedback.submission&.id == submission.id %>
               <button class="btn btn-outline" disabled>
                 <%= t 'submissions.submissions_table.selected' %>

--- a/app/views/feedbacks/_submissions_table.html.erb
+++ b/app/views/feedbacks/_submissions_table.html.erb
@@ -29,13 +29,13 @@
           </td>
           <td class="actions">
             <% if @feedback.submission&.id == submission.id %>
-              <button class="btn btn-text outline-btn-alignment" disabled>
+              <button class="btn btn-outline" disabled>
                 <%= t 'submissions.submissions_table.selected' %>
               </button>
             <% else %>
               <%= link_to (t 'submissions.submissions_table.select'),
                           feedback_path(@feedback, feedback: { submission_id: submission.id }),
-                          class: "btn btn-outline",
+                          class: "btn btn-outline align-action-disabled-btn",
                           title: t(".update-submission"),
                           confirm: t('.confirm'),
                           method: :patch %>

--- a/app/views/feedbacks/_submissions_table.html.erb
+++ b/app/views/feedbacks/_submissions_table.html.erb
@@ -28,17 +28,17 @@
             <%= submission.summary %>
           </td>
           <td class="actions">
-            <% unless @feedback.submission&.id == submission.id %>
+            <% if @feedback.submission&.id == submission.id %>
+              <button class="btn btn-text" disabled>
+                <%= t 'submissions.submissions_table.selected' %>
+              </button>
+            <% else %>
               <%= link_to (t 'submissions.submissions_table.select'),
                           feedback_path(@feedback, feedback: { submission_id: submission.id }),
                           class: "btn btn-outline",
                           title: t(".update-submission"),
                           confirm: t('.confirm'),
                           method: :patch %>
-            <% else %>
-              <button class="btn btn-text" disabled>
-                <%= t 'submissions.submissions_table.selected' %>
-              </button>
             <% end %>
           </td>
         </tr>

--- a/app/views/feedbacks/_submissions_table.html.erb
+++ b/app/views/feedbacks/_submissions_table.html.erb
@@ -35,7 +35,7 @@
             <% else %>
               <%= link_to (t 'submissions.submissions_table.select'),
                           feedback_path(@feedback, feedback: { submission_id: submission.id }),
-                          class: "btn btn-outline align-action-disabled-btn",
+                          class: "btn btn-outline",
                           title: t(".update-submission"),
                           confirm: t('.confirm'),
                           method: :patch %>

--- a/app/views/feedbacks/_submissions_table.html.erb
+++ b/app/views/feedbacks/_submissions_table.html.erb
@@ -29,9 +29,16 @@
           </td>
           <td class="actions">
             <% unless @feedback.submission&.id == submission.id %>
-              <%= link_to feedback_path(@feedback, feedback: { submission_id: submission.id }), class: "btn btn-icon btn-icon-filled bg-primary", title: t(".update-submission"), confirm: t('.confirm'), method: :patch do %>
-                <i class="mdi mdi-check"></i>
-              <% end %>
+              <%= link_to (t 'submissions.submissions_table.select'),
+                          feedback_path(@feedback, feedback: { submission_id: submission.id }),
+                          class: "btn btn-outline",
+                          title: t(".update-submission"),
+                          confirm: t('.confirm'),
+                          method: :patch %>
+            <% else %>
+              <button class="btn btn-text" disabled>
+                <%= t 'submissions.submissions_table.selected' %>
+              </button>
             <% end %>
           </td>
         </tr>

--- a/config/locales/views/submissions/en.yml
+++ b/config/locales/views/submissions/en.yml
@@ -14,6 +14,8 @@ en:
       result: Result
       summary: Summary
       annotated: This submission has remarks.
+      select: Select
+      selected: Selected
     index:
       title: All submissions
       for: for

--- a/config/locales/views/submissions/nl.yml
+++ b/config/locales/views/submissions/nl.yml
@@ -14,7 +14,7 @@ nl:
       result: Resultaat
       summary: Samenvatting
       annotated: Deze oplossing heeft opmerkingen.
-      select: Selecteer
+      select: Selecteren
       selected: Geselecteerd
     index:
       title: Alle oplossingen

--- a/config/locales/views/submissions/nl.yml
+++ b/config/locales/views/submissions/nl.yml
@@ -14,6 +14,8 @@ nl:
       result: Resultaat
       summary: Samenvatting
       annotated: Deze oplossing heeft opmerkingen.
+      select: Selecteer
+      selected: Geselecteerd
     index:
       title: Alle oplossingen
       for: voor


### PR DESCRIPTION
This pull request changes the buttons that are used to select the submission and adds an indication to the currently selected submission.

<img width="1310" alt="image" src="https://user-images.githubusercontent.com/68779933/187433426-a7b9c3ee-e144-4330-8b3a-322e9e496b54.png">
<img width="1312" alt="image" src="https://user-images.githubusercontent.com/68779933/187433535-06a933c7-a7ce-4ec0-ad95-a0f7fe44afa5.png">


Closes #3795  .
