### PR TITLE
Perform less repository requests on the course page

### DIFF
--- a/app/views/activities/_series_activities_table.html.erb
+++ b/app/views/activities/_series_activities_table.html.erb
@@ -34,7 +34,7 @@
     </tr>
     </thead>
     <tbody>
-    <% local_assigns[:activities].each_with_index do |activity, index| %>
+    <% local_assigns[:activities].includes(:repository).each_with_index do |activity, index| %>
       <tr>
         <td class='status-icon'>
           <% if user_signed_in? %>


### PR DESCRIPTION
This pull request avoids an N+1 amount of queries on a course page. 
Selecting repositories was one of our most frequent queries, and this page was the biggest contributor.

The repository is used on this page to check if the user is repository admin and thus should see extra info about the exercise. 
We could also avoid this by just limiting this feature to course admins.