### PR TITLE
Redirect from confirm new user and privacy page to root if no session info is available

### DIFF
--- a/app/controllers/auth/omniauth_callbacks_controller.rb
+++ b/app/controllers/auth/omniauth_callbacks_controller.rb
@@ -64,6 +64,9 @@ class Auth::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   # Confirm duplicate email before new user creation
 
   def confirm_new_user
+    # If we end up on this page without the relevant session info, redirect to root
+    return redirect_to root_path if auth_hash.blank?
+
     @institution = provider.institution
     @users = User.where(email: auth_email)
     @email = auth_email

--- a/app/controllers/auth/omniauth_callbacks_controller.rb
+++ b/app/controllers/auth/omniauth_callbacks_controller.rb
@@ -56,6 +56,9 @@ class Auth::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   end
 
   def accept_privacy_policy
+    # If we end up on this page without the relevant session info, redirect to root
+    return redirect_to root_path if auth_hash.blank?
+
     identity = create_new_user_and_identity!
 
     sign_in!(identity)
@@ -75,6 +78,9 @@ class Auth::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   end
 
   def accept_confirm_new_user
+    # If we end up on this page without the relevant session info, redirect to root
+    return redirect_to root_path if auth_hash.blank?
+
     # Redirect to privacy prompt before we create a new private user
     return redirect_to_privacy_prompt if provider&.institution.nil?
 


### PR DESCRIPTION
This pull request fixes a  bug  when session info is not provided.
```
Exception
undefined method 'to_sym' for nil:NilClass
   sym = sym.to_sym
```

These are probably triggered by `redirect_back` which is used at several occasions to support a dynamic back link. (often to support specific LTI pages). But it could also be triggered by manual use of the back button.

