### PR TITLE
Store session information in the database instead of a cookie

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -140,6 +140,9 @@ gem 'ddtrace', '~> 1.4.1'
 # Make sure filesystem changes only happen at the end of a transaction
 gem 'after_commit_everywhere', '~> 1.2.2'
 
+# Store session data in the database
+gem 'activerecord-session_store', '~> 2.0.0'
+
 group :development, :test do
   # Use mocha for stubbing and mocking
   gem 'mocha', '~> 1.14.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,6 +55,12 @@ GEM
     activerecord (7.0.4)
       activemodel (= 7.0.4)
       activesupport (= 7.0.4)
+    activerecord-session_store (2.0.0)
+      actionpack (>= 5.2.4.1)
+      activerecord (>= 5.2.4.1)
+      multi_json (~> 1.11, >= 1.11.2)
+      rack (>= 2.0.8, < 3)
+      railties (>= 5.2.4.1)
     activestorage (7.0.4)
       actionpack (= 7.0.4)
       activejob (= 7.0.4)
@@ -493,6 +499,7 @@ PLATFORMS
 
 DEPENDENCIES
   ace-rails-ap (~> 4.4)
+  activerecord-session_store (~> 2.0.0)
   after_commit_everywhere (~> 1.2.2)
   annotate (~> 3.2.0)
   autoprefixer-rails (~> 10.4.7)

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,7 +1,7 @@
 # Be sure to restart your server when you modify this file.
 
 if Rails.env.production? || Rails.env.staging?
-  Rails.application.config.session_store :cookie_store, key: '_dodona_session', same_site: :none, secure: true
+  Rails.application.config.session_store :active_record_store, key: '_dodona_session', same_site: :none, secure: true
 else
-  Rails.application.config.session_store :cookie_store, key: '_dodona_session'
+  Rails.application.config.session_store :active_record_store, key: '_dodona_session'
 end

--- a/db/migrate/20220929072055_add_sessions_table.rb
+++ b/db/migrate/20220929072055_add_sessions_table.rb
@@ -1,0 +1,12 @@
+class AddSessionsTable < ActiveRecord::Migration[7.0]
+  def change
+    create_table :sessions do |t|
+      t.string :session_id, :null => false
+      t.text :data
+      t.timestamps
+    end
+
+    add_index :sessions, :session_id, :unique => true
+    add_index :sessions, :updated_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_09_14_075029) do
+ActiveRecord::Schema[7.0].define(version: 2022_09_29_072055) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -475,6 +475,15 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_14_075029) do
     t.index ["activity_id"], name: "index_series_memberships_on_activity_id"
     t.index ["series_id", "activity_id"], name: "index_series_memberships_on_series_id_and_activity_id", unique: true
     t.index ["series_id"], name: "index_series_memberships_on_series_id"
+  end
+
+  create_table "sessions", charset: "utf8mb4", force: :cascade do |t|
+    t.string "session_id", null: false
+    t.text "data"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["session_id"], name: "index_sessions_on_session_id", unique: true
+    t.index ["updated_at"], name: "index_sessions_on_updated_at"
   end
 
   create_table "submissions", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|


### PR DESCRIPTION
This pull request fixes the cookie overflow bug that was caused by #4002

To fix this we store the session info in the database instead of a cookie as was already suggested in #2127

- [x]  Script to trim session db on ansible: https://github.com/dodona-edu/dodona-ansible/pull/151
> To avoid your sessions table expanding without limit as it will store expired and potentially sensitive session data, it is strongly recommended in production environments to schedule the `db:sessions:trim` rake task to run daily. Running `bin/rake db:sessions:trim` will delete all sessions that have not been updated in the last 30 days. 