### PR TITLE
Fix series preview table height on the course page

### DIFF
--- a/app/assets/javascripts/course.ts
+++ b/app/assets/javascripts/course.ts
@@ -94,7 +94,7 @@ function initCourseMembers(): void {
 }
 
 const TABLE_WRAPPER_SELECTOR = ".series-activities-table-wrapper";
-const SKELETON_TABLE_SELECTOR = ".activity-table-skeleton";
+const SKELETON_TABLE_SELECTOR = ".activity-table-skeletons";
 
 class Series {
     private readonly id: number;

--- a/app/assets/javascripts/course.ts
+++ b/app/assets/javascripts/course.ts
@@ -94,7 +94,7 @@ function initCourseMembers(): void {
 }
 
 const TABLE_WRAPPER_SELECTOR = ".series-activities-table-wrapper";
-const SKELETON_TABLE_SELECTOR = ".activity-table-skeleton";
+const SKELETON_TABLE_SELECTOR = ".skeleton-table";
 
 class Series {
     private readonly id: number;

--- a/app/assets/javascripts/course.ts
+++ b/app/assets/javascripts/course.ts
@@ -94,7 +94,7 @@ function initCourseMembers(): void {
 }
 
 const TABLE_WRAPPER_SELECTOR = ".series-activities-table-wrapper";
-const SKELETON_TABLE_SELECTOR = ".activity-table-skeletons";
+const SKELETON_TABLE_SELECTOR = ".activity-table-skeleton";
 
 class Series {
     private readonly id: number;

--- a/app/assets/stylesheets/models/series.css.scss
+++ b/app/assets/stylesheets/models/series.css.scss
@@ -180,47 +180,28 @@
   white-space: normal;
 }
 
-.activity-table-skeleton {
-  width: 100%;
+.skeleton-field {
+  background-image: linear-gradient($skeleton-color 100%, transparent 0);
 
-  .skeleton-head {
-    border-bottom: solid 1px $skeleton-color;
-    height: 33px;
-    background-repeat: no-repeat;
-    background-image:
-      linear-gradient($skeleton-color 100%, transparent 0),
-      linear-gradient($skeleton-color 100%, transparent 0),
-      linear-gradient($skeleton-color 100%, transparent 0);
-    background-size:
-      56px 12px,
-      90px 12px,
-      115px 12px;
-    background-position:
-      58px 10px,
-      calc(100% - 230px) 10px,
-      calc(100% - 75px) 10px;
+  &.skeleton-progress {
+    height: 8px;
+    width: 100px;
   }
 
-  .skeleton-row {
-    border-top: solid 1px $skeleton-color;
-    height: 37px;
+  &.skeleton-status {
+    height: 17px;
+    width: 110px;
+  }
+
+  &.skeleton-icon {
+    display: block;
+    background-size: 17px 17px;
     background-repeat: no-repeat;
-    background-image:
-      linear-gradient($skeleton-color 100%, transparent 0),
-      linear-gradient($skeleton-color 100%, transparent 0),
-      linear-gradient($skeleton-color 100%, transparent 0),
-      linear-gradient($skeleton-color 100%, transparent 0);
-    background-size:
-      90px 12px,
-      100px 12px,
-      90px 12px,
-      8px 12px;
-    background-position:
-      58px 15px,
-      calc(100% - 220px) 15px,
-      calc(100% - 100px) 15px,
-      calc(100% - 25px) 15px;
-    padding-right: 8px;
+    background-position: center;
+
+    &::before {
+      visibility: hidden;
+    }
   }
 }
 

--- a/app/assets/stylesheets/models/series.css.scss
+++ b/app/assets/stylesheets/models/series.css.scss
@@ -184,7 +184,7 @@
   .sk-p {
     background-image: linear-gradient($skeleton-color 100%, transparent 0);
     width: 116px;
-    background-size: 100px 8px;
+    background-size: 100px 12px;
     background-repeat: no-repeat;
     background-position-y: center;
     background-position-x: 8px;
@@ -193,7 +193,7 @@
   .sk-s {
     background-image: linear-gradient($skeleton-color 100%, transparent 0);
     width: 126px;
-    background-size: 110px 17px;
+    background-size: 110px 12px;
     background-repeat: no-repeat;
     background-position-y: center;
     background-position-x: 8px;
@@ -202,7 +202,7 @@
   .sk-i {
     background-image: linear-gradient($skeleton-color 100%, transparent 0);
     display: block;
-    background-size: 17px 17px;
+    background-size: 17px 12px;
     background-repeat: no-repeat;
     background-position: center;
 

--- a/app/assets/stylesheets/models/series.css.scss
+++ b/app/assets/stylesheets/models/series.css.scss
@@ -180,20 +180,27 @@
   white-space: normal;
 }
 
-.skeleton-field {
-  background-image: linear-gradient($skeleton-color 100%, transparent 0);
-
-  &.skeleton-progress {
-    height: 8px;
-    width: 100px;
+.skeleton-table {
+  .sk-p {
+    background-image: linear-gradient($skeleton-color 100%, transparent 0);
+    width: 116px;
+    background-size: 100px 8px;
+    background-repeat: no-repeat;
+    background-position-y: center;
+    background-position-x: 8px;
   }
 
-  &.skeleton-status {
-    height: 17px;
-    width: 110px;
+  .sk-s {
+    background-image: linear-gradient($skeleton-color 100%, transparent 0);
+    width: 126px;
+    background-size: 110px 17px;
+    background-repeat: no-repeat;
+    background-position-y: center;
+    background-position-x: 8px;
   }
 
-  &.skeleton-icon {
+  .sk-i {
+    background-image: linear-gradient($skeleton-color 100%, transparent 0);
     display: block;
     background-size: 17px 17px;
     background-repeat: no-repeat;

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -8,9 +8,9 @@
 #  secret            :string(255)
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
-#  description       :text(16777215)
-#  visibility        :integer
-#  registration      :integer
+#  description       :text(4294967295)
+#  visibility        :integer          default("visible_for_all")
+#  registration      :integer          default("open_for_institutional_users")
 #  teacher           :string(255)
 #  institution_id    :bigint
 #  search            :string(4096)

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -5,7 +5,7 @@
 #  id                       :integer          not null, primary key
 #  course_id                :integer
 #  name                     :string(255)
-#  description              :text(16777215)
+#  description              :text(4294967295)
 #  visibility               :integer
 #  order                    :integer          default(0), not null
 #  created_at               :datetime         not null

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -60,7 +60,7 @@ class Submission < ApplicationRecord
   scope :of_judge, ->(judge) { where(exercise_id: Exercise.where(judge_id: judge.id)) }
   scope :from_students, ->(course) { where(user: course.enrolled_members) }
 
-  scope :judged, -> { where.not(status: %i[running queued]) }
+  scope :judged, -> { where(status: ['unknown', 'correct', 'wrong', 'time limit exceeded', 'runtime error', 'compilation error', 'memory limit exceeded', 'internal error', 'output limit exceeded']) }
   scope :by_exercise_name, ->(name) { where(exercise: Exercise.by_name(name)) }
   scope :by_status, ->(status) { where(status: status.in?(statuses) ? status : -1) }
   scope :by_username, ->(name) { where(user: User.by_filter(name)) }

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -60,6 +60,8 @@ class Submission < ApplicationRecord
   scope :of_judge, ->(judge) { where(exercise_id: Exercise.where(judge_id: judge.id)) }
   scope :from_students, ->(course) { where(user: course.enrolled_members) }
 
+  # This scope used to use `where.not` with less options, but that was a lot slower because SQL does not use indexes in that case
+  # As this scope is used for the progress bars on the course page, the speedup was relevant
   scope :judged, -> { where(status: ['unknown', 'correct', 'wrong', 'time limit exceeded', 'runtime error', 'compilation error', 'memory limit exceeded', 'internal error', 'output limit exceeded']) }
   scope :by_exercise_name, ->(name) { where(exercise: Exercise.by_name(name)) }
   scope :by_status, ->(status) { where(status: status.in?(statuses) ? status : -1) }

--- a/app/views/series/_series.html.erb
+++ b/app/views/series/_series.html.erb
@@ -196,12 +196,30 @@
                 user: user
             } %>
           <% else %>
-            <div class="activity-table-skeleton">
-              <div class="skeleton-head"></div>
-              <% series.activity_count.times do %>
-                <div class="skeleton-row"></div>
+            <table class="table activity-table table-resource">
+              <tr class="">
+                <th class='status-icon'></th>
+                <th class='type-icon'></th>
+                <th><%= t "activities.index.activity_title" %></th>
+                <th class='count d-none d-sm-table-cell'>
+                  <%= t "activities.index.class_progress" %>
+                </th>
+                <th class='status ellipsis-overflow' title="<%= t "activities.index.status" %>"><%= t "activities.index.status" %></th>
+                <th class='status-icon'></th>
+              </tr>
+              <% series.activities.each do |activity| %>
+                <tr>
+                  <td class='status-icon'><i class="skeleton-field skeleton-icon mdi mdi-18 mdi-chevron-right"></i></td>
+                  <td class='type-icon'><i class="skeleton-field skeleton-icon mdi mdi-18 mdi-chevron-right"></i></td>
+                  <td><%= activity.name %></td>
+                  <td><div class="skeleton-field skeleton-progress"></div></td>
+                  <td><div class="skeleton-field skeleton-status"></div></td>
+                  <td>
+                    <i class="skeleton-field skeleton-icon mdi mdi-chevron-right"></i>
+                  </td>
+                </tr>
               <% end %>
-            </div>
+            </table>
           <% end %>
         </div>
       <% end %>

--- a/app/views/series/_series.html.erb
+++ b/app/views/series/_series.html.erb
@@ -196,7 +196,7 @@
                 user: user
             } %>
           <% else %>
-            <table class="table activity-table table-resource">
+            <table class="table activity-table table-resource skeleton-table">
               <tr class="">
                 <th class='status-icon'></th>
                 <th class='type-icon'></th>
@@ -209,14 +209,11 @@
               </tr>
               <% series.activities.each do |activity| %>
                 <tr>
-                  <td class='status-icon'><i class="skeleton-field skeleton-icon mdi mdi-18 mdi-chevron-right"></i></td>
-                  <td class='type-icon'><i class="skeleton-field skeleton-icon mdi mdi-18 mdi-chevron-right"></i></td>
+                  <td></td><td></td>
                   <td><%= activity.name %></td>
-                  <td><div class="skeleton-field skeleton-progress"></div></td>
-                  <td><div class="skeleton-field skeleton-status"></div></td>
-                  <td>
-                    <i class="skeleton-field skeleton-icon mdi mdi-chevron-right"></i>
-                  </td>
+                  <td class="sk-p"></td>
+                  <td class="sk-s"></td>
+                  <td><i class="sk-i mdi mdi-chevron-right"></i></td>
                 </tr>
               <% end %>
             </table>

--- a/db/migrate/20221117132148_add_exercise_status_course_index_to_submissions.rb
+++ b/db/migrate/20221117132148_add_exercise_status_course_index_to_submissions.rb
@@ -1,0 +1,5 @@
+class AddExerciseStatusCourseIndexToSubmissions < ActiveRecord::Migration[7.0]
+  def change
+    add_index :submissions, [:exercise_id, :status, :course_id], name: 'ex_st_co_idx'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_09_14_075029) do
+ActiveRecord::Schema[7.0].define(version: 2022_11_17_132148) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
     t.bigint "record_id", null: false
     t.bigint "blob_id", null: false
-    t.datetime "created_at", null: false
+    t.datetime "created_at", precision: nil, null: false
     t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
     t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
   end
@@ -28,12 +28,12 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_14_075029) do
     t.text "metadata", size: :medium
     t.bigint "byte_size", null: false
     t.string "checksum"
-    t.datetime "created_at", null: false
+    t.datetime "created_at", precision: nil, null: false
     t.string "service_name", null: false
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
   end
 
-  create_table "active_storage_variant_records", charset: "utf8mb4", force: :cascade do |t|
+  create_table "active_storage_variant_records", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
@@ -42,8 +42,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_14_075029) do
   create_table "activities", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name_nl"
     t.string "name_en"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.string "path"
     t.string "description_format"
     t.integer "repository_id"
@@ -90,7 +90,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_14_075029) do
     t.boolean "accepted_before_deadline", default: false, null: false
     t.boolean "solved", default: false, null: false
     t.boolean "started", default: false, null: false
-    t.datetime "solved_at"
+    t.datetime "solved_at", precision: nil
     t.integer "activity_id", null: false
     t.integer "series_id"
     t.integer "user_id", null: false
@@ -104,7 +104,6 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_14_075029) do
     t.index ["activity_id"], name: "index_activity_statuses_on_activity_id"
     t.index ["series_id"], name: "fk_rails_1bc42c2178"
     t.index ["user_id", "series_id_non_nil", "activity_id"], name: "index_on_user_id_series_id_non_nil_activity_id", unique: true
-    t.index ["user_id"], name: "fk_rails_8a05a160e8"
   end
 
   create_table "annotations", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
@@ -128,7 +127,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_14_075029) do
     t.index ["user_id"], name: "index_annotations_on_user_id"
   end
 
-  create_table "announcement_views", charset: "utf8mb4", force: :cascade do |t|
+  create_table "announcement_views", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "announcement_id", null: false
     t.integer "user_id", null: false
     t.datetime "created_at", null: false
@@ -138,7 +137,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_14_075029) do
     t.index ["user_id"], name: "index_announcement_views_on_user_id"
   end
 
-  create_table "announcements", charset: "utf8mb4", force: :cascade do |t|
+  create_table "announcements", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.text "text_nl", null: false
     t.text "text_en", null: false
     t.datetime "start_delivering_at"
@@ -155,8 +154,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_14_075029) do
     t.bigint "user_id"
     t.string "token_digest"
     t.string "description"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["token_digest"], name: "index_api_tokens_on_token_digest"
     t.index ["user_id", "description"], name: "index_api_tokens_on_user_id_and_description", unique: true
     t.index ["user_id"], name: "index_api_tokens_on_user_id"
@@ -165,8 +164,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_14_075029) do
   create_table "course_labels", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "course_id", null: false
     t.string "name", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["course_id", "name"], name: "index_course_labels_on_course_id_and_name", unique: true
   end
 
@@ -181,8 +180,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_14_075029) do
     t.integer "course_id", null: false
     t.integer "user_id", null: false
     t.integer "status", default: 2, null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.boolean "favorite", default: false
     t.index ["course_id"], name: "index_course_memberships_on_course_id"
     t.index ["user_id", "course_id"], name: "index_course_memberships_on_user_id_and_course_id", unique: true
@@ -200,11 +199,11 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_14_075029) do
     t.string "name"
     t.string "year"
     t.string "secret"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.text "description", size: :medium
