### PR TITLE
Revert mail gem to 2.7.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -82,6 +82,9 @@ gem 'jwt', '~> 2.6.0'
 gem 'hcaptcha', '~> 7.1.0'
 gem 'mail_form', '~> 1.9.0'
 
+# set fixed to keep an old version until https://github.com/mikel/mail/issues/1538 is fixed
+gem 'mail', '~> 2.7.1'
+
 # authorization
 gem 'pundit', '~> 2.3.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -238,11 +238,8 @@ GEM
     loofah (2.19.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
-    mail (2.8.0)
+    mail (2.7.1)
       mini_mime (>= 0.1.1)
-      net-imap
-      net-pop
-      net-smtp
     mail_form (1.9.0)
       actionmailer (>= 5.2)
       activemodel (>= 5.2)
@@ -536,6 +533,7 @@ DEPENDENCIES
   kramdown-parser-gfm (~> 1.1.0)
   letter_opener (~> 1.8.1)
   listen (~> 3.7.1)
+  mail (~> 2.7.1)
   mail_form (~> 1.9.0)
   memory_profiler (~> 1.0.1)
   minitest-ci (~> 3.4.0)


### PR DESCRIPTION
This pull request reverts the mail gem to version 2.7.1.

This is a temporary fix until a bugfix for https://github.com/mikel/mail/issues/1538 is released