### PR TITLE
Prevent updating of datalist value when no initial filter was set

### DIFF
--- a/app/assets/javascripts/components/datalist_input.ts
+++ b/app/assets/javascripts/components/datalist_input.ts
@@ -32,20 +32,27 @@ export class DatalistInput extends watchMixin(ShadowlessLitElement) {
     @property({ type: String })
     value: string;
     @property({ type: String })
-    filter: string = this.label;
-    @property({ type: String })
     placeholder: string;
 
     inputRef: Ref<HTMLInputElement> = createRef();
 
+    _filter= this.label;
+
+    @property({ type: String })
+    get filter(): string {
+        return this._filter;
+    }
+
+    set filter(value: string) {
+        this._filter = value;
+        this.value = this.options.find(o => this.filter === o.label)?.value || "";
+        this.fireEvent();
+    }
+
     watch = {
-        filter: () => {
-            this.value = this.options.find(o => this.filter === o.label)?.value || "";
-            this.fireEvent();
-        },
         options: () => {
             if (!this.filter) {
-                this.filter = this.label;
+                this._filter = this.label;
             }
 
             // If we can find a result amongst the filtered options
@@ -103,13 +110,11 @@ export class DatalistInput extends watchMixin(ShadowlessLitElement) {
     select(option: Option, e: Event): void {
         e.preventDefault();
         e.stopPropagation();
-        this.value = option.value;
         this.filter = option.label;
     }
 
     processInput(e): void {
         const input = this.inputRef.value.value;
-        this.value = "";
         this.filter = input;
         e.stopPropagation();
     }


### PR DESCRIPTION
This pull request fixes a bug in the datalist input component.

I was actually searching for this issue https://github.com/dodona-edu/dodona/discussions/4064#discussioncomment-4105228 but this seem to already have been fixed by #4023 or  #4083

#4023 caused a new issue that cleared the saved annotation text when edditing an existing saved annotation.
This was caused by the initialization of filter: `filter: string = this.label;` with the options not yet present (Due to them being loaded in the background). This in turn triggered setting `value` equal to "", which caused `this.label` to still return nothing even when the options were loaded.

This issue is now solved by this pr.
