### PR TITLE
Fix merge institutions when there are users with overlapping email addresses

### DIFF
--- a/app/models/institution.rb
+++ b/app/models/institution.rb
@@ -133,7 +133,8 @@ class Institution < ApplicationRecord
   end
 
   def merge_into(other)
-    errors.add(:merge, "has overlapping usernames. Run `bin/rake merge_institutions[#{id},#{other.id}]` on the server to solve this using an interactive script.") if other.users.exists?(username: users.pluck(:username))
+    errors.add(:merge, "has overlapping usernames. Run `RAILS_ENV=production bin/rake merge_institutions[#{id},#{other.id}]` on the server to solve this using an interactive script.") if other.users.exists?(username: users.pluck(:username))
+    errors.add(:merge, "has overlapping emails. Run `RAILS_ENV=production bin/rake merge_institutions[#{id},#{other.id}]` on the server to solve this using an interactive script.") if other.users.exists?(email: users.pluck(:email))
     errors.add(:merge, 'has link provider') if providers.any?(&:link?)
     return false if errors.any?
 

--- a/lib/tasks/merge_institutions.rb
+++ b/lib/tasks/merge_institutions.rb
@@ -38,7 +38,9 @@ class MergeInstitutions
     end
 
     i1.transaction do
-      if (overlap = i1.users.where(username: i2.users.pluck(:username)).count) > 0
+      overlapping_users = i1.users.where(username: i2.users.pluck(:username))
+                            .or(i1.users.where(email: i2.users.pluck(:email)))
+      if (overlap = overlapping_users.count) > 0
         @output.puts "There are #{overlap} overlapping users."
         @output.puts 'These users will be merged before the institution can be merged.'
 
@@ -50,8 +52,9 @@ class MergeInstitutions
         end
         return unless c == 'y'
 
-        i1.users.where(username: i2.users.pluck(:username)).each do |u1|
+        overlapping_users.each do |u1|
           u2 = i2.users.find { |u| u.username.downcase == u1.username.downcase }
+          u2 = i2.users.find { |u| u.email == u1.email } if u2.nil?
           next if u2.nil?
 
           @output.puts ''

--- a/test/tasks/merge_institutions_test.rb
+++ b/test/tasks/merge_institutions_test.rb
@@ -82,6 +82,20 @@ class MergeInstitutionsTest < ActiveSupport::TestCase
     assert User.exists?(u2.id)
   end
 
+  test 'The script should ask confirmation on overlapping emails' do
+    i1 = create :institution
+    i2 = create :institution
+    u1 = create :user, email: 'test@test.com', institution: i1
+    u2 = create :user, email: 'test@test.com', institution: i2
+
+    merge_institutions_interactive i1.id, i2.id, 'y', 'n'
+
+    assert Institution.exists?(i1.id)
+    assert Institution.exists?(i2.id)
+    assert User.exists?(u1.id)
+    assert User.exists?(u2.id)
+  end
+
   test 'The script should ignore non overlapping usernames' do
     i1 = create :institution
     i2 = create :institution
@@ -98,15 +112,17 @@ class MergeInstitutionsTest < ActiveSupport::TestCase
     assert_equal i2, u1.institution
   end
 
-  test 'The script should merge each overlapping username after confirmation' do
+  test 'The script should merge each overlapping username or email after confirmation' do
     i1 = create :institution
     i2 = create :institution
     overlapping_users_i1 = (1..5).map { |i| create :user, username: "test#{i}", institution: i1 }
+    overlapping_users_i1 += (1..3).map { |i| create :user, email: "test#{i}@test.com", institution: i1 }
     overlapping_users_i2 = (1..5).map { |i| create :user, username: "test#{i}", institution: i2 }
+    overlapping_users_i2 += (1..3).map { |i| create :user, email: "test#{i}@test.com", institution: i2 }
     unique_users_i1 = (1..5).map { |i| create :user, username: "foo#{i}", institution: i1 }
     unique_users_i2 = (1..5).map { |i| create :user, username: "bar#{i}", institution: i2 }
 
-    merge_institutions_interactive i1.id, i2.id, 'y', 'y', 'y', 'y', 'y', 'y', 'y'
+    merge_institutions_interactive i1.id, i2.id, 'y', 'y', 'y', 'y', 'y', 'y', 'y', 'y', 'y', 'y'
 
     assert_not Institution.exists?(i1.id)
     assert Institution.exists?(i2.id)
@@ -124,7 +140,9 @@ class MergeInstitutionsTest < ActiveSupport::TestCase
     i1 = create :institution
     i2 = create :institution
     overlapping_users_i1 = (1..5).map { |i| create :user, username: "test#{i}", institution: i1 }
+    overlapping_users_i1 += (1..3).map { |i| create :user, email: "test#{i}@test.com", institution: i1 }
     overlapping_users_i2 = (1..5).map { |i| create :user, username: "test#{i}", institution: i2 }
+    overlapping_users_i2 += (1..3).map { |i| create :user, email: "test#{i}@test.com", institution: i2 }
     unique_users_i1 = (1..5).map { |i| create :user, username: "foo#{i}", institution: i1 }
     unique_users_i2 = (1..5).map { |i| create :user, username: "bar#{i}", institution: i2 }
 


### PR DESCRIPTION
This pull request fixes merge institution.

It now throws a useful error instead of crashing when trying to merge institutions with overlapping emails in the browser.

It also suggest to merge these users before institution merge when running the command line script

This has been broken since #3981 
