### PR TITLE
Throw a 406 error instead of a 500 error when trying to load a json description

### DIFF
--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -122,6 +122,7 @@ class ActivitiesController < ApplicationController
   end
 
   def description
+    respond_to :html
     raise Pundit::NotAuthorizedError, 'Not allowed' unless @activity.access_token == params[:token]
 
     render layout: 'frame'

--- a/test/controllers/activities_controller_test.rb
+++ b/test/controllers/activities_controller_test.rb
@@ -748,4 +748,13 @@ class ExerciseDescriptionTest < ActionDispatch::IntegrationTest
     assert description_url.include?(Rails.configuration.sandbox_host)
     assert description_url.include?(exercise.access_token)
   end
+
+  test 'json link to description should return a 406' do
+    exercise = exercises(:python_exercise)
+
+    # should throw unknown format error, which rails will translate to a 406
+    assert_raises(ActionController::UnknownFormat) do
+      get description_activity_url(exercise, token: exercise.access_token, format: :json)
+    end
+  end
 end


### PR DESCRIPTION
This pull request fixes #4066. json is not supported for description, but it should not trigger an internal error either.

Now it returns a 406 error which signifies that the format is not supported.

Closes #4066 .
