### PR TITLE
SAML: Allow clock drift to account for clock skew between servers

### DIFF
--- a/lib/SAML/strategy.rb
+++ b/lib/SAML/strategy.rb
@@ -68,6 +68,8 @@ module OmniAuth
       def handle_response(raw, settings)
         # Parse the raw response.
         opts = response_options.merge(settings: settings)
+        # Allow clock drift to account for clock skew between servers.
+        opts = opts.merge({:allowed_clock_drift => 2.seconds})
         parsed_response = OneLogin::RubySaml::Response.new(raw, opts)
         parsed_response.soft = false
 


### PR DESCRIPTION
This pull request adds [clock drift](https://github.com/onelogin/ruby-saml#clock-drift) to SAML.

This fixes multiple user from the uhasselt being unable to log in due to a minor clock skew between their server and ours.

Ugent SAML login still works on naos with this change

