### PR TITLE
Only show course from latest year on home page

### DIFF
--- a/app/assets/javascripts/components/standalone-dropdown-filter.ts
+++ b/app/assets/javascripts/components/standalone-dropdown-filter.ts
@@ -31,7 +31,7 @@ export class StandaloneDropdownFilter extends watchMixin(FilterCollectionElement
     };
 
     render(): TemplateResult {
-        if (this.labels.length === 0) {
+        if (this.labels.length <= 1) {
             return html``;
         }
 

--- a/app/assets/javascripts/components/standalone-dropdown-filter.ts
+++ b/app/assets/javascripts/components/standalone-dropdown-filter.ts
@@ -1,0 +1,53 @@
+import { customElement, property } from "lit/decorators.js";
+import { FilterCollectionElement, Label } from "components/filter_collection_element";
+import { html, TemplateResult } from "lit";
+import { watchMixin } from "components/watch_mixin";
+
+/**
+ * This component inherits from FilterCollectionElement.
+ * It represents a dropdown which allows to select one label, with the currently selected label shown as a button
+ *
+ * @element d-standalone-dropdown-filter
+ *
+ * @prop {string} param - the searchQuery param to be used for this filter
+ * @prop {string} default - the default value for the filter
+ * @prop {[Label]} labels - all labels that could potentially be selected
+ */
+@customElement("d-standalone-dropdown-filter")
+export class StandaloneDropdownFilter extends watchMixin(FilterCollectionElement) {
+    @property()
+    multi = false;
+    @property()
+    paramVal = (label: Label): string => label.id.toString();
+    @property({ type: String })
+    default;
+
+    watch = {
+        default: () => {
+            if (this.getSelectedLabels().length == 0) {
+                this.select(this.labels.find(label => label.id == this.default));
+            }
+        }
+    };
+
+    render(): TemplateResult {
+        if (this.labels.length === 0) {
+            return html``;
+        }
+
+        return html`
+            <div class="dropdown">
+                <a class="btn btn-text dropdown-toggle" href="#" role="button" id="dropdownMenuLink" data-bs-toggle="dropdown" aria-expanded="false">
+                    ${this.getSelectedLabels()[0].name}
+                    <i class="mdi mdi-chevron-down mdi-18 right-icon"></i>
+                </a>
+
+                <ul class="dropdown-menu" aria-labelledby="dropdownMenuLink">
+                    ${this.labels.map(s => html`
+                            <li><a class="dropdown-item ${this.isSelected(s) ? "active" : ""}" @click="${() => this.select(s)}">${s.name}</a> </li>
+                    `)}
+                </ul>
+            </div>
+        `;
+    }
+}

--- a/app/assets/javascripts/components/standalone-dropdown-filter.ts
+++ b/app/assets/javascripts/components/standalone-dropdown-filter.ts
@@ -42,7 +42,7 @@ export class StandaloneDropdownFilter extends watchMixin(FilterCollectionElement
                     <i class="mdi mdi-chevron-down mdi-18 right-icon"></i>
                 </a>
 
-                <ul class="dropdown-menu" aria-labelledby="dropdownMenuLink">
+                <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="dropdownMenuLink">
                     ${this.labels.map(s => html`
                             <li><a class="dropdown-item ${this.isSelected(s) ? "active" : ""}" @click="${() => this.select(s)}">${s.name}</a> </li>
                     `)}

--- a/app/assets/javascripts/components/standalone-dropdown-filter.ts
+++ b/app/assets/javascripts/components/standalone-dropdown-filter.ts
@@ -24,8 +24,8 @@ export class StandaloneDropdownFilter extends watchMixin(FilterCollectionElement
 
     watch = {
         default: () => {
-            if (this.getSelectedLabels().length == 0) {
-                this.select(this.labels.find(label => label.id == this.default));
+            if (this.getSelectedLabels().length === 0) {
+                this.select(this.labels.find(label => this.paramVal(label) === this.default));
             }
         }
     };

--- a/app/assets/javascripts/favorite_course_buttons.ts
+++ b/app/assets/javascripts/favorite_course_buttons.ts
@@ -32,8 +32,8 @@ function initFavoriteButtons(doc: Document | HTMLElement = document): void {
 
                 const card = getParentByClassName(element, "course card").parentElement;
                 const favoritesRow = document.querySelector(".favorites-row");
-                if (favoritesRow.children.length === 0) {
-                    document.querySelector(".page-subtitle.first").classList.remove("hidden");
+                if (favoritesRow.children.length === 1) {
+                    favoritesRow.querySelector(".page-subtitle").classList.remove("hidden");
                 }
                 // create clone of card to place up top on the favorites row
                 const clone = card.cloneNode(true) as HTMLElement;
@@ -70,8 +70,8 @@ function initFavoriteButtons(doc: Document | HTMLElement = document): void {
                 const card = getParentByClassName(course, "course card").parentElement;
                 card.remove();
                 const favoritesRow = document.querySelector(".favorites-row");
-                if (favoritesRow.children.length === 0) {
-                    document.querySelector(".page-subtitle.first").classList.add("hidden");
+                if (favoritesRow.children.length === 1) {
+                    favoritesRow.querySelector(".page-subtitle").classList.add("hidden");
                 }
             } else {
                 new Toast(I18n.t("js.unfavorite-course-failed"));

--- a/app/assets/javascripts/favorite_course_buttons.ts
+++ b/app/assets/javascripts/favorite_course_buttons.ts
@@ -1,9 +1,9 @@
 import { Toast } from "./toast";
 import { fetch, getParentByClassName } from "util.js";
 
-function initFavoriteButtons(): void {
+function initFavoriteButtons(doc: Document | HTMLElement = document): void {
     function init(): void {
-        document.querySelectorAll(".favorite-button")
+        doc.querySelectorAll(".favorite-button")
             .forEach(btn => btn.addEventListener("click", toggleFavorite));
     }
 

--- a/app/assets/javascripts/search.ts
+++ b/app/assets/javascripts/search.ts
@@ -180,7 +180,7 @@ export class SearchQuery {
         const url = this.addParametersToUrl();
         const localIndex = ++this.searchIndex;
 
-        document.getElementById("progress-filter").style.visibility = "visible";
+        this.updateProgressFilterVisibility("visible");
         fetch(updateURLParameter(url, "format", "js"), {
             headers: {
                 "accept": "text/javascript"
@@ -193,7 +193,7 @@ export class SearchQuery {
                     this.appliedIndex = localIndex;
                     eval(data);
                 }
-                document.getElementById("progress-filter").style.visibility = "hidden";
+                this.updateProgressFilterVisibility("hidden");
 
                 // if there is local storage key => update the value to reuse later
                 if (this.localStorageKey) {
@@ -201,6 +201,12 @@ export class SearchQuery {
                     localStorage.setItem(this.localStorageKey, urlObj.searchParams.toString());
                 }
             });
+    }
+
+    updateProgressFilterVisibility(state: string): void {
+        if (document.getElementById("progress-filter")) {
+            document.getElementById("progress-filter").style.visibility = state;
+        }
     }
 
     /**

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -17,7 +17,7 @@ class PagesController < ApplicationController
       courses = course_memberships.map(&:course)
       @years = courses.map(&:year).uniq.sort.reverse
       @year = params[:year] || @years.max
-      @courses = courses.select { |c| c.year === @year }
+      @courses = courses.select { |c| c.year == @year }
       @favorite_courses = course_memberships.select(&:favorite).map(&:course)
       @homepage_series = courses.map { |c| c.homepage_series(0) }.flatten.sort_by(&:deadline)
 

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -14,10 +14,11 @@ class PagesController < ApplicationController
       ActivityStatus.add_status_for_user_and_activities(current_user, @recent_exercises, [last_submission: [:course]])
 
       course_memberships = current_user.course_memberships.includes(course: %i[institution series]).select(&:subscribed?)
-      @subscribed_courses = course_memberships.map(&:course)
+      courses = course_memberships.map(&:course)
+      @year = params[:year] || courses.map(&:year).max
+      @courses = courses.select { |c| c.year == @year }
       @favorite_courses = course_memberships.select(&:favorite).map(&:course)
-      @grouped_courses = @subscribed_courses.sort_by(&:year).reverse.group_by(&:year)
-      @homepage_series = @subscribed_courses.map { |c| c.homepage_series(0) }.flatten.sort_by(&:deadline)
+      @homepage_series = courses.map { |c| c.homepage_series(0) }.flatten.sort_by(&:deadline)
 
       @jump_back_in = current_user.jump_back_in
     else

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -15,7 +15,8 @@ class PagesController < ApplicationController
 
       course_memberships = current_user.course_memberships.includes(course: %i[institution series]).select(&:subscribed?)
       courses = course_memberships.map(&:course)
-      @year = params[:year] || courses.map(&:year).max
+      @years = courses.map(&:year).uniq.sort.reverse
+      @year = params[:year] || @years.max
       @courses = courses.select { |c| c.year == @year }
       @favorite_courses = course_memberships.select(&:favorite).map(&:course)
       @homepage_series = courses.map { |c| c.homepage_series(0) }.flatten.sort_by(&:deadline)

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -17,7 +17,7 @@ class PagesController < ApplicationController
       courses = course_memberships.map(&:course)
       @years = courses.map(&:year).uniq.sort.reverse
       @year = params[:year] || @years.max
-      @courses = courses.select { |c| c.year == @year }
+      @courses = courses.select { |c| c.year === @year }
       @favorite_courses = course_memberships.select(&:favorite).map(&:course)
       @homepage_series = courses.map { |c| c.homepage_series(0) }.flatten.sort_by(&:deadline)
 

--- a/app/javascript/packs/application_pack.js
+++ b/app/javascript/packs/application_pack.js
@@ -37,6 +37,7 @@ import { initClipboard } from "copy";
 import { FaviconManager } from "favicon";
 import "components/saved_annotations/saved_annotation_list";
 import "components/saved_annotations/saved_annotations_sidecard";
+import "components/standalone-dropdown-filter";
 
 // Initialize clipboard.js
 initClipboard();

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -171,6 +171,8 @@ class Course < ApplicationRecord
         .or(where(id: user&.subscribed_courses&.pluck(:id)))
     end
   }
+  scope :by_year, ->(year) { where(year: year) }
+  scope :latest_year, -> { order(year: :desc).limit(1).pick(:year) }
   default_scope { order(year: :desc, name: :asc) }
 
   token_generator :secret, unique: false, length: 5

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -171,8 +171,6 @@ class Course < ApplicationRecord
         .or(where(id: user&.subscribed_courses&.pluck(:id)))
     end
   }
-  scope :by_year, ->(year) { where(year: year) }
-  scope :latest_year, -> { order(year: :desc).limit(1).pick(:year) }
   default_scope { order(year: :desc, name: :asc) }
 
   token_generator :secret, unique: false, length: 5

--- a/app/views/pages/_course_cards.html.erb
+++ b/app/views/pages/_course_cards.html.erb
@@ -1,0 +1,5 @@
+<% courses.each do |course| %>
+  <div class="col-12 col-sm-12 col-lg-6">
+    <%= render partial: "course_card", locals: {course: course, show_deadlines: true} %>
+  </div>
+<% end %>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -16,7 +16,7 @@
           <h3><%= t('.courses') %></h3>
           <d-standalone-dropdown-filter class="mt-2"
                                         param="year"
-                                        labels="<%= @years.map { |y| { id: y, name: y } }.to_json %>"
+                                        labels="<%= @years.map { |y| { id: y, name: Course.format_year(y) } }.to_json %>"
                                         default="<%= @year %>">
           </d-standalone-dropdown-filter>
         </div>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -21,19 +21,11 @@
           </d-standalone-dropdown-filter>
         </div>
         <% unless @favorite_courses.empty? %>
-          <% @favorite_courses.each do |course| %>
-            <div class="col-12 col-sm-12 col-lg-6">
-              <%= render partial: "course_card", locals: {course: course, show_deadlines: true} %>
-            </div>
-          <% end %>
+          <%= render partial: "course_cards", locals: {courses: @favorite_courses} %>
         <% end %>
       </div>
       <div class="row" id="course-for-year-row">
-        <% @courses.each do |course| %>
-          <div class="col-12 col-sm-12 col-lg-6">
-            <%= render partial: "course_card", locals: {course: course, show_deadlines: true} %>
-          </div>
-        <% end %>
+        <%= render partial: "course_cards", locals: {courses: @courses} %>
       </div>
     <% end %>
   </div>
@@ -56,5 +48,6 @@
 <script type="text/javascript">
     dodona.ready.then(function () {
         dodona.initFavoriteButtons();
+        dodona.searchQuery.autoSearch = true;
     });
 </script>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -4,7 +4,7 @@
 <%= render partial: "pages/important_homepage_links" %>
 <div class="row">
   <div class="col-12 col-md-6 col-lg-8">
-    <% if @subscribed_courses.empty? %>
+    <% if @courses.empty? %>
       <%= render "getting_started_card" %>
       <% if current_user.institutional? %>
         <%= render 'privacy_disclaimer' %>
@@ -23,28 +23,13 @@
           <% end %>
         <% end %>
       </div>
-      <% first = true %>
-      <% @grouped_courses.each do |year, courses| %>
-        <% if first %>
-          <% first = false %>
-          <div class="page-subtitle <%= "hidden" if @favorite_courses.empty? %>">
-            <a class="anchor" id="<%= year.parameterize %>"></a>
-            <h3><%= Course.format_year year %></h3>
-          </div>
-        <% else %>
-          <div class="page-subtitle">
-            <a class="anchor" id="<%= year.parameterize %>"></a>
-            <h3><%= Course.format_year year %></h3>
+      <div class="row">
+        <% @courses.each do |course| %>
+          <div class="col-12 col-sm-12 col-lg-6">
+            <%= render partial: "course_card", locals: {course: course, show_deadlines: true} %>
           </div>
         <% end %>
-        <div class="row row-<%= year.parameterize %>">
-          <% courses.each do |course| %>
-            <div class="col-12 col-sm-12 col-lg-6">
-              <%= render partial: "course_card", locals: {course: course, show_deadlines: true} %>
-            </div>
-          <% end %>
-        </div>
-      <% end %>
+      </div>
     <% end %>
   </div>
   <div class="col-12 col-md-6 col-lg-4">

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -11,7 +11,14 @@
       <% end %>
     <% else %>
       <div class="row favorites-row">
-
+        <div class="page-subtitle <%= @favorite_courses.empty? ? "hidden" : "" %>">
+          <h3><%= t('.favorites') %></h3>
+        </div>
+        <% unless @favorite_courses.empty? %>
+          <%= render partial: "course_cards", locals: {courses: @favorite_courses} %>
+        <% end %>
+      </div>
+      <div class="row">
         <div class="page-subtitle justify-content-between">
           <h3><%= t('.courses') %></h3>
           <d-standalone-dropdown-filter class="mt-2"
@@ -20,9 +27,6 @@
                                         default="<%= @year %>">
           </d-standalone-dropdown-filter>
         </div>
-        <% unless @favorite_courses.empty? %>
-          <%= render partial: "course_cards", locals: {courses: @favorite_courses} %>
-        <% end %>
       </div>
       <div class="row" id="course-for-year-row">
         <%= render partial: "course_cards", locals: {courses: @courses} %>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -12,8 +12,13 @@
     <% else %>
       <div class="row favorites-row">
 
-        <div class="page-subtitle first">
+        <div class="page-subtitle justify-content-between">
           <h3><%= t('.courses') %></h3>
+          <d-standalone-dropdown-filter class="mt-2"
+                                        param="year"
+                                        labels="<%= @years.map { |y| { id: y, name: y } }.to_json %>"
+                                        default="<%= @year %>">
+          </d-standalone-dropdown-filter>
         </div>
         <% unless @favorite_courses.empty? %>
           <% @favorite_courses.each do |course| %>
@@ -23,7 +28,7 @@
           <% end %>
         <% end %>
       </div>
-      <div class="row">
+      <div class="row" id="course-for-year-row">
         <% @courses.each do |course| %>
           <div class="col-12 col-sm-12 col-lg-6">
             <%= render partial: "course_card", locals: {course: course, show_deadlines: true} %>

--- a/app/views/pages/home.js.erb
+++ b/app/views/pages/home.js.erb
@@ -1,3 +1,4 @@
-document.getElementById("course-for-year-row").innerHTML = "<%= escape_javascript(render partial: 'course_cards', locals: {courses: @courses}) %>";
-dodona.initFavoriteButtons();
+let row = document.getElementById("course-for-year-row")
+row.innerHTML = "<%= escape_javascript(render partial: 'course_cards', locals: {courses: @courses}) %>";
+dodona.initFavoriteButtons(row);
 dodona.initTooltips();

--- a/app/views/pages/home.js.erb
+++ b/app/views/pages/home.js.erb
@@ -1,0 +1,4 @@
+let row = document.getElementById("course-for-year-row")
+row.innerHTML = "<%= escape_javascript(render partial: 'course_cards', locals: {courses: @courses}) %>";
+dodona.initFavoriteButtons(row);
+dodona.initTooltips();

--- a/app/views/pages/home.js.erb
+++ b/app/views/pages/home.js.erb
@@ -1,4 +1,3 @@
-let row = document.getElementById("course-for-year-row")
-row.innerHTML = "<%= escape_javascript(render partial: 'course_cards', locals: {courses: @courses}) %>";
-dodona.initFavoriteButtons(row);
+document.getElementById("course-for-year-row").innerHTML = "<%= escape_javascript(render partial: 'course_cards', locals: {courses: @courses}) %>";
+dodona.initFavoriteButtons();
 dodona.initTooltips();


### PR DESCRIPTION
This pull request removes old course cards from the home page, only showing the latest year. Using a dropdown it allows to cycle through previous years.

Favorited courses are always shown on top.
![image](https://user-images.githubusercontent.com/21177904/207885927-1fcdbc4c-0e06-40d8-9822-b71655bd0de4.png)

![image](https://user-images.githubusercontent.com/21177904/207885989-d4c5ad42-1b77-4175-a607-31180cce715b.png)

No dropdown is shown when there are less then two different years
![image](https://user-images.githubusercontent.com/21177904/207813851-d3ea043f-1086-498e-b8ab-04b97fb58920.png)


Part of #2882 