### PR TITLE
Ask questions link to guide was not interpreted

### DIFF
--- a/app/assets/javascripts/components/annotations/annotation_form.ts
+++ b/app/assets/javascripts/components/annotations/annotation_form.ts
@@ -185,7 +185,7 @@ export class AnnotationForm extends watchMixin(ShadowlessLitElement) {
                     <div class="clearfix annotation-help-block">
                         <span class='help-block'>${unsafeHTML(I18n.t("js.user_annotation.help"))}</span>
                         ${this.questionMode ? html`
-                            <span class='help-block'>${I18n.t("js.user_annotation.help_student")}</span>
+                            <span class='help-block'>${unsafeHTML(I18n.t("js.user_annotation.help_student"))}</span>
                         ` : ""}
                         <span class="help-block float-end">
                             <span class="used-characters">${I18n.formatNumber(this.annotationText.length)}</span> / ${I18n.formatNumber(maxLength)}


### PR DESCRIPTION
This pull request makes the HTML link to the guides clickable in the ask question field for students

<img width="978" alt="image" src="https://user-images.githubusercontent.com/68779933/193214132-3077147a-7a7b-4c7d-8759-abda2e60a07c.png">

Closes #4043  .
