### PR TITLE
Add a custom captcha to the contact form

### DIFF
--- a/app/models/contact_form.rb
+++ b/app/models/contact_form.rb
@@ -3,7 +3,13 @@ class ContactForm < MailForm::Base
   attribute :email, validate: Devise.email_regexp
   attribute :subject, validate: true
   attribute :message, validate: true
+  attribute :human, validate: true
+  attribute :robot, validate: true
   attribute :dodona_user
+
+  validates :human, acceptance: true
+  # robot checkbox should not be accepted
+  validates :robot, inclusion: { in: %w[0] }
 
   def headers
     {

--- a/app/views/pages/contact.html.erb
+++ b/app/views/pages/contact.html.erb
@@ -38,6 +38,20 @@
             <div class="col-sm-8"><%= f.text_area :message, required: true, class: "form-control", rows: 8 %></div>
           </div>
 
+          <div class="field form-group row">
+            <div class="offset-sm-2 col-sm-8">
+              <%= f.check_box :human, class: "form-check-input" %>
+              <%= f.label t('.human'), :class => "form-check-label" %>
+            </div>
+          </div>
+
+          <div class="field form-group row">
+            <div class="offset-sm-2 col-sm-8">
+              <%= f.check_box :robot, class: "form-check-input" %>
+              <%= f.label t('.robot'), :class => "form-check-label" %>
+            </div>
+          </div>
+
           <% if Rails.env.production? || Rails.env.staging? %>
             <div class="form-group row">
               <div class="offset-sm-2 col-sm-8">

--- a/config/locales/views/pages/en.yml
+++ b/config/locales/views/pages/en.yml
@@ -60,6 +60,8 @@ en:
       rights_request_title: Teacher rights
       rights_request_redirect_html: Do you want to request teacher rights for your account? Please use <strong><a href="%{url}">this form</a></strong>.
       send: Send message
+      human: I am human
+      robot: I am a robot
     create_contact:
       mail_sent: "Your message has been sent. Thanks for getting in touch."
       captcha_failed: HCaptcha could not be verified; please try again.

--- a/config/locales/views/pages/nl.yml
+++ b/config/locales/views/pages/nl.yml
@@ -60,6 +60,8 @@ nl:
       rights_request_title: Lesgeversrechten
       rights_request_redirect_html: Wil je lesgeversrechten aanvragen voor je account? Gebruik dan <strong><a href="%{url}">dit formulier</a></strong>.
       send: Bericht verzenden
+      human: Ik ben een mens
+      robot: Ik ben een robot
     create_contact:
       captcha_failed: HCaptcha kon niet geverifieerd worden, probeer opnieuw.
       mail_sent: "Je bericht werd verstuurd. Bedankt om contact op te nemen."

--- a/test/controllers/pages_controller_test.rb
+++ b/test/controllers/pages_controller_test.rb
@@ -42,7 +42,9 @@ class PagesControllerTest < ActionDispatch::IntegrationTest
       name: 'Jan',
       email: 'Jan@UGent.BE',
       subject: '(╯°□°）╯︵ ┻━┻)',
-      message: '┬─┬ノ( º _ ºノ )'
+      message: '┬─┬ノ( º _ ºノ )',
+      human: '1',
+      robot: '0'
     }
     assert_changes 'ActionMailer::Base.deliveries.size', +1 do
       post create_contact_path(contact_form: contact_form)
@@ -55,12 +57,30 @@ class PagesControllerTest < ActionDispatch::IntegrationTest
       name: 'Jan',
       email: 'Jan@UGent.BE',
       subject: '(╯°□°）╯︵ ┻━┻)',
-      message: 'XEvil is annoying'
+      message: 'XEvil is annoying',
+      human: '1',
+      robot: '0'
     }
     assert_no_changes 'ActionMailer::Base.deliveries.size' do
       post create_contact_path(contact_form: contact_form)
     end
     assert_redirected_to root_url
+  end
+
+  test 'should not send email when robot' do
+    [%w[0 0], %w[0 1], %w[1 1]].each do |human, robot|
+      contact_form = {
+        name: 'Jan',
+        email: 'Jan@UGent.BE',
+        subject: '(╯°□°）╯︵ ┻━┻)',
+        message: '┬─┬ノ( º _ ºノ )',
+        human: human,
+        robot: robot
+      }
+      assert_no_changes 'ActionMailer::Base.deliveries.size' do
+        post create_contact_path(contact_form: contact_form)
+      end
+    end
   end
 
   test 'should get profile when logged in' do


### PR DESCRIPTION
This pull request adds a custom captcha. The goal is to receive less spam. The idea being that even though the captcha is simple, no one will actually create a custom captcha solver for Dodona.


![image](https://user-images.githubusercontent.com/21177904/203332593-e4f2c821-5331-43bc-9581-7012ac7d580a.png)
