### PR TITLE
Show teacher rights notification on public contact page

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -53,6 +53,7 @@ class PagesController < ApplicationController
 
   def contact
     @contact_form = ContactForm.new
+    @current_user = current_user
     @title = I18n.t('pages.contact.title')
   end
 

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -53,7 +53,6 @@ class PagesController < ApplicationController
 
   def contact
     @contact_form = ContactForm.new
-    @current_user = current_user
     @title = I18n.t('pages.contact.title')
   end
 

--- a/app/views/pages/contact.html.erb
+++ b/app/views/pages/contact.html.erb
@@ -11,12 +11,10 @@
           <p><%= t('.contact_p3_html') %></p>
         </div>
         <div class="col-lg-6">
-          <% if @current_user.nil? || policy(RightsRequest).create? %>
-            <div class="callout callout-info">
-              <h4><%= t('.rights_request_title') %></h4>
-              <%= t('.rights_request_redirect_html', url: new_rights_request_path) %>
-            </div>
-          <% end %>
+          <div class="callout callout-info">
+            <h4><%= t('.rights_request_title') %></h4>
+            <%= t('.rights_request_redirect_html', url: new_rights_request_path) %>
+          </div>
         </div>
       </div>
       <div class="card-supporting-text card-border">

--- a/app/views/pages/contact.html.erb
+++ b/app/views/pages/contact.html.erb
@@ -11,7 +11,7 @@
           <p><%= t('.contact_p3_html') %></p>
         </div>
         <div class="col-lg-6">
-          <% if policy(RightsRequest).new? %>
+          <% if @current_user.nil? || policy(RightsRequest).create? %>
             <div class="callout callout-info">
               <h4><%= t('.rights_request_title') %></h4>
               <%= t('.rights_request_redirect_html', url: new_rights_request_path) %>


### PR DESCRIPTION
This pull request shows the teacher rights notification also when not signed in. Hopefully this increases the amount of users that find the form on their own.

I removed the policy check, as that only checked if a user is present

