### PR TITLE
Migrate smartschool identifiers from username to userID

### DIFF
--- a/app/controllers/auth/omniauth_callbacks_controller.rb
+++ b/app/controllers/auth/omniauth_callbacks_controller.rb
@@ -208,21 +208,34 @@ class Auth::OmniauthCallbacksController < Devise::OmniauthCallbacksController
 
     identity = Identity.find_by(identifier: auth_uid, provider: provider)
 
-    return identity unless identity.nil? && provider.class.sym == :office365 && auth_email.present?
+    return identity unless identity.nil?
 
-    # This code supports a migration of the office365 oauth api from v1 to v2
-    # Try to find the user by the legacy identifier
-    identity = Identity.find_by(identifier: auth_email.split('@').first, provider: provider, identifier_based_on_email: true)
+    if provider.class.sym == :office365 && auth_email.present?
+      # This code supports a migration of the office365 oauth api from v1 to v2
+      # Try to find the user by the legacy identifier
+      identity = Identity.find_by(identifier: auth_email.split('@').first, provider: provider, identifier_based_on_email: true)
 
-    # Try to find user by preferred username
-    identity = Identity.find_by(identifier: auth_hash.extra.raw_info.preferred_username.split('@').first, provider: provider, identifier_based_on_email: true) if identity.nil? && auth_hash&.extra&.raw_info&.preferred_username.present?
+      # Try to find user by preferred username
+      identity = Identity.find_by(identifier: auth_hash.extra.raw_info.preferred_username.split('@').first, provider: provider, identifier_based_on_email: true) if identity.nil? && auth_hash&.extra&.raw_info&.preferred_username.present?
 
-    # Try to find user by name
-    identity = Identity.joins(:user).find_by(user: { first_name: auth_hash.info.first_name, last_name: auth_hash.info.last_name }, provider: provider, identifier_based_on_email: true) if identity.nil?
-    return nil if identity.nil?
+      # Try to find user by name
+      identity = Identity.joins(:user).find_by(user: { first_name: auth_hash.info.first_name, last_name: auth_hash.info.last_name }, provider: provider, identifier_based_on_email: true) if identity.nil?
+      return nil if identity.nil?
 
-    # Update the identifier to the new uid
-    identity.update(identifier: auth_uid, identifier_based_on_email: false)
+      # Update the identifier to the new uid
+      identity.update(identifier: auth_uid, identifier_based_on_email: false)
+    elsif provider.class.sym == :smartschool && auth_username.present?
+      # This code supports a migration of smartschool usernames to userID as identifier
+      # Try to find user by username
+      identity = Identity.find_by(identifier: auth_username, provider: provider, identifier_based_on_username: true)
+
+      # Try to find user by name
+      identity = Identity.joins(:user).find_by(user: { first_name: auth_hash.info.first_name, last_name: auth_hash.info.last_name }, provider: provider, identifier_based_on_username: true) if identity.nil?
+      return nil if identity.nil?
+
+      # Update the identifier to the new uid
+      identity.update(identifier: auth_uid, identifier_based_on_username: false)
+    end
     identity
   end
 
@@ -374,6 +387,10 @@ class Auth::OmniauthCallbacksController < Devise::OmniauthCallbacksController
 
   def auth_email
     auth_hash.info.email
+  end
+
+  def auth_username
+    auth_hash.info.username
   end
 
   def auth_provider_type

--- a/app/controllers/auth/omniauth_callbacks_controller.rb
+++ b/app/controllers/auth/omniauth_callbacks_controller.rb
@@ -229,6 +229,9 @@ class Auth::OmniauthCallbacksController < Devise::OmniauthCallbacksController
       # Try to find user by username
       identity = Identity.find_by(identifier: auth_username, provider: provider, identifier_based_on_username: true)
 
+      # Try to find user by email
+      identity = Identity.joins(:user).find_by(user: { email: auth_email }, provider: provider, identifier_based_on_username: true) if identity.nil?
+
       # Try to find user by name
       identity = Identity.joins(:user).find_by(user: { first_name: auth_hash.info.first_name, last_name: auth_hash.info.last_name }, provider: provider, identifier_based_on_username: true) if identity.nil?
       return nil if identity.nil?

