### PR TITLE
Allow the same email accross different institutions after user confirmation

### DIFF
--- a/app/controllers/auth/omniauth_callbacks_controller.rb
+++ b/app/controllers/auth/omniauth_callbacks_controller.rb
@@ -305,8 +305,6 @@ class Auth::OmniauthCallbacksController < Devise::OmniauthCallbacksController
     # Filter raw info and credentials from hash to limit cookie size
     hash = auth_hash.to_h
     hash = hash.except('extra', 'credentials').merge({ 'extra' => hash['extra']&.except('raw_info') })
-    logger.info "===================================================================================================="
-    logger.info hash.to_json
     session[:new_user_auth_hash] = hash.to_json
   end
 

--- a/app/controllers/auth/omniauth_callbacks_controller.rb
+++ b/app/controllers/auth/omniauth_callbacks_controller.rb
@@ -302,8 +302,8 @@ class Auth::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   end
 
   def store_hash_in_session!
-    # Filter raw info from hash to limit cookie size
-    hash = auth_hash.except('extra').merge({ 'extra' => auth_hash.extra.except('raw_info') })
+    # Filter raw info and credentials from hash to limit cookie size
+    hash = auth_hash.except('extra', 'credentials').merge({ 'extra' => auth_hash.extra.except('raw_info') })
     logger.info "===================================================================================================="
     logger.info hash.to_json
     session[:new_user_auth_hash] = hash.to_json

--- a/app/controllers/auth/omniauth_callbacks_controller.rb
+++ b/app/controllers/auth/omniauth_callbacks_controller.rb
@@ -407,9 +407,7 @@ class Auth::OmniauthCallbacksController < Devise::OmniauthCallbacksController
 
     # if auth hash was present in session, we can use that
     # we do want to remove it from the session so it does not stay there indefinitely
-    # rubocop:disable Style/OpenStructUse
     @new_user_auth_hash = JSON.parse(session.delete(:new_user_auth_hash), object_class: OmniAuth::AuthHash) if session[:new_user_auth_hash].present?
-    # rubocop:enable Style/OpenStructUse
 
     @new_user_auth_hash
   end

--- a/app/controllers/auth/omniauth_callbacks_controller.rb
+++ b/app/controllers/auth/omniauth_callbacks_controller.rb
@@ -303,7 +303,8 @@ class Auth::OmniauthCallbacksController < Devise::OmniauthCallbacksController
 
   def store_hash_in_session!
     # Filter raw info and credentials from hash to limit cookie size
-    hash = auth_hash.to_h.except('extra', 'credentials').merge({ 'extra' => auth_hash.extra.except('raw_info') })
+    hash = auth_hash.to_h
+    hash = hash.except('extra', 'credentials').merge({ 'extra' => hash.extra.except('raw_info') })
     logger.info "===================================================================================================="
     logger.info hash.to_json
     session[:new_user_auth_hash] = hash.to_json

--- a/app/controllers/auth/omniauth_callbacks_controller.rb
+++ b/app/controllers/auth/omniauth_callbacks_controller.rb
@@ -72,7 +72,6 @@ class Auth::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   end
 
   def accept_confirm_new_user
-    a = auth_hash
     # Redirect to privacy prompt before we create a new private user
     return redirect_to_privacy_prompt if provider&.institution.nil?
 

--- a/app/controllers/auth/omniauth_callbacks_controller.rb
+++ b/app/controllers/auth/omniauth_callbacks_controller.rb
@@ -304,6 +304,8 @@ class Auth::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   def store_hash_in_session!
     # Filter raw info from hash to limit cookie size
     hash = auth_hash.except('extra').merge({ 'extra' => auth_hash.extra.except('raw_info') })
+    logger.info "===================================================================================================="
+    logger.info hash.to_json
     session[:new_user_auth_hash] = hash.to_json
   end
 