-    t.integer "visibility"
-    t.integer "registration"
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
+    t.text "description", size: :long
+    t.integer "visibility", default: 0
+    t.integer "registration", default: 0
     t.string "teacher"
     t.bigint "institution_id"
     t.string "search", limit: 4096
@@ -218,15 +217,15 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_14_075029) do
   create_table "delayed_jobs", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "priority", default: 0, null: false
     t.integer "attempts", default: 0, null: false
-    t.text "handler", size: :medium, null: false
-    t.text "last_error", size: :medium
-    t.datetime "run_at"
-    t.datetime "locked_at"
-    t.datetime "failed_at"
+    t.text "handler", size: :long, null: false
+    t.text "last_error", size: :long
+    t.datetime "run_at", precision: nil
+    t.datetime "locked_at", precision: nil
+    t.datetime "failed_at", precision: nil
     t.string "locked_by"
     t.string "queue"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: nil
+    t.datetime "updated_at", precision: nil
     t.index ["priority", "run_at"], name: "delayed_jobs_priority"
   end
 
@@ -254,7 +253,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_14_075029) do
   create_table "evaluations", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "series_id"
     t.boolean "released", default: false, null: false
-    t.datetime "deadline", null: false
+    t.datetime "deadline", precision: nil, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["series_id"], name: "index_evaluations_on_series_id"
@@ -264,8 +263,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_14_075029) do
     t.integer "event_type", null: false
     t.integer "user_id"
     t.string "message", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["event_type"], name: "index_events_on_event_type"
     t.index ["user_id"], name: "fk_rails_0cb5590091"
   end
