### PR TITLE
Fix rendering of strikethrough on the remove course admin button

### DIFF
--- a/app/assets/stylesheets/material_icons.css.scss
+++ b/app/assets/stylesheets/material_icons.css.scss
@@ -37,16 +37,16 @@
   margin-top: 12px;
 }
 
-.mdi.mdi-icons-strikethrough.mdi-18::after {
+.mdi.mdi-icons-strikethrough::after {
   position: relative;
-  top: -27px;
-  left: 19px;
+  top: -36px;
+  left: 27px;
   width: 0;
   height: 0;
   content: "|";
   display: block;
   font-weight: bold;
-  font-size: 200%;
+  font-size: 250%;
   transform: rotate(45deg);
 }
 


### PR DESCRIPTION
This pull request fixes the remove course admin button. The bug probably existed since the redesign (see #3685 ) which increased button sizes.

![image](https://user-images.githubusercontent.com/21177904/200774756-b14e3aa4-b8a8-4225-add7-f57785f4c735.png)


Closes #4125 .