--- a/app/controllers/auth/omniauth_callbacks_controller.rb
+++ b/app/controllers/auth/omniauth_callbacks_controller.rb
@@ -450,7 +450,7 @@ class Auth::OmniauthCallbacksController < Devise::OmniauthCallbacksController
 
   def provider
     # Extract the provider from the authentication hash.
-    return Provider.find(auth_hash.extra.provider.id) if [Provider::Lti.sym, Provider::Saml.sym].include?(auth_provider_type)
+    return Provider.find(auth_hash.extra.provider_id) if [Provider::Lti.sym, Provider::Saml.sym].include?(auth_provider_type)
 
     # Fallback to an oauth provider
     oauth_provider

--- a/app/controllers/auth/omniauth_callbacks_controller.rb
+++ b/app/controllers/auth/omniauth_callbacks_controller.rb
@@ -303,8 +303,7 @@ class Auth::OmniauthCallbacksController < Devise::OmniauthCallbacksController
 
   def store_hash_in_session!
     # Filter raw info and credentials from hash to limit cookie size
-    hash = auth_hash.to_h
-    hash = hash.except('extra', 'credentials').merge({ 'extra' => hash['extra']&.except('raw_info') })
+    hash = auth_hash.except('extra', 'credentials').merge({ 'extra' => auth_hash.extra&.except('raw_info') })
     session[:new_user_auth_hash] = hash.to_json
   end
 
@@ -409,7 +408,7 @@ class Auth::OmniauthCallbacksController < Devise::OmniauthCallbacksController
     # if auth hash was present in session, we can use that
     # we do want to remove it from the session so it does not stay there indefinitely
     # rubocop:disable Style/OpenStructUse
-    @new_user_auth_hash = JSON.parse(session.delete(:new_user_auth_hash), object_class: OpenStruct) if session[:new_user_auth_hash].present?
+    @new_user_auth_hash = JSON.parse(session.delete(:new_user_auth_hash), object_class: OmniAuth::AuthHash) if session[:new_user_auth_hash].present?
     # rubocop:enable Style/OpenStructUse
 
     @new_user_auth_hash

--- a/app/controllers/auth/omniauth_callbacks_controller.rb
+++ b/app/controllers/auth/omniauth_callbacks_controller.rb
@@ -303,7 +303,7 @@ class Auth::OmniauthCallbacksController < Devise::OmniauthCallbacksController
 
   def store_hash_in_session!
     # Filter raw info and credentials from hash to limit cookie size
-    hash = auth_hash.except('extra', 'credentials').merge({ 'extra' => auth_hash.extra.except('raw_info') })
+    hash = auth_hash.to_h.except('extra', 'credentials').merge({ 'extra' => auth_hash.extra.except('raw_info') })
     logger.info "===================================================================================================="
     logger.info hash.to_json
     session[:new_user_auth_hash] = hash.to_json

--- a/app/controllers/auth/omniauth_callbacks_controller.rb
+++ b/app/controllers/auth/omniauth_callbacks_controller.rb
@@ -304,7 +304,7 @@ class Auth::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   def store_hash_in_session!
     # Filter raw info and credentials from hash to limit cookie size
     hash = auth_hash.to_h
-    hash = hash.except('extra', 'credentials').merge({ 'extra' => hash.extra.except('raw_info') })
+    hash = hash.except('extra', 'credentials').merge({ 'extra' => hash['extra'].except('raw_info') })
     logger.info "===================================================================================================="
     logger.info hash.to_json
     session[:new_user_auth_hash] = hash.to_json

--- a/app/controllers/auth/omniauth_callbacks_controller.rb
+++ b/app/controllers/auth/omniauth_callbacks_controller.rb
@@ -304,7 +304,7 @@ class Auth::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   def store_hash_in_session!
     # Filter raw info and credentials from hash to limit cookie size
     hash = auth_hash.to_h