@@ -309,8 +308,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_14_075029) do
     t.string "name"
     t.string "short_name"
     t.string "logo"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.boolean "generated_name", default: true, null: false
     t.integer "category", default: 0, null: false
   end
@@ -319,8 +318,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_14_075029) do
     t.string "name"
     t.string "image"
     t.string "path"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.string "renderer", null: false
     t.string "remote"
     t.integer "clone_status", default: 1, null: false
@@ -349,8 +348,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_14_075029) do
     t.string "name", null: false
     t.string "editor_name", null: false
     t.string "extension", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.string "icon"
     t.string "renderer_name", null: false
     t.index ["name"], name: "index_programming_languages_on_name", unique: true
@@ -380,8 +379,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_14_075029) do
     t.string "remote"
     t.string "path"
     t.integer "judge_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.integer "clone_status", default: 1, null: false
     t.index ["judge_id"], name: "index_repositories_on_judge_id"
     t.index ["name"], name: "index_repositories_on_name", unique: true
@@ -395,7 +394,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_14_075029) do
     t.index ["user_id"], name: "fk_rails_6b59ad362c"
   end
 
-  create_table "rights_requests", charset: "utf8mb4", force: :cascade do |t|
+  create_table "rights_requests", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.string "institution_name"
     t.text "context", null: false
