### PR TITLE
Don't store current location for confirm new user page

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,7 +12,7 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :null_session
 
   before_action :store_current_location,
-                except: %i[media sign_in institution_not_supported privacy_prompt accept_privacy_policy],
+                except: %i[media sign_in institution_not_supported privacy_prompt accept_privacy_policy confirm_new_user accept_confirm_new_user],
                 unless: -> { devise_controller? || remote_request? }
 
   before_action :skip_session,


### PR DESCRIPTION
This pull request fixes a bug: 
When a user tries to sign in on a specific page, we try to redirect them to that page after the sign in process. The confirm new user page is part of the login flow and should not overwrite the destination page.
