### PR TITLE
Fix table height for not fully loaded series

### DIFF
--- a/app/assets/javascripts/course.ts
+++ b/app/assets/javascripts/course.ts
@@ -94,7 +94,7 @@ function initCourseMembers(): void {
 }
 
 const TABLE_WRAPPER_SELECTOR = ".series-activities-table-wrapper";
-const SKELETON_TABLE_SELECTOR = ".activity-table-skeleton";
+const SKELETON_TABLE_SELECTOR = ".unloaded-skeleton-field";
 
 class Series {
     private readonly id: number;

--- a/app/assets/stylesheets/models/series.css.scss
+++ b/app/assets/stylesheets/models/series.css.scss
@@ -180,47 +180,28 @@
   white-space: normal;
 }
 
-.activity-table-skeleton {
-  width: 100%;
+.unloaded-skeleton-field {
+  background-image: linear-gradient($skeleton-color 100%, transparent 0);
 
-  .skeleton-head {
-    border-bottom: solid 1px $skeleton-color;
-    height: 33px;
-    background-repeat: no-repeat;
-    background-image:
-      linear-gradient($skeleton-color 100%, transparent 0),
-      linear-gradient($skeleton-color 100%, transparent 0),
-      linear-gradient($skeleton-color 100%, transparent 0);
-    background-size:
-      56px 12px,
-      90px 12px,
-      115px 12px;
-    background-position:
-      58px 10px,
-      calc(100% - 230px) 10px,
-      calc(100% - 75px) 10px;
+  &.skeleton-progress {
+    height: 8px;
+    width: 100px;
   }
 
-  .skeleton-row {
-    border-top: solid 1px $skeleton-color;
-    height: 37px;
+  &.skeleton-status {
+    height: 17px;
+    width: 110px;
+  }
+
+  &.skeleton-icon {
+    display: block;
+    background-size: 17px 17px;
     background-repeat: no-repeat;
-    background-image:
-      linear-gradient($skeleton-color 100%, transparent 0),
-      linear-gradient($skeleton-color 100%, transparent 0),
-      linear-gradient($skeleton-color 100%, transparent 0),
-      linear-gradient($skeleton-color 100%, transparent 0);
-    background-size:
-      90px 12px,
-      100px 12px,
-      90px 12px,
-      8px 12px;
-    background-position:
-      58px 15px,
-      calc(100% - 220px) 15px,
-      calc(100% - 100px) 15px,
-      calc(100% - 25px) 15px;
-    padding-right: 8px;
+    background-position: center;
+
+    &::before {
+      visibility: hidden;
+    }
   }
 }
 

--- a/app/views/activities/_series_activities_table.html.erb
+++ b/app/views/activities/_series_activities_table.html.erb
@@ -46,7 +46,7 @@
               <% end %>
               <%= render partial: 'activities/user_status_icon', locals: {activity: activity, series: local_assigns[:series], user: user} %>
             <% else %>
-              TBD
+              <i class="mdi mdi-check unloaded-skeleton-field skeleton-icon"></i>
             <% end %>
           <% end %>
         </td>
@@ -109,7 +109,7 @@
                 <% end %>
               <% end %>
             <% else %>
-              TBD
+              <div class="unloaded-skeleton-field skeleton-progress"></div>
             <% end %>
           </td>
         <% end %>
@@ -119,7 +119,7 @@
             <% if loaded %>
               <%= render partial: 'activities/user_status', locals: {activity: activity, series: local_assigns[:series], user: user} %>
             <% else %>
-              TBD
+              <div class="unloaded-skeleton-field skeleton-status"></div>
             <% end %>
           </td>
           <td>
@@ -141,7 +141,7 @@
                 <% end %>
               <% end %>
             <% else %>
-              TBD
+              <i class="mdi mdi-chevron-right unloaded-skeleton-field skeleton-icon"></i>
             <% end %>
           </td>
         <% end %>

--- a/app/views/activities/_series_activities_table.html.erb
+++ b/app/views/activities/_series_activities_table.html.erb
@@ -76,7 +76,7 @@
 
         <% if @course.blank? || policy(local_assigns[:series]).show_progress? %>
           <td class="d-none d-sm-table-cell">
-            <%if loaded %>
+            <% if loaded %>
               <% if activity.exercise? %>
                 <% if @course %>
                   <%= render partial: 'application/progress_chart',

--- a/app/views/activities/_series_activities_table.html.erb
+++ b/app/views/activities/_series_activities_table.html.erb
@@ -4,7 +4,9 @@
    else
      user = current_user
    end %>
-
+<% unless defined? loaded %>
+  <% loaded = true %>
+<% end %>
 <div class="table-scroll-wrapper">
   <table class="table activity-table table-resource">
     <thead>
@@ -38,10 +40,14 @@
       <tr>
         <td class='status-icon'>
           <% if user_signed_in? %>
-            <% if current_user.repository_admin?(activity.repository) || current_user.course_admin?(@course) %>
-              <%= render partial: 'activities/repository_status', locals: {activity: activity, series: local_assigns[:series]} %>
+            <% if loaded %>
+              <% if current_user.repository_admin?(activity.repository) || current_user.course_admin?(@course) %>
+                <%= render partial: 'activities/repository_status', locals: {activity: activity, series: local_assigns[:series]} %>
+              <% end %>
+              <%= render partial: 'activities/user_status_icon', locals: {activity: activity, series: local_assigns[:series], user: user} %>
+            <% else %>
+              TBD
             <% end %>
-            <%= render partial: 'activities/user_status_icon', locals: {activity: activity, series: local_assigns[:series], user: user} %>
           <% end %>
         </td>
 
@@ -70,60 +76,72 @@
 
         <% if @course.blank? || policy(local_assigns[:series]).show_progress? %>
           <td class="d-none d-sm-table-cell">
-            <% if activity.exercise? %>
-              <% if @course %>
-                <%= render partial: 'application/progress_chart',
-                  locals: {
-                    total: @course.subscribed_members_count,
-                    tried: activity.users_tried(course: @course),
-                    correct: activity.users_correct(course: @course),
-                    info_tried: 'activities.index.progress_chart_info_tried',
-                    info_correct: 'activities.index.progress_chart_info_correct'
-                  }
-                %>
-              <% else %>
-                <%= content_tag :span, title: t('activities.activity.count_tooltip'), class: "text-end text-muted" do %>
-                  <%= activity.users_correct %>/<%= activity.users_tried %>
+            <%if loaded %>
+              <% if activity.exercise? %>
+                <% if @course %>
+                  <%= render partial: 'application/progress_chart',
+                    locals: {
+                      total: @course.subscribed_members_count,
+                      tried: activity.users_tried(course: @course),
+                      correct: activity.users_correct(course: @course),
+                      info_tried: 'activities.index.progress_chart_info_tried',
+                      info_correct: 'activities.index.progress_chart_info_correct'
+                    }
+                  %>
+                <% else %>
+                  <%= content_tag :span, title: t('activities.activity.count_tooltip'), class: "text-end text-muted" do %>
+                    <%= activity.users_correct %>/<%= activity.users_tried %>
+                  <% end %>
+                <% end %>
+              <% elsif activity.content_page? %>
+                <% if @course %>
+                  <%= render partial: 'application/read_chart',
+                    locals: {
+                      total: @course.subscribed_members_count,
+                      read: activity.users_read(course: @course),
+                      info_read: 'activities.index.progress_chart_info_read'
+                    }
+                  %>
+                <% else %>
+                  <%= content_tag :span, title: t('activities.activity.read_tooltip'), class: "text-end text-muted" do %>
+                    <%= t 'activities.activity.read_by', count: activity.users_read %>
+                  <% end %>
                 <% end %>
               <% end %>
-            <% elsif activity.content_page? %>
-              <% if @course %>
-                <%= render partial: 'application/read_chart',
-                  locals: {
-                    total: @course.subscribed_members_count,
-                    read: activity.users_read(course: @course),
-                    info_read: 'activities.index.progress_chart_info_read'
-                  }
-                %>
-              <% else %>
-                <%= content_tag :span, title: t('activities.activity.read_tooltip'), class: "text-end text-muted" do %>
-                  <%= t 'activities.activity.read_by', count: activity.users_read %>
-                <% end %>
-              <% end %>
+            <% else %>
+              TBD
             <% end %>
           </td>
         <% end %>
 
         <% if user_signed_in? %>
           <td>
-            <%= render partial: 'activities/user_status', locals: {activity: activity, series: local_assigns[:series], user: user} %>
+            <% if loaded %>
+              <%= render partial: 'activities/user_status', locals: {activity: activity, series: local_assigns[:series], user: user} %>
+            <% else %>
+              TBD
+            <% end %>
           </td>
           <td>
-            <% if activity.exercise? && (activity.started_for?(user, local_assigns[:series]) || current_user.course_admin?(local_assigns[:series]&.course)) %>
-              <% options = current_user == user ? {} : {user_id: user.id} %>
-              <%= link_to submissions_scoped_path(exercise: activity, course: local_assigns[:series]&.course, series: local_assigns[:series], options: options),
-                          title: t('layout.menu.my_submissions'),
-                          class: 'btn-icon' do %>
-                <i class="mdi mdi-chevron-right"></i>
+            <% if loaded %>
+              <% if activity.exercise? && (activity.started_for?(user, local_assigns[:series]) || current_user.course_admin?(local_assigns[:series]&.course)) %>
+                <% options = current_user == user ? {} : {user_id: user.id} %>
+                <%= link_to submissions_scoped_path(exercise: activity, course: local_assigns[:series]&.course, series: local_assigns[:series], options: options),
+                            title: t('layout.menu.my_submissions'),
+                            class: 'btn-icon' do %>
+                  <i class="mdi mdi-chevron-right"></i>
+                <% end %>
               <% end %>
-            <% end %>
-            <% if activity.content_page? &&  current_user.course_admin?(local_assigns[:series]&.course) %>
-              <% options = current_user == user ? {} : {user_id: user.id} %>
-              <%= link_to activity_read_states_scoped_path(content_page: activity, course: local_assigns[:series]&.course, series: local_assigns[:series], options: options),
-                          title: t('activities.navbar_links.read_states'),
-                          class: 'btn-icon' do %>
-                <i class="mdi mdi-chevron-right"></i>
+              <% if activity.content_page? &&  current_user.course_admin?(local_assigns[:series]&.course) %>
+                <% options = current_user == user ? {} : {user_id: user.id} %>
+                <%= link_to activity_read_states_scoped_path(content_page: activity, course: local_assigns[:series]&.course, series: local_assigns[:series], options: options),
+                            title: t('activities.navbar_links.read_states'),
+                            class: 'btn-icon' do %>
+                  <i class="mdi mdi-chevron-right"></i>
+                <% end %>
               <% end %>
+            <% else %>
+              TBD
             <% end %>
           </td>
         <% end %>

--- a/app/views/series/_series.html.erb
+++ b/app/views/series/_series.html.erb
@@ -188,21 +188,13 @@
 
       <% if policy(series).overview? && series.activity_count > 0 %>
         <div class="series-activities-table-wrapper">
-          <% if loaded %>
-            <%= render partial: 'activities/series_activities_table', locals: {
-                series: series,
-                activities: series.activities,
-                get_activity_path: get_activity_path,
-                user: user
-            } %>
-          <% else %>
-            <div class="activity-table-skeleton">
-              <div class="skeleton-head"></div>
-              <% series.activity_count.times do %>
-                <div class="skeleton-row"></div>
-              <% end %>
-            </div>
-          <% end %>
+          <%= render partial: 'activities/series_activities_table', locals: {
+              series: series,
+              activities: series.activities,
+              get_activity_path: get_activity_path,
+              user: user,
+              loaded: loaded,
+          } %>
         </div>
       <% end %>
     </div>


### PR DESCRIPTION
This pull request fixes the automatic scroll on course pages. I only replaced the slow fields of the table by a placeholder, instead of all the fields, allowing a search by exercise name as requested.

Below you can find the results of a speed comparison. For fair comparison I cleared my sql cache before each request. I tested on https://dodona.ugent.be/nl/courses/359/ which is a rather large course.
- Old: 2421ms/1798ms/1887ms
- Load course with all series: 14446ms/13961ms
- Load course with only progress bars hidden: 2445ms/2345ms/2298ms/2513ms
- New: 1875ms/1900ms/1991ms

Old:
![image](https://user-images.githubusercontent.com/21177904/202190866-cc65e066-d70f-45ef-b755-4576e13e1913.png)

New:
![image](https://user-images.githubusercontent.com/21177904/202190708-64dc73fb-94b7-4892-81e0-b7f3e77d5b16.png)


Closes #3962.

Replaced by #4169
