### PR TITLE
Always display score items in a fixed order

### DIFF
--- a/app/models/score.rb
+++ b/app/models/score.rb
@@ -26,6 +26,8 @@ class Score < ApplicationRecord
   validates :score_item_id, uniqueness: { scope: :feedback_id }
   validate :not_out_of_bounds
 
+  default_scope { joins(:score_item).order('score_items.id': :asc) }
+
   private
 
   def maybe_complete_feedback

--- a/app/models/score_item.rb
+++ b/app/models/score_item.rb
@@ -23,6 +23,8 @@ class ScoreItem < ApplicationRecord
 
   validates :maximum, numericality: { greater_than: 0, less_than: 1000 }
 
+  default_scope { order(id: :asc) }
+
   private
 
   def uncomplete_feedbacks_if_maximum_changed

--- a/app/views/evaluations/overview.html.erb
+++ b/app/views/evaluations/overview.html.erb
@@ -22,7 +22,7 @@
           <tbody>
             <% @feedbacks.each do |fb| %>
               <% show_total = policy(fb.evaluation_exercise).show_total? %>
-              <% scores = policy_scope(fb.scores).includes(:score_item).order('score_items.id') %>
+              <% scores = policy_scope(fb.scores).includes(:score_item) %>
               <tr>
                 <%# The last row is normally borderless, but this doesn't work due to the rowspan. %>
                 <td class="align-top <%= "border-bottom-0" if fb === @feedbacks.last %>"


### PR DESCRIPTION
This pull request defines a default order for score items and their related scores. For now this is just the order of creation.
This might be changed in the future by #2713

Closes  #4313