-    hash = hash.except('extra', 'credentials').merge({ 'extra' => hash['extra'].except('raw_info') })
+    hash = hash.except('extra', 'credentials').merge({ 'extra' => hash['extra']&.except('raw_info') })
     logger.info "===================================================================================================="
     logger.info hash.to_json
     session[:new_user_auth_hash] = hash.to_json

--- a/app/controllers/auth/omniauth_callbacks_controller.rb
+++ b/app/controllers/auth/omniauth_callbacks_controller.rb
@@ -72,6 +72,7 @@ class Auth::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   end
 
   def accept_confirm_new_user
+    a = auth_hash
     # Redirect to privacy prompt before we create a new private user
     return redirect_to_privacy_prompt if provider&.institution.nil?
 
@@ -366,7 +367,7 @@ class Auth::OmniauthCallbacksController < Devise::OmniauthCallbacksController
 
   def redirect_to_confirm_new_user!
     store_hash_in_session!
-    redirect_to confirm_new_user
+    redirect_to confirm_new_user_path
   end
 
   def redirect_duplicate_email_for_provider!
@@ -450,7 +451,7 @@ class Auth::OmniauthCallbacksController < Devise::OmniauthCallbacksController
 
   def provider
     # Extract the provider from the authentication hash.
-    return auth_hash.extra.provider if [Provider::Lti.sym, Provider::Saml.sym].include?(auth_provider_type)
+    return Provider.find(auth_hash.extra.provider.id) if [Provider::Lti.sym, Provider::Saml.sym].include?(auth_provider_type)
 
     # Fallback to an oauth provider
     oauth_provider

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -111,7 +111,7 @@ class User < ApplicationRecord
   devise :omniauthable, omniauth_providers: %i[google_oauth2 lti office365 oidc saml smartschool surf]
 
   validates :username, uniqueness: { case_sensitive: false, allow_blank: true, scope: :institution }
-  validates :email, uniqueness: { case_sensitive: false, allow_blank: true }
+  validates :email, uniqueness: { case_sensitive: false, allow_blank: true, scope: :institution }
   validate :max_one_institution
   validate :provider_allows_blank_email
 

--- a/app/views/auth/confirm_new_user.html.erb
+++ b/app/views/auth/confirm_new_user.html.erb
@@ -12,13 +12,13 @@
       <% else %>
         <%= markdown t(".message_personal_p2") %>
       <% end %>
-      <%= link_to t(".create_new_account"), confirm_new_account_path, method: :post, class: "btn btn-primary" %>
+      <%= link_to t(".create_new_account"), confirm_new_user_path, method: :post, class: "btn btn-primary" %>
     </div>
     <% @users.each do |user| %>
       <div class="row">
         <h2>
           <% if user.institutional? %>
-            <%= markdown t(".sign_in_to_institutional", institution: @user.institution.name, name: user.full_name) %>
+            <%= markdown t(".sign_in_to_institutional", institution: user.institution.name, name: user.full_name) %>
           <% else %>
             <%= markdown t(".sign_in_to_personal", name: user.full_name) %>
           <% end %>

--- a/app/views/auth/confirm_new_user.html.erb
+++ b/app/views/auth/confirm_new_user.html.erb
@@ -1,0 +1,35 @@
+<div class="row">
+  <div class="col-md-10">
+    <div class="row">
+      <h1><%= t ".title" %></h1>
+      <% if @users.length > 1 %>
+        <%= markdown t(".message_plural_p1", email: @email) %>
+      <% else %>
+        <%= markdown t(".message_single_p1", email: @email) %>
+      <% end %>
+      <% if @institution.present? %>
+        <%= markdown t(".message_institutional_p2", institution: @institution.name) %>
+      <% else %>
+        <%= markdown t(".message_personal_p2") %>
+      <% end %>
+      <%= link_to t(".create_new_account"), confirm_new_account_path, method: :post, class: "btn btn-primary" %>
+    </div>
+    <% @users.each do |user| %>
+      <div class="row">
+        <h2>
+          <% if user.institutional? %>
+            <%= markdown t(".sign_in_to_institutional", institution: @user.institution.name, name: user.full_name) %>
+          <% else %>
+            <%= markdown t(".sign_in_to_personal", name: user.full_name) %>
+          <% end %>
+        </h2>
+        <% user.providers.where(mode: %i[prefer secondary]).each do |provider| %>
+          <%= render partial: 'auth/provider_button', locals: { provider: provider } %>
+        <% end %>
+      </div>
+    <% end %>
+    <div class="row">
+      <p><%= t ".contact_support_html", form: link_to(t(".contact_form"), contact_path)%></p>
+    </div>
+  </div>
+</div>

