### PR TITLE
Make sure activity statuses always exist

### DIFF
--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -192,6 +192,7 @@ class Series < ApplicationRecord
 
   def invalidate_activity_statuses
     ActivityStatus.delete_by(series: self)
+    series_memberships.each(&:add_activity_statuses_delayed)
   end
 
   def invalidate_caches(user)

--- a/app/models/series_membership.rb
+++ b/app/models/series_membership.rb
@@ -20,9 +20,26 @@ class SeriesMembership < ApplicationRecord
 
   validates :series_id, uniqueness: { scope: :activity_id }
   after_create :invalidate_caches
+  after_create :add_activity_statuses_delayed
   after_destroy :invalidate_caches
   after_destroy :invalidate_status
   after_destroy :regenerate_activity_token
+
+  def add_activity_statuses_delayed
+    delay(queue: :statistics).add_activity_statuses
+  end
+
+  def add_activity_statuses
+    if activity.is_a? Exercise
+      activity.submissions.where(course: series.course).distinct(:user_id).find_each do |submission|
+        ActivityStatus.create(series: series, activity: activity, user: submission.user)
+      end
+    else
+      activity.activity_read_states.where(course: series.course).distinct(:user_id).find_each do |ars|
+        ActivityStatus.create(series: series, activity: activity, user: ars.user)
+      end
+    end
+  end
 
   def invalidate_caches
     course.invalidate_activities_count_cache

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -67,7 +67,7 @@ Rails.application.configure do
   # Annotate rendered view with file names.
   # config.action_view.annotate_rendered_view_with_filenames = true
 
-  Delayed::Worker.delay_jobs = ->(job) { !%w[default exports git].include?(job.queue) }
+  Delayed::Worker.delay_jobs = ->(job) { !%w[default exports git statistics].include?(job.queue) }
 
   config.submissions_storage_path = Rails.root.join('tmp/data/storage/submissions')
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -640,5 +640,10 @@ if Rails.env.development?
     RightsRequest.create(user: s, context: Faker::Lorem.paragraph(sentence_count: 10))
   end
 
+  puts "Create activity statuses (#{Time.now - start})"
+  # We do these all at once, because we disabled the callbacks earlier
+  # This is a lot faster than doing it one by one after each submission
+  SeriesMembership.find_each(&:add_activity_statuses)
+
   puts "Finished! (#{Time.now - start})"
 end

--- a/test/models/activity_status_test.rb
+++ b/test/models/activity_status_test.rb
@@ -47,4 +47,63 @@ class ActivityStatusTest < ActiveSupport::TestCase
     ActivityStatus.create(user: user, activity: activity, series: nil)
     assert_equal 1, ActivityStatus.count
   end
+
+  test 'activity status should always exist if a user has a submission' do
+    user = users(:student)
+    course = courses(:course1)
+    series = create :series, course: course, exercise_count: 1
+    activity = series.activities.first
+    create :submission, exercise: activity, course: course, status: :correct, user: user
+    assert_not_nil ActivityStatus.find_by(user: user, activity: activity, series: series)
+    assert_not_nil ActivityStatus.find_by(user: user, activity: activity, series: nil)
+  end
+
+  test 'activity status should always exist if a user has a activity read state' do
+    user = users(:student)
+    course = courses(:course1)
+    series = create :series, course: course, content_page_count: 1
+    activity = series.activities.first
+    create :activity_read_state, activity: activity, course: course, user: user
+    assert_not_nil ActivityStatus.find_by(user: user, activity: activity, series: series)
+    assert_not_nil ActivityStatus.find_by(user: user, activity: activity, series: nil)
+  end
+
+  test 'Activity status should be destroyed when series membership is destroyed' do
+    user = users(:student)
+    course = courses(:course1)
+    series = create :series, course: course, content_page_count: 1
+    activity = series.activities.first
+    create :activity_read_state, activity: activity, course: course, user: user
+    assert_not_nil ActivityStatus.find_by(user: user, activity: activity, series: series)
+    assert_not_nil ActivityStatus.find_by(user: user, activity: activity, series: nil)
+    SeriesMembership.find_by(series: series, activity: activity).destroy
+    assert_nil ActivityStatus.find_by(user: user, activity: activity, series: series)
+    assert_not_nil ActivityStatus.find_by(user: user, activity: activity, series: nil)
+  end
+
+  test 'Activity status should be created when series membership is created' do
+    user = users(:student)
+    course = courses(:course1)
+    series = create :series, course: course, content_page_count: 1
+    series2 = create :series, course: course
+    activity = series.activities.first
+    create :activity_read_state, activity: activity, course: course, user: user
+    assert_nil ActivityStatus.find_by(user: user, activity: activity, series: series2)
+    SeriesMembership.create(series: series2, activity: activity)
+    assert_not_nil ActivityStatus.find_by(user: user, activity: activity, series: series2)
+  end
+
+  test 'Activity status should be updated when series deadline is updated' do
+    user = users(:student)
+    course = courses(:course1)
+    series = create :series, course: course, content_page_count: 1, deadline: 1.week.from_now
+    activity = series.activities.first
+    create :activity_read_state, activity: activity, course: course, user: user
+    assert_not_nil ActivityStatus.find_by(user: user, activity: activity, series: series)
+    assert ActivityStatus.find_by(user: user, activity: activity, series: series).accepted_before_deadline
+    series.deadline = Time.now - 1.week
+    series.save
+    assert_not_nil ActivityStatus.find_by(user: user, activity: activity, series: series)
+    assert_not ActivityStatus.find_by(user: user, activity: activity, series: series).accepted_before_deadline
+  end
 end

--- a/test/models/activity_status_test.rb
+++ b/test/models/activity_status_test.rb
@@ -101,7 +101,7 @@ class ActivityStatusTest < ActiveSupport::TestCase
     create :activity_read_state, activity: activity, course: course, user: user
     assert_not_nil ActivityStatus.find_by(user: user, activity: activity, series: series)
     assert ActivityStatus.find_by(user: user, activity: activity, series: series).accepted_before_deadline
-    series.deadline = Time.now - 1.week
+    series.deadline = 1.week.ago
     series.save
     assert_not_nil ActivityStatus.find_by(user: user, activity: activity, series: series)
     assert_not ActivityStatus.find_by(user: user, activity: activity, series: series).accepted_before_deadline


### PR DESCRIPTION
This pull request makes sure Activity statuses are always present. This is necessary for fast computation of #4247 and #4261.

I found 2 case where Activity statuses didn't exist: After an activity was added to a series or after a series deadline was changed.
Both now start a delayed job to update the activity statuses.

This code was previously in #4247, but I split it of, as this has to be rolled out first.

After the roll out we will also have to run the following code to make sure an activity status exists for all current submissions:
```ruby
# We currently only need activity statusses within a course, making this enough
# Also activity statusses outside a course are never removed, so should exist since the introduction of the table
SeriesMembership.reorder(id: :asc).find_each(&:add_activity_statuses)

# safer but slower method to cover all cases
Submission.reorder(id: :asc).find_each { |s| s.exercise.activity_statuses_for(s.user, s.course) }
ActivityReadState.reorder(id: :asc).find_each { |s| s.activity.activity_statuses_for(s.user, s.course) }
```

- [x] Tests were added
