### PR TITLE
Fix my_institution activities tab when not signed in

### DIFF
--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -124,7 +124,7 @@ class Activity < ApplicationRecord
       where(repository: Repository.has_admin(options[:user]))
         .or(where(repository: Repository.has_allowed_course(options[:course])))
     when :my_institution
-      joins(:repository).merge(Repository.owned_by_institution(options[:user].institution))
+      joins(:repository).merge(Repository.owned_by_institution(options[:user]&.institution))
     when :featured
       joins(:repository).merge(Repository.featured)
     else

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -56,7 +56,7 @@ class Repository < ApplicationRecord
 
   scope :has_allowed_course, ->(course) { joins(:course_repositories).where(course_repositories: { course_id: course&.id }) }
   scope :has_admin, ->(user) { joins(:repository_admins).where(repository_admins: { user_id: user&.id }) }
-  scope :owned_by_institution, ->(institution) { where(id: RepositoryAdmin.joins(:user).where(users: { institution_id: institution&.id }).group(:repository_id).select(:repository_id)) }
+  scope :owned_by_institution, ->(institution) { where(id: RepositoryAdmin.joins(:user).where(users: { institution_id: institution&.id }).where.not(users: { institution_id: nil }).group(:repository_id).select(:repository_id)) }
   scope :featured, -> { where(featured: true) }
 
   def full_path

--- a/test/models/activity_test.rb
+++ b/test/models/activity_test.rb
@@ -274,4 +274,10 @@ class ActivityTest < ActiveSupport::TestCase
     assert_not_includes Activity.repository_scope(scope: :featured), exercise
     assert_not_includes Activity.repository_scope(scope: :featured), content_page
   end
+
+  test 'repository scope my institution should return nothing if user has no institution or is nil' do
+    assert_not_empty Activity.all
+    assert_empty Activity.repository_scope(scope: :my_institution, user: nil)
+    assert_empty Activity.repository_scope(scope: :my_institution, user: create(:user, institution_id: nil))
+  end
 end


### PR DESCRIPTION
This pull request fixes a crash when the link contains the "my_institution" tab when not signed in.

- [x] Tests are added