--- a/app/views/auth/confirm_new_user.html.erb
+++ b/app/views/auth/confirm_new_user.html.erb
@@ -12,23 +12,25 @@
       <% else %>
         <%= markdown t(".message_personal_p2") %>
       <% end %>
-      <%= link_to t(".create_new_account"), confirm_new_user_path, method: :post, class: "btn btn-primary" %>
+      <div>
+        <%= link_to t(".create_new_account"), confirm_new_user_path, method: :post, class: "btn btn-primary" %>
+      </div>
     </div>
     <% @users.each do |user| %>
-      <div class="row">
-        <h2>
+      <div class="row pt-4">
+        <h3>
           <% if user.institutional? %>
             <%= markdown t(".sign_in_to_institutional", institution: user.institution.name, name: user.full_name) %>
           <% else %>
             <%= markdown t(".sign_in_to_personal", name: user.full_name) %>
           <% end %>
-        </h2>
+        </h3>
         <% user.providers.where(mode: %i[prefer secondary]).each do |provider| %>
           <%= render partial: 'auth/provider_button', locals: { provider: provider } %>
         <% end %>
       </div>
     <% end %>
-    <div class="row">
+    <div class="row pt-4">
       <p><%= t ".contact_support_html", form: link_to(t(".contact_form"), contact_path)%></p>
     </div>
   </div>

--- a/config/initializers/office365.rb
+++ b/config/initializers/office365.rb
@@ -44,7 +44,8 @@ module OmniAuth
 
       extra do
         {
-            'raw_info' => raw_info
+            'raw_info' => raw_info,
+            'preferred_username' => raw_info['preferred_username']
         }
       end
 

--- a/config/locales/views/auth/en.yml
+++ b/config/locales/views/auth/en.yml
@@ -29,3 +29,15 @@ en:
       text_html: "In order to use Dodona, you need to accept our privacy statement. On the <a href=\"%{your_data}\" target=\"_blank\">your data</a> page we explain in clear and understandable language what data we collect and how we use it. Our <a href=\"%{privacy_statement}\" target=\"_blank\">privacy statement</a> contains the legally binding version."
       accept_button: Accept the privacy statement
       decline_button: Decline
+    confirm_new_user:
+      title: Email already in use
+      message_single_p1: "A user with the same email address (**%{email}**) already exist within a different institution. This is probably you. If you are trying to sign in to this account, click on one of the sign in methods below and sign in again."
+      message_plural_p1: "Multiple users with the same email address (**%{email}**) already exist within different institutions. These are probably you. If you are trying to sign in to one of these account, click on the relevant sign in method below and sign in again."
+      message_personal_p2: "If you want to create a new personal account, click on \"Create new account\"."
+      message_institutional_p2: "If you want to create a new account for the institution **%{institution}**, click on \"Create new account\"."
+      sign_in_to_institutional: "Sign in to **%{name}** (%{institution})"
+      sign_in_to_personal: "Sign in to **%{name}** (personal account)"
+      create_new_account: "Create new account"
+      "contact_support_html": "If this isn't you or you keep having issues? Fill in the %{form} and we will assist you as soon as possible."
+      contact_form: "contact form"
+

