### PR TITLE
Store auth hash in cache instead of session to fix cookie overflow

### DIFF
--- a/app/controllers/auth/omniauth_callbacks_controller.rb
+++ b/app/controllers/auth/omniauth_callbacks_controller.rb
@@ -1,6 +1,8 @@
 class Auth::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   # Disable CSRF since the token information is lost.
   skip_before_action :verify_authenticity_token
+  CACHE_EXPIRY_TIME = 5.minutes
+  CACHE_STRING = '/auth_hash/%<id>s'.freeze
 
   # ==> Failure route.
 
@@ -311,9 +313,16 @@ class Auth::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   end
 
   def store_hash_in_session!
-    # Filter raw info and credentials from hash to limit cookie size
-    hash = auth_hash.except('extra', 'credentials').merge({ 'extra' => auth_hash.extra&.except('raw_info') })
-    session[:new_user_auth_hash] = hash.to_json
+    # generate random unique key for the hash
+    # It is sufficiently random for uniqueness: https://stackoverflow.com/questions/18554306/generating-unique-token-on-the-fly-with-rails
+    id = SecureRandom.urlsafe_base64(16)
+    # store hash in cached memory
+    lookup_string = format(CACHE_STRING, id: id)
+    hash = auth_hash.to_json
+    Rails.cache.write(lookup_string, hash, expires_in: CACHE_EXPIRY_TIME)
+    x = Rails.cache.read(lookup_string)
+    # store unique id in session
+    session[:new_user_auth_hash_id] = id
   end
 
   def redirect_to_provider!(target_provider)
@@ -414,9 +423,13 @@ class Auth::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   def auth_hash
     return request.env['omniauth.auth'] if request.env['omniauth.auth'].present?
 
-    # if auth hash was present in session, we can use that
-    # we do want to remove it from the session so it does not stay there indefinitely
-    @new_user_auth_hash = JSON.parse(session.delete(:new_user_auth_hash), object_class: OmniAuth::AuthHash) if session[:new_user_auth_hash].present?
+    if session[:new_user_auth_hash_id].present?
+      # if auth hash was present in session, we can use that
+      # we do want to remove it from the session so it does not stay there indefinitely
+      lookup_string = format(CACHE_STRING, id: session.delete(:new_user_auth_hash_id))
+      cached_hash = Rails.cache.read(lookup_string)
+      @new_user_auth_hash = JSON.parse(cached_hash, object_class: OmniAuth::AuthHash) if cached_hash.present?
+    end
 
     @new_user_auth_hash
   end

--- a/app/controllers/auth/omniauth_callbacks_controller.rb
+++ b/app/controllers/auth/omniauth_callbacks_controller.rb
@@ -320,7 +320,6 @@ class Auth::OmniauthCallbacksController < Devise::OmniauthCallbacksController
     lookup_string = format(CACHE_STRING, id: id)
     hash = auth_hash.to_json
     Rails.cache.write(lookup_string, hash, expires_in: CACHE_EXPIRY_TIME)
-    x = Rails.cache.read(lookup_string)
     # store unique id in session
     session[:new_user_auth_hash_id] = id
   end

--- a/test/controllers/auth/omniauth_callbacks_controller_test.rb
+++ b/test/controllers/auth/omniauth_callbacks_controller_test.rb
@@ -3,15 +3,13 @@ require 'test_helper'
 class OmniauthCallbacksControllerTest < ActionDispatch::IntegrationTest
   include ActiveJob::TestHelper
 
-  def setup
-    super
+  setup do
     # Caching is used in some login flows and should be active for the tests
     ActionController::Base.perform_caching = true
     Rails.cache = ActiveSupport::Cache::MemCacheStore.new
   end
 
-  def teardown
-    super
+  teardown do
     ActionController::Base.perform_caching = false
     Rails.cache = ActiveSupport::Cache::NullStore.new
   end

--- a/test/controllers/auth/omniauth_callbacks_controller_test.rb
+++ b/test/controllers/auth/omniauth_callbacks_controller_test.rb
@@ -6,7 +6,7 @@ class OmniauthCallbacksControllerTest < ActionDispatch::IntegrationTest
   setup do
     # Caching is used in some login flows and should be active for the tests
     ActionController::Base.perform_caching = true
-    Rails.cache = ActiveSupport::Cache::MemCacheStore.new
+    Rails.cache = ActiveSupport::Cache::MemoryStore.new
   end
 
   teardown do

--- a/test/controllers/auth/omniauth_callbacks_controller_test.rb
+++ b/test/controllers/auth/omniauth_callbacks_controller_test.rb
@@ -3,6 +3,19 @@ require 'test_helper'
 class OmniauthCallbacksControllerTest < ActionDispatch::IntegrationTest
   include ActiveJob::TestHelper
 
+  def setup
+    super
+    # Caching is used in some login flows and should be active for the tests
+    ActionController::Base.perform_caching = true
+    Rails.cache = ActiveSupport::Cache::MemCacheStore.new
+  end
+
+  def teardown
+    super
+    ActionController::Base.perform_caching = false
+    Rails.cache = ActiveSupport::Cache::NullStore.new
+  end
+
   def omniauth_mock_identity(identity, params = {})
     # Generic hash.
     auth_hash = {


### PR DESCRIPTION
This pull request fixes a cookie overflow bug that was cause by the auth hash being stored in the session. (#4002)
To fix this we opted to store the auth hash in mem_cache, with an expiry of 5 minutes. The session now contains a unique key to that hash object.

Replaces  #4041
