### PR TITLE
Clear scores of empty feedback on submission select

### DIFF
--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -105,9 +105,9 @@ class Feedback < ApplicationRecord
   end
 
   def reset_feedback_after_submission_update
-    return unless will_save_change_to_submission_id? && submission_id_in_database.present?
+    return unless will_save_change_to_submission_id?
 
-    Submission.find(submission_id_in_database).annotations.where(evaluation_id: evaluation_id).destroy_all
+    Submission.find(submission_id_in_database).annotations.where(evaluation_id: evaluation_id).destroy_all if submission_id_in_database.present?
     scores.each(&:destroy)
   end
 


### PR DESCRIPTION
The fix in #3405 was incomplete. This fixes the behaviour described in https://github.com/dodona-edu/dodona/issues/4315#issuecomment-1382698253

- [x] Tests were added