--- a/config/locales/views/auth/en.yml
+++ b/config/locales/views/auth/en.yml
@@ -31,13 +31,13 @@ en:
       decline_button: Decline
     confirm_new_user:
       title: Email already in use
-      message_single_p1: "A user with the same email address (**%{email}**) already exist within a different institution. This is probably you. If you are trying to sign in to this account, click on one of the sign in methods below and sign in again."
-      message_plural_p1: "Multiple users with the same email address (**%{email}**) already exist within different institutions. These are probably you. If you are trying to sign in to one of these account, click on the relevant sign in method below and sign in again."
+      message_single_p1: "A Dodona user with the same email address (**%{email}**) already exist within a different institution. This is probably you. If you want to sign in with the existing account, click on the sign in button below and sign in again."
+      message_plural_p1: "Multiple Dodona users with the same email address (**%{email}**) already exist within different institutions. These are probably you. If you want to sign in with one of these existing accounts, click on the relevant sign in button below and sign in again."
       message_personal_p2: "If you want to create a new personal account, click on \"Create new account\"."
       message_institutional_p2: "If you want to create a new account for the institution **%{institution}**, click on \"Create new account\"."
       sign_in_to_institutional: "Sign in to **%{name}** (%{institution})"
       sign_in_to_personal: "Sign in to **%{name}** (personal account)"
       create_new_account: "Create new account"
-      "contact_support_html": "If this isn't you or you keep having issues? Fill in the %{form} and we will assist you as soon as possible."
+      "contact_support_html": "If this isn't you or if you keep having issues, fill in the %{form} and we will assist you as soon as possible."
       contact_form: "contact form"
 

--- a/config/locales/views/auth/nl.yml
+++ b/config/locales/views/auth/nl.yml
@@ -31,12 +31,12 @@ nl:
       decline_button: Weigeren
     confirm_new_user:
       title: Email al in gebruik
-      message_single_p1: "Er bestaat al een gebruiker met hetzelfde email adres (**%{email}**) in een andere onderwijsinstelling. Waarschijnlijk ben jij dit. Gebruik een van onderstaande login methodes om aan te melden met deze bestaande account."
-      message_plural_p1: "Er bestaan al meerdere gebruikers met hetzelfde email adres (**%{email}**) in andere onderwijsinstellingen. Waarschijnlijk ben jij dit. Gebruik een van onderstaande login methodes om aan te melden met een bestaande account."
-      message_personal_p2: "Als je een nieuwe persoonlijke account wilt aanmaken, klik op \"Maak een nieuwe account\"."
-      message_institutional_p2: "Als je een nieuwe account wilt aanmaken voor de onderwijsinstelling **%{institution}**, klik op \"Maak een nieuwe account\"."
+      message_single_p1: "Er bestaat al een Dodonagebruiker met hetzelfde emailadres (**%{email}**) in een andere onderwijsinstelling. Waarschijnlijk ben jij dit. Wil je aanmelden met deze bestaande account, klik dan onderaan op de aanmeldknop."
+      message_plural_p1: "Er bestaan al meerdere Dodonagebruikers met hetzelfde emailadres (**%{email}**) in andere onderwijsinstellingen. Waarschijnlijk ben jij dit. Wil je aanmelden met een van deze bestaande accounts, klik dan onderaan op de correcte aanmeldknop."
+      message_personal_p2: "Als je een nieuwe persoonlijke account wilt aanmaken, klik dan op \"Maak een nieuwe account\"."
+      message_institutional_p2: "Als je een nieuwe account wilt aanmaken voor de onderwijsinstelling **%{institution}**, klik dan op \"Maak een nieuwe account\"."
       sign_in_to_institutional: "Meld aan als **%{name}** (%{institution})"
       sign_in_to_personal: "Meld aan als **%{name}** (%{persoonlijke account})"
       create_new_account: "Maak een nieuwe account"
