### PR TITLE
Use state variable to detect whether popstate should trigger

### DIFF
--- a/app/assets/javascripts/search.ts
+++ b/app/assets/javascripts/search.ts
@@ -114,11 +114,13 @@ export class SearchQuery {
         this.queryParams.subscribe(k => this.paramChange(k));
         this.queryParams.subscribeByKey("refresh", (k, o, n) => this.refresh(n));
 
-        window.onpopstate = () => {
-            if (this.updateAddressBar) {
+        window.onpopstate = e => {
+            if (this.updateAddressBar && e.state === "set_by_search") {
                 this.setBaseUrl();
             }
         };
+
+        window.history.replaceState("set_by_search", "Dodona");
 
         this.setRefreshElement(refreshElement);
     }
@@ -155,9 +157,9 @@ export class SearchQuery {
             return;
         }
         if (push) {
-            window.history.pushState(true, "Dodona", url);
+            window.history.pushState("set_by_search", "Dodona", url);
         } else {
-            window.history.replaceState(true, "Dodona", url);
+            window.history.replaceState("set_by_search", "Dodona", url);
         }
     }
 


### PR DESCRIPTION
This pull request replaces the fix in #3857 

By removing the check on state in #3857 multiple bugs were caused. Eg:
- #3878
- #3879 
- #3971 

All had the same issue that a event popstate was triggered for a state not set by pushstate or replacestate.

I edited the onpopstate event handler in search.ts to more clearly specify that it should only handle popstate events on states set by search.ts

I fixed the original backbuton issue by also calling a replace state when first loading a page with a searchbar. 