--- a/app/models/identity.rb
+++ b/app/models/identity.rb
@@ -2,13 +2,14 @@
 #
 # Table name: identities
 #
-#  id                        :bigint           not null, primary key
-#  identifier                :string(255)      not null
-#  provider_id               :bigint           not null
-#  user_id                   :integer          not null
-#  created_at                :datetime         not null
-#  updated_at                :datetime         not null
-#  identifier_based_on_email :boolean          default(FALSE), not null
+#  id                           :bigint           not null, primary key
+#  identifier                   :string(255)      not null
+#  provider_id                  :bigint           not null
+#  user_id                      :integer          not null
+#  created_at                   :datetime         not null
+#  updated_at                   :datetime         not null
+#  identifier_based_on_email    :boolean          default(FALSE), not null
+#  identifier_based_on_username :boolean          default(FALSE), not null
 #
 class Identity < ApplicationRecord
   belongs_to :provider, inverse_of: :identities

--- a/config/initializers/smartschool.rb
+++ b/config/initializers/smartschool.rb
@@ -16,7 +16,7 @@ module OmniAuth
              token_url: '/OAuth/index/token'
 
       # These are called after authentication has succeeded.
-      uid {raw_info['username']}
+      uid {raw_info['userID']}
 
       info do
         {

--- a/db/migrate/20220830124315_add_identifier_based_on_username_to_identity.rb
+++ b/db/migrate/20220830124315_add_identifier_based_on_username_to_identity.rb
@@ -1,0 +1,6 @@
+class AddIdentifierBasedOnUsernameToIdentity < ActiveRecord::Migration[7.0]
+  def change
+    add_column :identities, :identifier_based_on_username, :boolean, null: false, default: false
+    Identity.joins(:provider).where(provider: {type: "Provider::Office365"}).update_all(identifier_based_on_username: true)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_08_18_074900) do
+ActiveRecord::Schema[7.0].define(version: 2022_08_30_124315) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -297,6 +297,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_18_074900) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "identifier_based_on_email", default: false, null: false
+    t.boolean "identifier_based_on_username", default: false, null: false
     t.index ["provider_id", "identifier"], name: "index_identities_on_provider_id_and_identifier", unique: true
     t.index ["provider_id", "user_id"], name: "index_identities_on_provider_id_and_user_id", unique: true
     t.index ["user_id"], name: "fk_rails_5373344100"

--- a/test/controllers/auth/omniauth_callbacks_controller_test.rb
+++ b/test/controllers/auth/omniauth_callbacks_controller_test.rb
@@ -528,6 +528,88 @@ class OmniauthCallbacksControllerTest < ActionDispatch::IntegrationTest
     sign_out user
   end
 
+  test 'Smartschool identifier should be updated upon login if the identifier still used the old format' do
+    # Setup.
+    provider = create :smartschool_provider
+    user = create :user, institution: provider.institution
+    identity = create :identity, provider: provider, user: user, identifier: 'OLD-UID', identifier_based_on_username: true
+    omniauth_mock_identity identity,
+                           info: {
+                             username: 'OLD-UID'
+                           },
+                           uid: 'NEW-UID'
+
+    get omniauth_url(provider)
+    follow_redirect!
+
+    assert_equal @controller.current_user, user
+    identity.reload
+    assert_equal identity.identifier, 'NEW-UID'
+
+    # Cleanup.
+    sign_out user
+
+    # sign in should still work with changed identifier
+    omniauth_mock_identity identity,
+                           info: {
+                             username: 'OLD-UID'
+                           },
+                           uid: 'NEW-UID'
+
+    get omniauth_url(provider)
+    follow_redirect!
+
+    # Assert successful authentication.
+    assert_redirected_to root_path
+    assert_equal @controller.current_user, user
+
+    # Cleanup.
+    sign_out user
+
+    # Should not be able to change it again
+    omniauth_mock_identity identity,
+                           info: {
+                             username: 'NEW-UID'
+                           },
+                           uid: 'NEWER-UID'
+
+    get omniauth_url(provider)
+    follow_redirect!
+
+    # Assert successful authentication.
+    assert_redirected_to root_path
+    assert_not_equal @controller.current_user, user
+    identity.reload
+    assert_equal identity.identifier, 'NEW-UID'
+
+    # Cleanup.
+    sign_out user
+  end
+
+  test 'Smartschool legacy sign in works with name' do
+    # Setup.
+    provider = create :smartschool_provider
+    user = create :user, institution: provider.institution, first_name: 'Foo', last_name: 'Bar'
+    identity = create :identity, provider: provider, user: user, identifier: 'OLD-UID', identifier_based_on_username: true
+    omniauth_mock_identity identity,
+                           info: {
+                             first_name: 'Foo',
+                             last_name: 'Bar',
+                             username: 'NEW-USERNAME'
+                           },
+                           uid: 'NEW-UID'
+
+    get omniauth_url(provider)
+    follow_redirect!
+
+    assert_equal @controller.current_user, user
+    identity.reload
+    assert_equal identity.identifier, 'NEW-UID'
+
+    # Cleanup.
+    sign_out user
+  end
+
   test 'lti redirects to main provider' do
     main_provider = create :provider
     provider = create :lti_provider, institution: main_provider.institution, mode: :link