-      "contact_support_html": "Ben jij dit niet of blijf je problemen hebben? Vul het %{form} in en we helpen je zo snel mogelijk verder."
+      "contact_support_html": "Ben jij dit niet of blijf je problemen hebben, vul dan het %{form} in en we helpen je zo snel mogelijk verder."
       contact_form: "contactformulier"

--- a/config/locales/views/auth/nl.yml
+++ b/config/locales/views/auth/nl.yml
@@ -29,3 +29,14 @@ nl:
       text_html: "Om Dodona te gebruiken moet je onze privacyverklaring accepteren. Op de pagina <a href=\"%{your_data}\" target=\"_blank\">jouw data</a> leggen we in mensentaal uit welke data we verzamelen en hoe we die gebruiken. De juridisch bindende versie kan je in onze <a href=\"%{privacy_statement}\" target=\"_blank\">privacyverklaring</a> vinden."
       accept_button: Privacyverklaring accepteren
       decline_button: Weigeren
+    confirm_new_user:
+      title: Email al in gebruik
+      message_single_p1: "Er bestaat al een gebruiker met hetzelfde email adres (**%{email}**) in een andere onderwijsinstelling. Waarschijnlijk ben jij dit. Gebruik een van onderstaande login methodes om aan te melden met deze bestaande account."
+      message_plural_p1: "Er bestaan al meerdere gebruikers met hetzelfde email adres (**%{email}**) in andere onderwijsinstellingen. Waarschijnlijk ben jij dit. Gebruik een van onderstaande login methodes om aan te melden met een bestaande account."
+      message_personal_p2: "Als je een nieuwe persoonlijke account wilt aanmaken, klik op \"Maak een nieuwe account\"."
+      message_institutional_p2: "Als je een nieuwe account wilt aanmaken voor de onderwijsinstelling **%{institution}**, klik op \"Maak een nieuwe account\"."
+      sign_in_to_institutional: "Meld aan als **%{name}** (%{institution})"
+      sign_in_to_personal: "Meld aan als **%{name}** (%{persoonlijke account})"
+      create_new_account: "Maak een nieuwe account"
+      "contact_support_html": "Ben jij dit niet of blijf je problemen hebben? Vul het %{form} in en we helpen je zo snel mogelijk verder."
+      contact_form: "contactformulier"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,8 @@ Rails.application.routes.draw do
         delete '/sign_out' => 'authentication#destroy', as: 'sign_out'
         get '/privacy_prompt' => 'omniauth_callbacks#privacy_prompt'
         post '/privacy_prompt' => 'omniauth_callbacks#accept_privacy_policy'
+        get '/confirm_new_user' => 'omniauth_callbacks#confirm_new_user'
+        post '/confirm_new_user' => 'omniauth_callbacks#accept_confirm_new_user'
       end
 
       get '/users/saml/metadata' => 'saml#metadata'

--- a/db/migrate/20220914075029_update_index_to_users_to_email.rb
+++ b/db/migrate/20220914075029_update_index_to_users_to_email.rb
@@ -1,0 +1,6 @@
+class UpdateIndexToUsersToEmail < ActiveRecord::Migration[7.0]
+  def change
+    remove_index :users, :email if index_exists?(:users, :email)
+    add_index :users, [:email, :institution_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_08_30_124315) do
+ActiveRecord::Schema[7.0].define(version: 2022_09_14_075029) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -496,7 +496,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_30_124315) do
     t.string "search", limit: 4096
     t.datetime "seen_at"
     t.datetime "sign_in_at"
-    t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["email", "institution_id"], name: "index_users_on_email_and_institution_id", unique: true
     t.index ["institution_id"], name: "index_users_on_institution_id"
     t.index ["token"], name: "index_users_on_token"
     t.index ["username", "institution_id"], name: "index_users_on_username_and_institution_id", unique: true

