### PR TITLE
Revert bootstrap to 5.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@types/jquery": "^3.5.14",
     "babel-loader": "^8.2.5",
     "babel-plugin-macros": "^3.1.0",
-    "bootstrap": "^5.2.1",
+    "bootstrap": "5.2.0",
     "clipboard": "^2.0.11",
     "core-js": "^3.25.1",
     "d3": "^7.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2505,10 +2505,10 @@ binary-extensions@^2.0.0:
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.2.0.tgz#75f502eeaf9ffde42fc98829645be4ea76bd9e2d"
   integrity sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==
 
-bootstrap@^5.2.1:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-5.2.1.tgz#45f97ff05cbe828bad807b014d8425f3aeb8ec3a"
-  integrity sha512-UQi3v2NpVPEi1n35dmRRzBJFlgvWHYwyem6yHhuT6afYF+sziEt46McRbT//kVXZ7b1YUYEVGdXEH74Nx3xzGA==
+bootstrap@5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-5.2.0.tgz#838727fb60f1630db370fe57c63cbcf2962bb3d3"
+  integrity sha512-qlnS9GL6YZE6Wnef46GxGv1UpGGzAwO0aPL1yOjzDIJpeApeMvqV24iL+pjr2kU4dduoBA9fINKWKgMToobx9A==
 
 brace-expansion@^1.1.7:
   version "1.1.11"


### PR DESCRIPTION
This pull request reverts bootstrap to avoid https://github.com/twbs/bootstrap/issues/37130
