### PR TITLE
Fix course user tabs

### DIFF
--- a/app/assets/javascripts/course.ts
+++ b/app/assets/javascripts/course.ts
@@ -54,8 +54,9 @@ function initCourseMembers(): void {
         // Switch to clicked tab
         document.querySelectorAll("#user-tabs li a")
             .forEach(el => {
-                el.addEventListener("click", function () {
+                el.addEventListener("click", function (e) {
                     selectTab(el);
+                    e.preventDefault();
                 });
             });
 


### PR DESCRIPTION
This pull request fixes course user tabs.
These were broken because the default event of a `<a href="#"></a>` triggers a popstate event in some browsers (eg firefox). Which in turn is handled as if the back button is pressed.

Similar issues have been appearing since #3857 
I'll have a another look if a better solution for the back button issue exists.