### PR TITLE
Always try to show three cards on homepage top

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -470,7 +470,8 @@ class User < ApplicationRecord
         submission: latest_submission,
         activity: latest_submission.exercise,
         series: latest_submission.series,
-        course: latest_submission.course
+        course: latest_submission.course,
+        text: I18n.t('pages.clickable_homepage_cards.last_submission')
       }
     end
 
@@ -482,18 +483,20 @@ class User < ApplicationRecord
           submission: nil,
           activity: next_activity,
           series: latest_submission.series,
-          course: latest_submission.course
+          course: latest_submission.course,
+          text: result.empty? ? I18n.t('pages.clickable_homepage_cards.next_exercise_success') : I18n.t('pages.clickable_homepage_cards.next_exercise')
         }
-      end
 
-      if latest_submission.series.next_activity(next_activity).present?
-        # there is another exercise after the next one, so show the series
-        result << {
-          submission: nil,
-          activity: nil,
-          series: latest_submission.series,
-          course: latest_submission.course
-        }
+        if latest_submission.series.next_activity(next_activity).present?
+          # there is another exercise after the next one, so show the series
+          result << {
+            submission: nil,
+            activity: nil,
+            series: latest_submission.series,
+            course: latest_submission.course,
+            text: I18n.t('pages.clickable_homepage_cards.continue_series')
+          }
+        end
       end
 
       next_series = latest_submission.series.next
@@ -503,7 +506,8 @@ class User < ApplicationRecord
           submission: nil,
           activity: nil,
           series: next_series,
-          course: latest_submission.course
+          course: latest_submission.course,
+          text: result.empty? ? I18n.t('pages.clickable_homepage_cards.next_series_success') : I18n.t('pages.clickable_homepage_cards.next_series')
         }
       end
     end
@@ -515,7 +519,8 @@ class User < ApplicationRecord
         submission: nil,
         activity: nil,
         series: nil,
-        course: latest_submission.course
+        course: latest_submission.course,
+        text: I18n.t('pages.clickable_homepage_cards.course')
       }
     end
     result

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -512,7 +512,6 @@ class User < ApplicationRecord
       end
     end
 
