### PR TITLE
Add `unstarted_by` scope to exercise model

### DIFF
--- a/app/models/exercise.rb
+++ b/app/models/exercise.rb
@@ -40,7 +40,7 @@ class Exercise < Activity
   before_save :check_memory_limit
 
   # Only used manually from the console
-  scope :unsolved_by, ->(users) { where.not(id: Submission.where(user_id: users).select(:exercise_id)) }
+  scope :unstarted_by, ->(users) { where.not(id: Submission.where(user_id: users).select(:exercise_id)) }
 
   def exercise?
     true

--- a/app/models/exercise.rb
+++ b/app/models/exercise.rb
@@ -39,6 +39,9 @@ class Exercise < Activity
 
   before_save :check_memory_limit
 
+  # Only used manually from the console
+  scope :unsolved_by, ->(users) { where.not(id: Submission.where(user_id: users).select(:exercise_id)) }
+
   def exercise?
     true
   end

--- a/test/models/exercise_test.rb
+++ b/test/models/exercise_test.rb
@@ -536,6 +536,20 @@ class ExerciseTest < ActiveSupport::TestCase
   end
 end
 
+class ExerciseUnstartedTest < ActiveSupport::TestCase
+  test 'unstarted_by should return a correct result' do
+    user1 = users(:zeus)
+    user2 = users(:staff)
+    exercises = create_list(:exercise, 3)
+    create(:submission, exercise: exercises.first, user: user1)
+    create(:submission, exercise: exercises.second, user: user2)
+
+    result = Exercise.where(id: exercises.map(&:id)).unstarted_by(User.all)
+    assert_equal 1, result.count
+    assert_equal exercises.third, result[0]
+  end
+end
+
 class ExerciseRemoteTest < ActiveSupport::TestCase
   setup do
     # allow pushing


### PR DESCRIPTION
Every once in a while, I have to look up exercises that are not solved by a group of users yet. Every time I have to re-invent the query to do so. This makes it so I won't have to re-invent the query.