@@ -404,7 +403,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_14_075029) do
     t.index ["user_id"], name: "index_rights_requests_on_user_id"
   end
 
-  create_table "saved_annotations", charset: "utf8mb4", force: :cascade do |t|
+  create_table "saved_annotations", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "title", null: false
     t.text "annotation_text", size: :medium
     t.integer "user_id", null: false
@@ -446,12 +445,12 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_14_075029) do
   create_table "series", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "course_id"
     t.string "name"
-    t.text "description", size: :medium
+    t.text "description", size: :long
     t.integer "visibility"
     t.integer "order", default: 0, null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.datetime "deadline"
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "deadline", precision: nil
     t.string "access_token"
     t.string "indianio_token"
     t.boolean "progress_enabled", default: true, null: false
@@ -470,8 +469,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_14_075029) do
     t.integer "series_id"
     t.integer "activity_id"
     t.integer "order", default: 999
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["activity_id"], name: "index_series_memberships_on_activity_id"
     t.index ["series_id", "activity_id"], name: "index_series_memberships_on_series_id_and_activity_id", unique: true
     t.index ["series_id"], name: "index_series_memberships_on_series_id"
@@ -481,8 +480,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_14_075029) do
     t.integer "exercise_id"
     t.integer "user_id"
     t.string "summary"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.integer "status"
     t.boolean "accepted", default: false
     t.integer "course_id"
