### PR TITLE
Cache submission annotation count to avoid many slow queries

### DIFF
--- a/app/models/annotation.rb
+++ b/app/models/annotation.rb
@@ -56,7 +56,6 @@ class Annotation < ApplicationRecord
                   column_name: proc { |annotation| annotation.released? ? 'released_annotation_count' : nil },
                   column_names: { Annotation.released => 'released_annotation_count' }
 
-
   def released?
     evaluation.blank? || evaluation.released
   end

--- a/app/models/evaluation.rb
+++ b/app/models/evaluation.rb
@@ -30,6 +30,7 @@ class Evaluation < ApplicationRecord
   before_save :manage_feedbacks
   before_destroy :destroy_notification
   after_save :manage_user_notifications
+  after_save :update_released_annotation_counts, if: :released?
 
   def users=(new_users)
     removed = users - new_users
@@ -158,5 +159,9 @@ class Evaluation < ApplicationRecord
 
   def destroy_notification
     Notification.where(notifiable: self)&.destroy_all
+  end
+
+  def update_released_annotation_counts
+    annotations.counter_culture_fix_counts
   end
 end

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -2,17 +2,18 @@
 #
 # Table name: submissions
 #
-#  id          :integer          not null, primary key
-#  exercise_id :integer
-#  user_id     :integer
-#  summary     :string(255)
-#  created_at  :datetime         not null
-#  updated_at  :datetime         not null
-#  status      :integer
-#  accepted    :boolean          default(FALSE)
-#  course_id   :integer
-#  fs_key      :string(24)
-#  number      :integer
+#  id                        :integer          not null, primary key
+#  exercise_id               :integer
+#  user_id                   :integer
+#  summary                   :string(255)
+#  created_at                :datetime         not null
+#  updated_at                :datetime         not null
+#  status                    :integer
+#  accepted                  :boolean          default(FALSE)
+#  course_id                 :integer
+#  fs_key                    :string(24)
+#  number                    :integer
+#  released_annotation_count :integer          default(0), not null
 #
 
 class Submission < ApplicationRecord
@@ -203,7 +204,7 @@ class Submission < ApplicationRecord
   end
 
   def annotated?
-    annotations.left_joins(:evaluation).released.any?
+    released_annotation_count > 0
   end
 
   def skip_rate_limit_check?

--- a/app/policies/annotation_policy.rb
+++ b/app/policies/annotation_policy.rb
@@ -4,7 +4,7 @@ class AnnotationPolicy < ApplicationPolicy
       if user&.zeus?
         scope.all
       elsif user
-        common = scope.joins(:submission).left_joins(:evaluation)
+        common = scope.joins(:submission)
         common.released.where(submissions: { user: user }).or(common.where(submissions: { course_id: user.administrating_courses.map(&:id) }))
       else
         scope.none
@@ -23,9 +23,8 @@ class AnnotationPolicy < ApplicationPolicy
   def show?
     return false unless SubmissionPolicy.new(user, record.submission).show?
     return true if user&.course_admin?(record&.course)
-    return true if record.evaluation.blank?
 
-    record.evaluation.released
+    record.released?
   end
 
   def update?

--- a/db/migrate/20230202085953_add_released_annotation_count_to_submissions.rb
+++ b/db/migrate/20230202085953_add_released_annotation_count_to_submissions.rb
@@ -1,0 +1,11 @@
+class AddReleasedAnnotationCountToSubmissions < ActiveRecord::Migration[7.0]
+  def self.up
+    add_column :submissions, :released_annotation_count, :integer, null: false, default: 0
+
+    Annotation.counter_culture_fix_counts
+  end
+
+  def self.down
+    remove_column :submissions, :released_annotation_count
+  end
+end

--- a/db/migrate/20230202085953_add_released_annotation_count_to_submissions.rb
+++ b/db/migrate/20230202085953_add_released_annotation_count_to_submissions.rb
@@ -2,7 +2,8 @@ class AddReleasedAnnotationCountToSubmissions < ActiveRecord::Migration[7.0]
   def self.up
     add_column :submissions, :released_annotation_count, :integer, null: false, default: 0
 