--- a/test/controllers/auth/omniauth_callbacks_controller_test.rb
+++ b/test/controllers/auth/omniauth_callbacks_controller_test.rb
@@ -586,6 +586,29 @@ class OmniauthCallbacksControllerTest < ActionDispatch::IntegrationTest
     sign_out user
   end
 
+  test 'Smartschool legacy sign in works with email' do
+    # Setup.
+    provider = create :smartschool_provider
+    user = create :user, institution: provider.institution, email: 'foo.bar@test.com'
+    identity = create :identity, provider: provider, user: user, identifier: 'OLD-UID', identifier_based_on_username: true
+    omniauth_mock_identity identity,
+                           info: {
+                             email: 'foo.bar@test.com',
+                             username: 'NEW-USERNAME'
+                           },
+                           uid: 'NEW-UID'
+
+    get omniauth_url(provider)
+    follow_redirect!
+
+    assert_equal @controller.current_user, user
+    identity.reload
+    assert_equal identity.identifier, 'NEW-UID'
+
+    # Cleanup.
+    sign_out user
+  end
+
   test 'Smartschool legacy sign in works with name' do
     # Setup.
     provider = create :smartschool_provider

--- a/test/factories/identities.rb
+++ b/test/factories/identities.rb
@@ -2,13 +2,14 @@
 #
 # Table name: identities
 #
-#  id                        :bigint           not null, primary key
-#  identifier                :string(255)      not null
-#  provider_id               :bigint           not null
-#  user_id                   :integer          not null
-#  created_at                :datetime         not null
-#  updated_at                :datetime         not null
-#  identifier_based_on_email :boolean          default(FALSE), not null
+#  id                           :bigint           not null, primary key
+#  identifier                   :string(255)      not null
+#  provider_id                  :bigint           not null
+#  user_id                      :integer          not null
+#  created_at                   :datetime         not null
+#  updated_at                   :datetime         not null
+#  identifier_based_on_email    :boolean          default(FALSE), not null
+#  identifier_based_on_username :boolean          default(FALSE), not null
 #
 FactoryBot.define do
   factory :identity do

--- a/test/models/identity_test.rb
+++ b/test/models/identity_test.rb
@@ -2,13 +2,14 @@
 #
 # Table name: identities
 #
-#  id                        :bigint           not null, primary key
-#  identifier                :string(255)      not null
-#  provider_id               :bigint           not null
-#  user_id                   :integer          not null
-#  created_at                :datetime         not null
-#  updated_at                :datetime         not null
-#  identifier_based_on_email :boolean          default(FALSE), not null
+#  id                           :bigint           not null, primary key
+#  identifier                   :string(255)      not null
+#  provider_id                  :bigint           not null
+#  user_id                      :integer          not null
+#  created_at                   :datetime         not null
+#  updated_at                   :datetime         not null
+#  identifier_based_on_email    :boolean          default(FALSE), not null
+#  identifier_based_on_username :boolean          default(FALSE), not null
 #
 require 'test_helper'
 


### PR DESCRIPTION
This pull request migrates the identifiers for smartschool from their username to the userid. This should solve issues created by username changes.

- [x] Tests were added