@@ -490,6 +489,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_14_075029) do
     t.integer "number"
     t.index ["accepted"], name: "index_submissions_on_accepted"
     t.index ["course_id"], name: "index_submissions_on_course_id"
+    t.index ["exercise_id", "status", "course_id"], name: "ex_st_co_idx"
     t.index ["exercise_id", "user_id", "accepted", "created_at"], name: "ex_us_ac_cr_index"
     t.index ["exercise_id", "user_id", "status", "created_at"], name: "ex_us_st_cr_index"
     t.index ["exercise_id"], name: "index_submissions_on_exercise_id"
@@ -504,15 +504,15 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_14_075029) do
     t.string "last_name"
     t.string "email"
     t.integer "permission", default: 0
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.string "lang", default: "nl"
     t.string "token"
     t.string "time_zone", default: "Brussels"
     t.bigint "institution_id"
     t.string "search", limit: 4096
-    t.datetime "seen_at"
-    t.datetime "sign_in_at"
+    t.datetime "seen_at", precision: nil
+    t.datetime "sign_in_at", precision: nil
     t.index ["email", "institution_id"], name: "index_users_on_email_and_institution_id", unique: true
     t.index ["institution_id"], name: "index_users_on_institution_id"
     t.index ["token"], name: "index_users_on_token"

--- a/test/factories/courses.rb
+++ b/test/factories/courses.rb
@@ -8,9 +8,9 @@
 #  secret            :string(255)
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
-#  description       :text(16777215)
-#  visibility        :integer
-#  registration      :integer
+#  description       :text(4294967295)
+#  visibility        :integer          default("visible_for_all")
+#  registration      :integer          default("open_for_institutional_users")
 #  teacher           :string(255)
 #  institution_id    :bigint
 #  search            :string(4096)

