### PR TITLE
Update identitities for correct provider in migration

### DIFF
--- a/db/migrate/20220830124315_add_identifier_based_on_username_to_identity.rb
+++ b/db/migrate/20220830124315_add_identifier_based_on_username_to_identity.rb
@@ -1,6 +1,6 @@
 class AddIdentifierBasedOnUsernameToIdentity < ActiveRecord::Migration[7.0]
   def change
     add_column :identities, :identifier_based_on_username, :boolean, null: false, default: false
-    Identity.joins(:provider).where(provider: {type: "Provider::Office365"}).update_all(identifier_based_on_username: true)
+    Identity.joins(:provider).where(provider: {type: "Provider::Smartschool"}).update_all(identifier_based_on_username: true)
   end
 end


### PR DESCRIPTION
This pull request fixes a typo in a migration. This edit has already been rolled out manually on production. I fixed it here for future consistency.
