### PR TITLE
No more teal in token colors

### DIFF
--- a/app/views/layouts/_searchbar.html.erb
+++ b/app/views/layouts/_searchbar.html.erb
@@ -41,7 +41,7 @@
             multi: false,
             data: <%= raw render template: 'programming_languages/index', formats: :json %>,
             color: function () {
-                return "teal";
+                return "red";
             },
         };
         <% end %>


### PR DESCRIPTION
This pull request swaps out teal for red in the search tokens. To me, teal doesn't match with the other colors we used here, red blends in better. 

Other opinions are of course welcome!

![image](https://user-images.githubusercontent.com/481872/186669011-e08ef416-7e73-4a50-9d74-e823cc6e14fe.png)

![image](https://user-images.githubusercontent.com/481872/186669077-f358a7c0-f6a6-4dad-b558-54a02c78d0b0.png)
