### PR TITLE
Hide output if it is much longer than expected to avoid browser crashes

### DIFF
--- a/app/helpers/renderers/text_differ.rb
+++ b/app/helpers/renderers/text_differ.rb
@@ -21,11 +21,11 @@ class TextDiffer
                 end
               end
             end
-    if @generated_linecount > @expected_linecount + 100
-      @to_many_lines = @generated_linecount
-      @generated_linecount = @expected_linecount + 100
-      @generated = @generated.split("\n", -1).first(@generated_linecount).to_a.join("\n")
-    end
+    return unless @generated_linecount > @expected_linecount + 100
+
+    @to_many_lines = @generated_linecount
+    @generated_linecount = @expected_linecount + 100
+    @generated = @generated.split("\n", -1).first(@generated_linecount).to_a.join("\n")
   end
 
   def unified

--- a/app/helpers/renderers/text_differ.rb
+++ b/app/helpers/renderers/text_differ.rb
@@ -8,6 +8,12 @@ class TextDiffer
   def initialize(generated, expected)
     @generated = generated || ''
     @expected = expected || ''
+
+    if @generated.length > @expected.length + 5000
+      @too_many_characters = @generated.length
+      @generated = "#{@generated.first(@expected.length + 5000)}..."
+    end
+
     @generated_linecount = generated&.lines&.count || 0
     @expected_linecount = expected&.lines&.count || 0
     @simplified_table = @generated_linecount > 100 || @expected_linecount > 100
@@ -21,11 +27,6 @@ class TextDiffer
                 end
               end
             end
-    return unless @generated_linecount > @expected_linecount + 100
-
-    @too_many_lines = @generated_linecount
-    @generated_linecount = @expected_linecount + 100
-    @generated = @generated.split("\n", -1).first(@generated_linecount).to_a.join("\n")
   end
 
   def unified
@@ -52,7 +53,7 @@ class TextDiffer
         nil
       end
     end.html_safe
-    cut_off_message(builder) if @too_many_lines
+    cut_off_message(builder) if @too_many_characters
     builder
   end
 
@@ -247,7 +248,7 @@ class TextDiffer
 
   def cut_off_message(builder)
     builder.div(class: 'callout callout-warning') do
-      builder << I18n.t('submissions.show.cut_off_message', generated: @too_many_lines, count: @expected_linecount)
+      builder << I18n.t('submissions.show.cut_off_message', generated: @too_many_characters, count: @expected.length)
     end
   end
 end

--- a/app/helpers/renderers/text_differ.rb
+++ b/app/helpers/renderers/text_differ.rb
@@ -21,6 +21,11 @@ class TextDiffer
                 end
               end
             end
+    if @generated_linecount > @expected_linecount + 100
+      @to_many_lines = @generated_linecount
+      @generated_linecount = @expected_linecount + 100
+      @generated = @generated.split("\n", -1).first(@generated_linecount).to_a.join("\n")
+    end
   end
 
   def unified
@@ -47,6 +52,8 @@ class TextDiffer
         nil
       end
     end.html_safe
+    cut_off_message(builder) if @to_many_lines
+    builder
   end
 
   def split
@@ -236,5 +243,11 @@ class TextDiffer
     gen_result += '</strong>' if in_gen_strong
     exp_result += '</strong>' if in_exp_strong
     [gen_result, exp_result]
+  end
+
+  def cut_off_message(builder)
+    builder.div(class: 'callout callout-warning') do
+      builder << I18n.t('submissions.show.cut_off_message', generated: @to_many_lines, count: @expected_linecount)
+    end
   end
 end

--- a/app/helpers/renderers/text_differ.rb
+++ b/app/helpers/renderers/text_differ.rb
@@ -23,7 +23,7 @@ class TextDiffer
             end
     return unless @generated_linecount > @expected_linecount + 100
 
-    @to_many_lines = @generated_linecount
+    @too_many_lines = @generated_linecount
     @generated_linecount = @expected_linecount + 100
     @generated = @generated.split("\n", -1).first(@generated_linecount).to_a.join("\n")
   end