-
     if latest_submission.course.present?
       # continue working on this course
       result << {

--- a/app/views/pages/_important_homepage_links.html.erb
+++ b/app/views/pages/_important_homepage_links.html.erb
@@ -1,23 +1,35 @@
+<%
+  no_deadlines = [@homepage_series.count, 2].min
+  no_jbi = [@jump_back_in.count, 3 - no_deadlines].min
+  no_deadlines = [@homepage_series.count, 3].min if no_jbi == 0
+%>
+
 <div class="row">
   <% if @jump_back_in.present? %>
-  <div class="col-lg-4 ">
-    <h4><%= t ".jump_back_in" %></h4>
-    <% if @jump_back_in[:activity].present? %>
-      <%= render partial: 'pages/clickable_homepage_cards/activity', locals: @jump_back_in %>
-    <% elsif @jump_back_in[:series].present? %>
-      <%= render partial: 'pages/clickable_homepage_cards/series', locals: @jump_back_in %>
-    <% else %>
-      <%= render partial: 'pages/clickable_homepage_cards/course', locals: @jump_back_in %>
-    <% end %>
-  </div>
+    <div class="col-lg-<%= no_jbi * 4%> ">
+      <h4><%= t ".jump_back_in" %></h4>
+      <div class="row">
+        <% @jump_back_in.first(no_jbi).each do |card| %>
+          <div class="col-lg-<%= 12 / no_jbi %>">
+            <% if card[:activity].present? %>
+              <%= render partial: 'pages/clickable_homepage_cards/activity', locals: card %>
+            <% elsif card[:series].present? %>
+              <%= render partial: 'pages/clickable_homepage_cards/series', locals: card %>
+            <% else %>
+              <%= render partial: 'pages/clickable_homepage_cards/course', locals: card %>
+            <% end %>
+          </div>
+        <% end %>
+      </div>
+    </div>
   <% end %>
   <% if @homepage_series.present? %>
-    <div class="col-lg-8">
+    <div class="col-lg-<%= no_deadlines * 4%>">
       <h4><%= t '.upcoming_deadlines' %></h4>
       <div class="row">
-        <% @homepage_series.first(2).each do |series| %>
-          <div class="col-lg-6">
-            <%= render partial: 'pages/clickable_homepage_cards/series', locals: {series: series, show_progress: true} %>
+        <% @homepage_series.first(no_deadlines).each do |series| %>
+          <div class="col-lg-<%= 12 / no_deadlines %>">
+            <%= render partial: 'pages/clickable_homepage_cards/series', locals: { series: series, show_progress: true } %>
           </div>
         <% end %>
       </div>

--- a/app/views/pages/_important_homepage_links.html.erb
+++ b/app/views/pages/_important_homepage_links.html.erb
@@ -29,7 +29,7 @@
       <div class="row">
         <% @homepage_series.first(no_deadlines).each do |series| %>
           <div class="col-lg-<%= 12 / no_deadlines %>">
-            <%= render partial: 'pages/clickable_homepage_cards/series', locals: { series: series, show_progress: true } %>
+            <%= render partial: 'pages/clickable_homepage_cards/series', locals: { series: series } %>
           </div>
         <% end %>
       </div>

--- a/app/views/pages/clickable_homepage_cards/_activity.html.erb
+++ b/app/views/pages/clickable_homepage_cards/_activity.html.erb
@@ -32,11 +32,7 @@
     </div>
 
     <small class="ellipsis-overflow">
-        <% if submission.present? %>
-            <%= t ".jump_back_in_info" %>
-        <% else %>
-            <%= t ".jump_back_in_info_success" %>
-        <% end %>
+      <%= text %>
     </small>
   </div>
 <% end %>

--- a/app/views/pages/clickable_homepage_cards/_course.html.erb
+++ b/app/views/pages/clickable_homepage_cards/_course.html.erb
@@ -14,7 +14,7 @@
     </div>
 
     <small class="ellipsis-overflow">
-      <%= t ".jump_back_in_info" %>
+      <%= text %>
     </small>
   </div>
 <% end %>

--- a/app/views/pages/clickable_homepage_cards/_series.html.erb
+++ b/app/views/pages/clickable_homepage_cards/_series.html.erb
@@ -1,4 +1,4 @@
-<% show_progress ||= false %>
+<% text ||= false %>
 <% card_class = nil
    card_class = series.completed_before_deadline?(current_user) ? "colored-success" : "colored-danger" if series.deadline.present? %>
 <%= link_to course_path(series.course, series: series, anchor: series.anchor) do %>
@@ -25,7 +25,7 @@
         </div>
       </h4>
     </div>
-    <% if show_progress %>
+    <% unless text %>
       <%= render partial: 'progress_chart', locals: {
         total: series.activity_count,
         tried: series.started_activity_count(current_user),
@@ -37,7 +37,7 @@
       } %>
     <% else %>
         <small class="ellipsis-overflow">
-            <%= t ".jump_back_in_info" %>
+            <%= text %>
         </small>
     <% end %>
   </div>

--- a/config/locales/views/pages/en.yml
+++ b/config/locales/views/pages/en.yml
@@ -32,13 +32,14 @@ en:
       jump_back_in: Jump back in
       upcoming_deadlines: Upcoming deadlines
     clickable_homepage_cards:
-      course:
-        jump_back_in_info: "Continue working on this course."
-      activity:
-        jump_back_in_info: "Continue working on this exercise."
-        jump_back_in_info_success: "You solved the previous exercise. Start this one!"
+      last_submission: "Continue working on this exercise."
+      next_exercise_success: "You solved the previous exercise. Start this one!"
+      next_exercise: "Or start the next exercise."
+      continue_series: "Continue working on this series."
+      next_series_success: "You solved the previous series. Start this one!"
+      next_series: "Or start the next series."
+      course: "Continue working on this course."
       series:
-        jump_back_in_info: "You finished the previous series. Start this one!"
         progress_chart_info_correct:
           one: "One exercise solved correctly."
           other: "%{count} exercises solved correctly."

--- a/config/locales/views/pages/nl.yml
+++ b/config/locales/views/pages/nl.yml
@@ -32,11 +32,14 @@ nl:
       jump_back_in: Ga verder
       upcoming_deadlines: Aankomende deadlines
     clickable_homepage_cards:
-      course:
-        jump_back_in_info: "Werk verder aan deze cursus."
-      activity:
-        jump_back_in_info: "Werk verder aan deze oefening."
-        jump_back_in_info_success: "De vorige oefening was correct, start met deze oefening."
+      last_submission: "Werk verder aan deze oefening."
+      next_exercise_success: "De vorige oefening was correct, start met deze oefening."
+      next_exercise: "Of start met de volgende oefening."
+      continue_series: "Werk verder aan deze reeks."
+      next_series_success: "De vorige reeks was correct, start met deze reeks."
+      next_series: "Of start met de volgende reeks."
+      course: "Werk verder aan deze cursus."
+
       series:
         jump_back_in_info: "Je hebt de vorige reeks afgewerkt, start met deze reeks."
         progress_chart_info_correct:

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -811,10 +811,10 @@ class UserHasManyTest < ActiveSupport::TestCase
 
     submission = create :wrong_submission, user: user
 
-    assert_equal submission, user.jump_back_in[:submission]
-    assert_equal submission.exercise, user.jump_back_in[:activity]
-    assert_nil user.jump_back_in[:course]
-    assert_nil user.jump_back_in[:series]
+    assert_equal submission, user.jump_back_in.first[:submission]
+    assert_equal submission.exercise, user.jump_back_in.first[:activity]
+    assert_nil user.jump_back_in.first[:course]
+    assert_nil user.jump_back_in.first[:series]
   end
 
   test 'jump back in should return most recent incomplete activity with series and course context' do
@@ -825,10 +825,10 @@ class UserHasManyTest < ActiveSupport::TestCase
     series.exercises << create(:exercise)
     submission = create :wrong_submission, user: user, course: course, exercise: course.series.first.exercises.first
 
-    assert_equal submission, user.jump_back_in[:submission]
-    assert_equal submission.exercise, user.jump_back_in[:activity]
-    assert_equal course, user.jump_back_in[:course]
-    assert_equal series, user.jump_back_in[:series]
+    assert_equal submission, user.jump_back_in.first[:submission]
+    assert_equal submission.exercise, user.jump_back_in.first[:activity]
+    assert_equal course, user.jump_back_in.first[:course]
+    assert_equal series, user.jump_back_in.first[:series]
   end
 
   test 'jump back in should return next activity if most recent activity was complete' do
@@ -842,10 +842,10 @@ class UserHasManyTest < ActiveSupport::TestCase
     series.exercises << a2
     create :correct_submission, user: user, course: course, exercise: a1
 
-    assert_nil user.jump_back_in[:submission]
-    assert_equal a2, user.jump_back_in[:activity]
-    assert_equal course, user.jump_back_in[:course]
-    assert_equal series, user.jump_back_in[:series]
+    assert_nil user.jump_back_in.first[:submission]
+    assert_equal a2, user.jump_back_in.first[:activity]
+    assert_equal course, user.jump_back_in.first[:course]
+    assert_equal series, user.jump_back_in.first[:series]
   end
 
   test 'jump back in should return next series if most recent activity was complete and it was the last in the series' do
@@ -860,10 +860,10 @@ class UserHasManyTest < ActiveSupport::TestCase
     series1.exercises << a2
     create :correct_submission, user: user, course: course, exercise: a2
 
-    assert_nil user.jump_back_in[:submission]
-    assert_nil user.jump_back_in[:activity]
-    assert_equal course, user.jump_back_in[:course]
-    assert_equal series2, user.jump_back_in[:series]
+    assert_nil user.jump_back_in.first[:submission]
+    assert_nil user.jump_back_in.first[:activity]
+    assert_equal course, user.jump_back_in.first[:course]
+    assert_equal series2, user.jump_back_in.first[:series]
   end
 
   test 'jump back in should return the course if most recent activity was complete and it was the last in the series and course' do
@@ -877,10 +877,10 @@ class UserHasManyTest < ActiveSupport::TestCase
     series.exercises << a2
     create :correct_submission, user: user, course: course, exercise: a2
 
-    assert_nil user.jump_back_in[:submission]
-    assert_nil user.jump_back_in[:activity]
-    assert_nil user.jump_back_in[:series]
-    assert_equal course, user.jump_back_in[:course]
+    assert_nil user.jump_back_in.first[:submission]
+    assert_nil user.jump_back_in.first[:activity]
+    assert_nil user.jump_back_in.first[:series]
+    assert_equal course, user.jump_back_in.first[:course]
   end
 
   test 'jump back in should return the course if most recent activity was complete and the submission has no series' do
@@ -890,19 +890,19 @@ class UserHasManyTest < ActiveSupport::TestCase
     a1 = create :exercise
     create :correct_submission, user: user, course: course, exercise: a1
 
-    assert_nil user.jump_back_in[:submission]
-    assert_nil user.jump_back_in[:activity]
-    assert_nil user.jump_back_in[:series]
-    assert_equal course, user.jump_back_in[:course]
+    assert_nil user.jump_back_in.first[:submission]
+    assert_nil user.jump_back_in.first[:activity]
+    assert_nil user.jump_back_in.first[:series]
+    assert_equal course, user.jump_back_in.first[:course]
   end
 
-  test 'jump back in should return nil if most recent activity was complete and the submission has no course' do
+  test 'jump back in should return empty if most recent activity was complete and the submission has no course' do
     user = create :user
 
     a1 = create :exercise
     create :correct_submission, user: user, exercise: a1
 
-    assert_nil user.jump_back_in
+    assert_empty user.jump_back_in
   end
 
   test 'jump back in should only return series the user has access to' do
@@ -915,16 +915,16 @@ class UserHasManyTest < ActiveSupport::TestCase
 
     course.series.second.update(visibility: :hidden)
 
-    assert_nil user.jump_back_in[:submission]
-    assert_nil user.jump_back_in[:activity]
-    assert_equal course, user.jump_back_in[:course]
-    assert_nil user.jump_back_in[:series]
+    assert_nil user.jump_back_in.first[:submission]
+    assert_nil user.jump_back_in.first[:activity]
+    assert_equal course, user.jump_back_in.first[:course]
+    assert_nil user.jump_back_in.first[:series]
 
     course.series.second.update(visibility: :closed)
-    assert_nil user.jump_back_in[:series]
+    assert_nil user.jump_back_in.first[:series]
 
     course.series.second.update(visibility: :open)
-    assert_equal course.series.second, user.jump_back_in[:series]
+    assert_equal course.series.second, user.jump_back_in.first[:series]
 
     CourseMembership.create user: user, course: course, status: :course_admin
 
@@ -933,12 +933,12 @@ class UserHasManyTest < ActiveSupport::TestCase
     assert user.course_admin?(course)
 
     course.series.second.update(visibility: :hidden)
-    assert_equal course.series.second, user.jump_back_in[:series]
+    assert_equal course.series.second, user.jump_back_in.first[:series]
 
     course.series.second.update(visibility: :closed)
-    assert_equal course.series.second, user.jump_back_in[:series]
+    assert_equal course.series.second, user.jump_back_in.first[:series]
 
     course.series.second.update(visibility: :open)
-    assert_equal course.series.second, user.jump_back_in[:series]
+    assert_equal course.series.second, user.jump_back_in.first[:series]
   end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -815,6 +815,8 @@ class UserHasManyTest < ActiveSupport::TestCase
     assert_equal submission.exercise, user.jump_back_in.first[:activity]
     assert_nil user.jump_back_in.first[:course]
     assert_nil user.jump_back_in.first[:series]
+
+    assert_equal 1, user.jump_back_in.count
   end
 
   test 'jump back in should return most recent incomplete activity with series and course context' do
@@ -823,12 +825,38 @@ class UserHasManyTest < ActiveSupport::TestCase
     course = create :course, series_count: 2
     series = course.series.first
     series.exercises << create(:exercise)
+    series.exercises << create(:exercise)
+    series.exercises << create(:exercise)
     submission = create :wrong_submission, user: user, course: course, exercise: course.series.first.exercises.first
 
     assert_equal submission, user.jump_back_in.first[:submission]
     assert_equal submission.exercise, user.jump_back_in.first[:activity]
-    assert_equal course, user.jump_back_in.first[:course]
     assert_equal series, user.jump_back_in.first[:series]
+    assert_equal course, user.jump_back_in.first[:course]
+
+    assert_equal 5, user.jump_back_in.count
+
+    # second should be next activity in series
+    assert_nil user.jump_back_in.second[:submission]
+    assert_equal series.exercises.second, user.jump_back_in.second[:activity]
+    assert_equal series, user.jump_back_in.second[:series]
+    assert_equal course, user.jump_back_in.second[:course]
+
+    # third should be this series
+    assert_nil user.jump_back_in.third[:submission]
+    assert_nil user.jump_back_in.third[:activity]
+    assert_equal series, user.jump_back_in.third[:series]
+    assert_equal course, user.jump_back_in.third[:course]
+
+    assert_nil user.jump_back_in.fourth[:submission]
+    assert_nil user.jump_back_in.fourth[:activity]
+    assert_equal course.series.second, user.jump_back_in.fourth[:series]
+    assert_equal course, user.jump_back_in.fourth[:course]
+
+    assert_nil user.jump_back_in.fifth[:submission]
+    assert_nil user.jump_back_in.fifth[:activity]
+    assert_nil user.jump_back_in.fifth[:series]
+    assert_equal course, user.jump_back_in.fifth[:course]
   end
 
   test 'jump back in should return next activity if most recent activity was complete' do
@@ -846,6 +874,18 @@ class UserHasManyTest < ActiveSupport::TestCase
     assert_equal a2, user.jump_back_in.first[:activity]
     assert_equal course, user.jump_back_in.first[:course]
     assert_equal series, user.jump_back_in.first[:series]
+
+    assert_equal 3, user.jump_back_in.count
+
+    assert_nil user.jump_back_in.second[:submission]
+    assert_nil user.jump_back_in.second[:activity]
+    assert_equal course.series.second, user.jump_back_in.second[:series]
+    assert_equal course, user.jump_back_in.second[:course]
+
+    assert_nil user.jump_back_in.third[:submission]
+    assert_nil user.jump_back_in.third[:activity]
+    assert_nil user.jump_back_in.third[:series]
+    assert_equal course, user.jump_back_in.third[:course]
   end
 
   test 'jump back in should return next series if most recent activity was complete and it was the last in the series' do
@@ -864,6 +904,13 @@ class UserHasManyTest < ActiveSupport::TestCase
     assert_nil user.jump_back_in.first[:activity]
     assert_equal course, user.jump_back_in.first[:course]
     assert_equal series2, user.jump_back_in.first[:series]
+
+    assert_equal 2, user.jump_back_in.count
+
+    assert_nil user.jump_back_in.second[:submission]
+    assert_nil user.jump_back_in.second[:activity]
+    assert_nil user.jump_back_in.second[:series]
+    assert_equal course, user.jump_back_in.second[:course]
   end
 
   test 'jump back in should return the course if most recent activity was complete and it was the last in the series and course' do
@@ -881,6 +928,8 @@ class UserHasManyTest < ActiveSupport::TestCase
     assert_nil user.jump_back_in.first[:activity]
     assert_nil user.jump_back_in.first[:series]
     assert_equal course, user.jump_back_in.first[:course]
+
+    assert_equal 1, user.jump_back_in.count
   end
 
   test 'jump back in should return the course if most recent activity was complete and the submission has no series' do
@@ -894,6 +943,8 @@ class UserHasManyTest < ActiveSupport::TestCase
     assert_nil user.jump_back_in.first[:activity]
     assert_nil user.jump_back_in.first[:series]
     assert_equal course, user.jump_back_in.first[:course]
+
+    assert_equal 1, user.jump_back_in.count
   end
 
   test 'jump back in should return empty if most recent activity was complete and the submission has no course' do


### PR DESCRIPTION
This pull request adds extra jump back in cards in an attempt to fill the top row of cards more often.
If enough deadlines and jump back in options are available, the division will still be 1/2 of each respectively.
But each kind of card can fill up to three spots if less of the other kind are available.

Jump back in will display up to the first three of the following list in order:
- last worked on exercise (if incorrect)
- the next exercise (in the same series)
- The series of this exercise (If there is more than 1 exercise after the current exercise in this series)
- The next series (if exists)
- The course of the exercise (if exists)

![image](https://user-images.githubusercontent.com/21177904/207870145-ff8a4aa8-00bf-4055-9a19-227c42f9e68f.png)
![image](https://user-images.githubusercontent.com/21177904/207870352-1b3f3a94-e819-4fae-ae8d-c3c25b2d34ef.png)
![image](https://user-images.githubusercontent.com/21177904/207871017-12c939bd-6358-474a-8a93-c301e5d2965e.png)
![image](https://user-images.githubusercontent.com/21177904/207874177-af5771f5-bfda-4d47-8834-d3f95ec0be29.png)

<!-- If there are visual changes, add a screenshot -->

- [x] Tests were added

Part of #2882 
