### PR TITLE
Fix shift in rows in evaluation overview table

### DIFF
--- a/app/assets/stylesheets/components/table.css.scss
+++ b/app/assets/stylesheets/components/table.css.scss
@@ -45,7 +45,7 @@
     }
 
     td:not(.sticky-column) {
-      height: 42px;
+      height: 45px;
     }
 
     thead .user-name {


### PR DESCRIPTION
This pull request fixes the alignment of the rows in the evaluation detail overview

<img width="1363" alt="image" src="https://user-images.githubusercontent.com/68779933/186661559-66fdf3a2-24b8-4899-af34-8f66cc0e7d13.png">


other tables to double-check nothing else breaks:
<img width="1354" alt="image" src="https://user-images.githubusercontent.com/68779933/186665251-4a54af34-6c98-4d0d-8db3-35d35b9e54ba.png">
<img width="1312" alt="image" src="https://user-images.githubusercontent.com/68779933/186665310-6545c496-a17b-492a-9908-02b221771b0e.png">

Closes #3794  .