@@ -52,7 +52,7 @@ class TextDiffer
         nil
       end
     end.html_safe
-    cut_off_message(builder) if @to_many_lines
+    cut_off_message(builder) if @too_many_lines
     builder
   end
 
@@ -247,7 +247,7 @@ class TextDiffer
 
   def cut_off_message(builder)
     builder.div(class: 'callout callout-warning') do
-      builder << I18n.t('submissions.show.cut_off_message', generated: @to_many_lines, count: @expected_linecount)
+      builder << I18n.t('submissions.show.cut_off_message', generated: @too_many_lines, count: @expected_linecount)
     end
   end
 end

--- a/config/locales/views/submissions/en.yml
+++ b/config/locales/views/submissions/en.yml
@@ -70,3 +70,6 @@ en:
       tab_staff: This tab is only visible for course admins
       tab_zeus: This tab is only visisble for administrators
       for: "for"
+      cut_off_message:
+        one: Your output was cut off as it is much longer than expected. You produced %{generated} lines while only one line was expected.
+        other: Your output was cut off as it is much longer than expected. You produced %{generated} lines while %{count} lines were expected.

--- a/config/locales/views/submissions/en.yml
+++ b/config/locales/views/submissions/en.yml
@@ -71,5 +71,5 @@ en:
       tab_zeus: This tab is only visisble for administrators
       for: "for"
       cut_off_message:
-        one: Your output was cut off as it is much longer than expected. You produced %{generated} lines while only one line was expected.
-        other: Your output was cut off as it is much longer than expected. You produced %{generated} lines while %{count} lines were expected.
+        one: Your output was cut off as it is much longer than expected. You produced %{generated} characters while only one character was expected.
+        other: Your output was cut off as it is much longer than expected. You produced %{generated} characters while only %{count} characters were expected.

--- a/config/locales/views/submissions/nl.yml
+++ b/config/locales/views/submissions/nl.yml
@@ -71,5 +71,5 @@ nl:
       tab_zeus: Dit tabblad is enkel zichtbaar voor admins
       for: "voor"
       cut_off_message:
-        one: De uitvoer van je programma is ingekort aangezien je veel meer uitvoer had dan het verwachte resultaat. Je genereerde %{generated} lijnen terwijl er slechts één lijn verwacht werd.
-        other: De uitvoer van je programma is ingekort aangezien je veel meer uitvoer had dan het verwachte resultaat. Je genereerde %{generated} lijnen terwijl er slechts %{count} lijnen verwacht werden.
+        one: De uitvoer van je programma is ingekort aangezien je veel meer uitvoer had dan het verwachte resultaat. Je genereerde %{generated} karakters terwijl er slechts één karakter verwacht werd.
+        other: De uitvoer van je programma is ingekort aangezien je veel meer uitvoer had dan het verwachte resultaat. Je genereerde %{generated} karakters terwijl er slechts %{count} karakters verwacht werden.

--- a/config/locales/views/submissions/nl.yml
+++ b/config/locales/views/submissions/nl.yml
@@ -70,3 +70,6 @@ nl:
       tab_staff: Dit tabblad is enkel zichtbaar voor cursusbeheerders
       tab_zeus: Dit tabblad is enkel zichtbaar voor admins
       for: "voor"
+      cut_off_message:
+        one: De uitvoer van je programma is ingekort aangezien je veel meer uitvoer had dan het verwachte resultaat. Je genereerde %{generated} lijnen terwijl er slechts één lijn verwacht werd.
+        other: De uitvoer van je programma is ingekort aangezien je veel meer uitvoer had dan het verwachte resultaat. Je genereerde %{generated} lijnen terwijl er slechts %{count} lijnen verwacht werden.


### PR DESCRIPTION
This pull request hides very long submission output to avoid browser crashes. This solves #4265 

To much output is defined as 5000  characters more than the expected output. (But this is open for discussion)

![image](https://user-images.githubusercontent.com/21177904/214794829-2400402f-f5d0-4249-aeca-07dd61cbec56.png)


Closes #4265.
