### PR TITLE
Use more readable username as display username when provided

### DIFF
--- a/app/controllers/auth/omniauth_callbacks_controller.rb
+++ b/app/controllers/auth/omniauth_callbacks_controller.rb
@@ -142,6 +142,7 @@ class Auth::OmniauthCallbacksController < Devise::OmniauthCallbacksController
 
   def redirect_to_privacy_prompt
     session[:new_user_identifier] = auth_hash.uid
+    session[:new_user_username] = auth_hash.info.username || auth_hash.uid
     session[:new_user_email] = auth_hash.info.email
     session[:new_user_first_name] = auth_hash.info.first_name
     session[:new_user_last_name] = auth_hash.info.last_name
@@ -153,6 +154,7 @@ class Auth::OmniauthCallbacksController < Devise::OmniauthCallbacksController
 
   def sign_in_new_user_from_session!
     identifier = session.delete(:new_user_identifier)
+    username = session.delete(:new_user_username)
     email = session.delete(:new_user_email)
     first_name = session.delete(:new_user_first_name)
     last_name = session.delete(:new_user_last_name)
@@ -162,7 +164,7 @@ class Auth::OmniauthCallbacksController < Devise::OmniauthCallbacksController
 
     # Create a new user
     user = User.new institution: provider&.institution, email: email, first_name: first_name, last_name: last_name,
-                    username: identifier
+                    username: username
 
     # Create a new identity for the newly created user
     user.identities.build identifier: identifier, provider: provider

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -349,7 +349,7 @@ class User < ApplicationRecord
   # Update the user using the data provided in the omniauth hash.
   def update_from_provider(auth_hash, auth_provider)
     tap do |user|
-      user.username = auth_hash.uid
+      user.username = auth_hash.info.username || auth_hash.uid
       user.email = auth_hash.info.email
       user.first_name = auth_hash.info.first_name
       user.last_name = auth_hash.info.last_name


### PR DESCRIPTION
This pull request uses the provided username strings for the user username field.

As usernames tend to change over time and are not always guaranteed to be unique for multiple providers, we are moving to real unique identifiers to identify users. See  #3947 or #3806.

But as these are often not very readable or recognizable for users, it would still be useful to display the original usernames at specific places in our application. So for providers that actually return a username field, we should use that for display purposes.