--- a/test/factories/series.rb
+++ b/test/factories/series.rb
@@ -5,7 +5,7 @@
 #  id                       :integer          not null, primary key
 #  course_id                :integer
 #  name                     :string(255)
-#  description              :text(16777215)
+#  description              :text(4294967295)
 #  visibility               :integer
 #  order                    :integer          default(0), not null
 #  created_at               :datetime         not null

--- a/test/fixtures/courses.yml
+++ b/test/fixtures/courses.yml
@@ -8,9 +8,9 @@
 #  secret            :string(255)
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
-#  description       :text(16777215)
-#  visibility        :integer
-#  registration      :integer
+#  description       :text(4294967295)
+#  visibility        :integer          default("visible_for_all")
+#  registration      :integer          default("open_for_institutional_users")
 #  teacher           :string(255)
 #  institution_id    :bigint
 #  search            :string(4096)

--- a/test/models/course_test.rb
+++ b/test/models/course_test.rb
@@ -8,9 +8,9 @@
 #  secret            :string(255)
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
-#  description       :text(16777215)
-#  visibility        :integer
-#  registration      :integer
+#  description       :text(4294967295)
+#  visibility        :integer          default("visible_for_all")
+#  registration      :integer          default("open_for_institutional_users")
 #  teacher           :string(255)
 #  institution_id    :bigint
 #  search            :string(4096)

--- a/test/models/series_test.rb
+++ b/test/models/series_test.rb
@@ -5,7 +5,7 @@
 #  id                       :integer          not null, primary key
 #  course_id                :integer
 #  name                     :string(255)
-#  description              :text(16777215)
+#  description              :text(4294967295)
 #  visibility               :integer
 #  order                    :integer          default(0), not null
 #  created_at               :datetime         not null


### PR DESCRIPTION
This pull request is a third attempt to fix #3962. See #4167 and  #4169 for previous attempts.

This pull request contains two parts:
- A replacement of the old table preview. The new table preview has the correct height in all browser and also contains the activity name as requested by @niknetniko .
- A speed up of the progress bar load, to offset reduced speed by the new table.

## Analysis
To analyze the impact of these changes, I looked at two large courses. For fair comparison I disabled memcached and the sql query cache. 

### http://dodona.ugent.be/nl/courses/800/
102 series | 640 exercises | 488 users | 491.449 submissions

| Pr    | Total request time | Time in views | Time in Activerecord | Filesize |
|-------|--------------|---------------|----------------------|----------|
| Old   | 755ms        | 620.0ms       | 125.4ms              | 833KB    |
| #4167 | 2049ms       | 1780.3ms      | 228.3ms              |          |
| #4169 | 6947ms       | 2827.0ms      | 4101.8ms             |          |
| New   | 1049ms       | 838.6ms       | 200.3ms              | 990KB    |


### http://dodona.ugent.be/nl/courses/359/
22 series | 90 exercises | 623 users | 355.789 submissions

| Pr    | Total request time | Time in views | Time in Activerecord | Filesize |
|-------|--------------|---------------|----------------------|----------|
| Old   | 2006ms       | 394.3ms       | 1603.1ms             | 296 KB   |
| #4167 | 1931ms       | 463.9ms       | 1456.2ms             |          |
| #4169 | 1879ms       | 684.6ms       | 1182.8ms             |          |
| New   | 970ms        | 352.4ms       | 607.9ms              | 326.3KB  |

### Notes
The speed up is much less noticeable for the first course. This is due to the first two series of that course being exams in which few students participated. 
In the second course the speedup is much greater then the slowdown, caused by loading the activity names.

In order to limit the increase in file size, I tried to keep the amount of html for each row to a minimum.

## Visual
Old
![image](https://user-images.githubusercontent.com/21177904/202487015-9d5399c6-ad1c-41ae-ad9a-65d42f943406.png)

New
![image](https://user-images.githubusercontent.com/21177904/203263584-c805d3d5-4d9a-4d35-917f-a07ad57f82e8.png)

Closes #3962 .

PS: this pr also containes some changes to the generated database file.
This is probably caused by me having a backup of production on my machine.
I would keep these changes in as they reflect the state of the production database.
