### PR TITLE
Keep programming languages in memory

### DIFF
--- a/app/models/exercise.rb
+++ b/app/models/exercise.rb
@@ -43,6 +43,10 @@ class Exercise < Activity
   # Only used manually from the console
   scope :unstarted_by, ->(users) { where.not(id: Submission.where(user_id: users).select(:exercise_id)) }
 
+  def programming_language
+    ProgrammingLanguage.find(programming_language_id) || super
+  end
+
   def exercise?
     true
   end

--- a/app/models/exercise.rb
+++ b/app/models/exercise.rb
@@ -44,7 +44,7 @@ class Exercise < Activity
   scope :unstarted_by, ->(users) { where.not(id: Submission.where(user_id: users).select(:exercise_id)) }
 
   def programming_language
-    ProgrammingLanguage.find(programming_language_id) || super
+    ProgrammingLanguage.cached_find(programming_language_id) || super
   end
 
   def exercise?

--- a/app/models/programming_language.rb
+++ b/app/models/programming_language.rb
@@ -21,7 +21,7 @@ class ProgrammingLanguage < ApplicationRecord
   has_many :exercises, dependent: :restrict_with_error
 
   # There are only a few programming languages, so we can keep them in memory
-  @@in_memory_instances = {}
+  @@in_memory_instances = {} # rubocop:disable Style/ClassVars
 
   def self.find(*ids)
     # We don't have cache keys for this stuff yet

--- a/app/models/programming_language.rb
+++ b/app/models/programming_language.rb
@@ -16,8 +16,28 @@ class ProgrammingLanguage < ApplicationRecord
   DEFAULT_ICON = 'file-document-edit-outline'.freeze
 
   before_save :fill_fields
+  after_save :remove_from_cache
 
   has_many :exercises, dependent: :restrict_with_error
+
+  # There are only a few programming languages, so we can keep them in memory
+  @@in_memory_instances = {}
+
+  def self.find(*ids)
+    # We don't have cache keys for this stuff yet
+    return super unless ids.length == 1
+
+    id = ids.first
+    return nil if id.nil?
+
+    return super unless id.is_a?(Integer)
+
+    @@in_memory_instances[id] ||= super
+  end
+
+  def remove_from_cache
+    @@in_memory_instances.delete(id)
+  end
 
   def fill_fields
     self.editor_name ||= name

--- a/app/models/programming_language.rb
+++ b/app/models/programming_language.rb
@@ -23,16 +23,12 @@ class ProgrammingLanguage < ApplicationRecord
   # There are only a few programming languages, so we can keep them in memory
   @@in_memory_instances = {} # rubocop:disable Style/ClassVars
 
-  def self.find(*ids)
-    # We don't have cache keys for this stuff yet
-    return super unless ids.length == 1
-
-    id = ids.first
+  def self.cached_find(id)
     return nil if id.nil?
 
-    return super unless id.is_a?(Integer)
+    return nil unless id.is_a?(Integer)
 
-    @@in_memory_instances[id] ||= super
+    @@in_memory_instances[id] ||= find(id)
   end
 
   def remove_from_cache


### PR DESCRIPTION
This pull request keeps programming languages in memory in a hash table. This greatly reduces the number of queries.

I considered a few different options to do this:

### Adding `includes(:programming_languages)` statements
This would be relevant everywhere activity icons are displayed. This would reduce the numbers of queries by a lot already, but would still be similar to the amount of times `activities` are queried. This would still be a lot of queries for only 18 different programming languages.

### using Memcached
This would replace database queries by memcached access. Because the queries themselves are small, most of the cost is due to the overhead of contacting a different server. This would not be solved by memcached.

### Keeping an in memory hashmap
This is the option I chose. As there are only 18 different languages this won't take that much active memory. It reduces the number of queries to virtually zero. 
The downside is the use of class variables in a multi threaded environment, that could be prone to timing related bugs. 