-    Annotation.counter_culture_fix_counts
+    # This should be run in production after the migration has been deployed
+    # Annotation.counter_culture_fix_counts
   end
 
   def self.down

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_30_132327) do
+ActiveRecord::Schema[7.0].define(version: 2023_02_02_085953) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -493,6 +493,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_30_132327) do
     t.integer "course_id"
     t.string "fs_key", limit: 24
     t.integer "number"
+    t.integer "released_annotation_count", default: 0, null: false
     t.index ["accepted"], name: "index_submissions_on_accepted"
     t.index ["course_id"], name: "index_submissions_on_course_id"
     t.index ["exercise_id", "status", "course_id"], name: "ex_st_co_idx"

--- a/test/factories/submissions.rb
+++ b/test/factories/submissions.rb
@@ -2,17 +2,18 @@
 #
 # Table name: submissions
 #
-#  id          :integer          not null, primary key
-#  exercise_id :integer
-#  user_id     :integer
-#  summary     :string(255)
-#  created_at  :datetime         not null
-#  updated_at  :datetime         not null
-#  status      :integer
-#  accepted    :boolean          default(FALSE)
-#  course_id   :integer
-#  fs_key      :string(24)
-#  number      :integer
+#  id                        :integer          not null, primary key
+#  exercise_id               :integer
+#  user_id                   :integer
+#  summary                   :string(255)
+#  created_at                :datetime         not null
+#  updated_at                :datetime         not null
+#  status                    :integer
+#  accepted                  :boolean          default(FALSE)
+#  course_id                 :integer
+#  fs_key                    :string(24)
+#  number                    :integer
+#  released_annotation_count :integer          default(0), not null
 #
 
 FactoryBot.define do

--- a/test/models/submission_test.rb
+++ b/test/models/submission_test.rb
@@ -2,17 +2,18 @@
 #
 # Table name: submissions
 #
-#  id          :integer          not null, primary key
-#  exercise_id :integer
-#  user_id     :integer
-#  summary     :string(255)
-#  created_at  :datetime         not null
-#  updated_at  :datetime         not null
-#  status      :integer
-#  accepted    :boolean          default(FALSE)
-#  course_id   :integer
-#  fs_key      :string(24)
-#  number      :integer
+#  id                        :integer          not null, primary key
+#  exercise_id               :integer
+#  user_id                   :integer
+#  summary                   :string(255)
+#  created_at                :datetime         not null
+#  updated_at                :datetime         not null
+#  status                    :integer
+#  accepted                  :boolean          default(FALSE)
+#  course_id                 :integer
+#  fs_key                    :string(24)
+#  number                    :integer
+#  released_annotation_count :integer          default(0), not null
 #
 
 require 'test_helper'
@@ -419,6 +420,18 @@ class SubmissionTest < ActiveSupport::TestCase
 
     course.series.second.update!(visibility: :hidden)
     assert_nil submission.series
+  end
+
+  test 'Annotations should be counted once an evaluation is released' do
+    submission = create :submission, status: :correct, course: courses(:course1)
+    assert_equal 0, submission.released_annotation_count
+    create :annotation, submission: submission
+    assert_equal 1, submission.reload.released_annotation_count
+    evaluation = create :evaluation
+    create :annotation, submission: submission, evaluation: evaluation
+    assert_equal 1, submission.reload.released_annotation_count
+    evaluation.update!(released: true)
+    assert_equal 2, submission.reload.released_annotation_count
   end
 
   class StatisticsTest < ActiveSupport::TestCase


### PR DESCRIPTION
This pull request caches the released_annotation_count for every submission in the database. The goal is to avoid a lot of queries that check if a submission is annotated.

This query was third in our server time usage:
![image](https://user-images.githubusercontent.com/21177904/216293413-68e6eab7-1bad-4f46-886b-92566a70ec12.png)
The cause was the check if a submission has annotations on every page were submissions are listed. (And for example on the activity page, this is loaded every time a user submits)

I also updated the `released` scope to also include `left_joins(:evaluations)` as this was a mandatory addition to get this scope working and thus always included when this scope was used.

I also had to trigger an update of counter culture manually from evaluations, as this use case was not covered.

To avoid slow migrations, the following should be run on production afterwards:
```ruby
Annotation.counter_culture_fix_counts
```

Until this is run, no `has_annotations` announcements will be show, but this seems too minor an issue to require separate rollout


- [x] Tests were added
