### PR TITLE
Add unique index to series_id for evaluations

### DIFF
--- a/db/migrate/20230127090704_add_unique_index_to_evaluations.rb
+++ b/db/migrate/20230127090704_add_unique_index_to_evaluations.rb
@@ -1,6 +1,6 @@
 class AddUniqueIndexToEvaluations < ActiveRecord::Migration[7.0]
   def change
-    Evaluation.joins("Join evaluations b ON b.series_id = evaluations.series_id and b.id < evaluations.id").delete_all
+    Evaluation.joins("Join evaluations b ON b.series_id = evaluations.series_id and b.id < evaluations.id").destroy_all
     add_index :evaluations, :series_id, unique: true, name: 'index_evaluations_on_unique_series_id'
     remove_index :evaluations, :series_id, name: 'index_evaluations_on_series_id'
   end

--- a/db/migrate/20230127090704_add_unique_index_to_evaluations.rb
+++ b/db/migrate/20230127090704_add_unique_index_to_evaluations.rb
@@ -1,0 +1,6 @@
+class AddUniqueIndexToEvaluations < ActiveRecord::Migration[7.0]
+  def change
+    add_index :evaluations, :series_id, unique: true, name: 'index_evaluations_on_unique_series_id'
+    remove_index :evaluations, :series_id, name: 'index_evaluations_on_series_id'
+  end
+end

--- a/db/migrate/20230127090704_add_unique_index_to_evaluations.rb
+++ b/db/migrate/20230127090704_add_unique_index_to_evaluations.rb
@@ -1,5 +1,6 @@
 class AddUniqueIndexToEvaluations < ActiveRecord::Migration[7.0]
   def change
+    Evaluation.joins("Join evaluations b ON b.series_id = evaluations.series_id and b.id < evaluations.id").delete_all
     add_index :evaluations, :series_id, unique: true, name: 'index_evaluations_on_unique_series_id'
     remove_index :evaluations, :series_id, name: 'index_evaluations_on_series_id'
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_19_083641) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_27_090704) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -104,8 +104,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_19_083641) do
     t.integer "series_id_non_nil", null: false
     t.index ["accepted", "user_id", "series_id"], name: "index_activity_statuses_on_accepted_and_user_id_and_series_id"
     t.index ["activity_id"], name: "index_activity_statuses_on_activity_id"
-    t.index ["series_id", "started", "user_id", "last_submission_id"], name: "index_as_on_series_and_started_and_user_and_last_submission"
     t.index ["series_id"], name: "fk_rails_1bc42c2178"
+    t.index ["started", "user_id", "last_submission_id"], name: "index_as_on_started_and_user_and_last_submission"
     t.index ["started", "user_id", "series_id"], name: "index_activity_statuses_on_started_and_user_id_and_series_id"
     t.index ["user_id", "series_id", "last_submission_id"], name: "index_as_on_user_and_series_and_last_submission"
     t.index ["user_id", "series_id_non_nil", "activity_id"], name: "index_on_user_id_series_id_non_nil_activity_id", unique: true
@@ -261,7 +261,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_19_083641) do
     t.datetime "deadline", precision: nil, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["series_id"], name: "index_evaluations_on_series_id"
+    t.index ["series_id"], name: "index_evaluations_on_unique_series_id", unique: true
   end
 
   create_table "events", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|


### PR DESCRIPTION
This pull request adds a unique index to evaluations. This avoids multiple evaluations belonging to the same series.

Although a new evaluation should never be created if one already exists, it has happened in practice, resulting in further errors down the line. The unique index should result in an error upon creation, which we can then look into avoiding.

Tested on naos. Duplicate evaluations are removed, series can be deleted again.

Closes #4356 .