--- a/lib/LTI/auth/strategy.rb
+++ b/lib/LTI/auth/strategy.rb
@@ -50,7 +50,7 @@ module OmniAuth
                 email: raw_info[:email]
             },
             extra: {
-                provider: provider,
+                provider_id: provider&.id,
                 redirect_params: {
                     id_token: jwt_token,
                     provider_id: provider&.id

--- a/lib/SAML/strategy.rb
+++ b/lib/SAML/strategy.rb
@@ -55,7 +55,7 @@ module OmniAuth
         info['username'] || @name_id
       end
 
-      extra { {provider: @provider} }
+      extra { {provider_id: @provider&.id} }
 
       def on_callback_path?
         # Intercept requests sent to /users/saml/auth and forward those to the

--- a/test/controllers/auth/omniauth_callbacks_controller_test.rb
+++ b/test/controllers/auth/omniauth_callbacks_controller_test.rb
@@ -243,7 +243,7 @@ class OmniauthCallbacksControllerTest < ActionDispatch::IntegrationTest
       # Setup.
       provider = create provider_name
       user = create :user, institution: provider.institution
-      other_user = create :user
+      other_user = create :user, institution: provider.institution
       identity = create :identity, provider: provider, user: user
 
       omniauth_mock_identity identity,
@@ -301,7 +301,7 @@ class OmniauthCallbacksControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
-  test 'login with other institution should not work' do
+  test 'login with other institution should ask confirmation' do
     AUTH_PROVIDERS.each do |provider_name|
       first_provider = create provider_name
       first_user = create :user, institution: first_provider.institution
@@ -317,9 +317,21 @@ class OmniauthCallbacksControllerTest < ActionDispatch::IntegrationTest
         follow_redirect!
       end
 
-      assert_redirected_to root_path
+      # Before confirm no one is signed in
+      assert_redirected_to confirm_new_user_path
       assert_nil @controller.current_user
       assert_not_equal first_user.reload.username, second_user.username
+
+      assert_difference 'User.count', 1 do
+        post confirm_new_user_path
+        follow_redirect!
+      end
+
+      # After confirm a new user is created
+      assert_equal @controller.current_user.username, second_user.username
+      assert_not_equal first_user.reload.username, second_user.username
+
+      sign_out @controller.current_user
     end
   end
 

--- a/test/controllers/auth/omniauth_callbacks_controller_test.rb
+++ b/test/controllers/auth/omniauth_callbacks_controller_test.rb
@@ -22,7 +22,7 @@ class OmniauthCallbacksControllerTest < ActionDispatch::IntegrationTest
     }.deep_merge(params)
 
     # LTI and SAML include the provider.
-    auth_hash = auth_hash.deep_merge({ extra: { provider: identity.provider } }) if [Provider::Lti, Provider::Saml].include?(identity.provider.class)
+    auth_hash = auth_hash.deep_merge({ extra: { provider_id: identity.provider.id } }) if [Provider::Lti, Provider::Saml].include?(identity.provider.class)
 
     OmniAuth.config.mock_auth[:default] = OmniAuth::AuthHash.new(auth_hash)
   end


### PR DESCRIPTION
This pull request allows emails to be the same as long as the institution differs. (Emails are still unique within an institution)

To avoid confusion of users unwillingly creating new accounts, this pr also adds a confirmation screen if a new account is created for an existing email address.

![image](https://user-images.githubusercontent.com/21177904/190391050-3807f7d7-f388-47e0-9412-182bdaebfafb.png)

This pr depends on #4002 as it makes use of the same methods to store the full hash in the session. I did improve upon that pr, because the session could get too large. For this reason I stored only the provider id in stead of the full provider and I also left out the credentials and raw info when storing it in the session.

I also grouped some duplicated code into methods in the omniauth_callbacks_controller.

- [x] Tests were added

Closes  #3981.
Closes #3982.
