### PR TITLE
Cache submission `annotated?` as boolean

### DIFF
--- a/app/helpers/renderers/feedback_code_renderer.rb
+++ b/app/helpers/renderers/feedback_code_renderer.rb
@@ -95,7 +95,7 @@ class FeedbackCodeRenderer
           window.dodona.codeListing = new window.dodona.codeListingClass(#{submission.id}, #{submission.course_id.to_json}, #{submission.exercise_id}, #{user.id}, #{@code.to_json}, #{@code.lines.length}, #{user_is_student});
           window.dodona.codeListing.addMachineAnnotations(#{messages.to_json});
           #{'window.dodona.codeListing.initAnnotateButtons();' if user_perm}
-          window.dodona.codeListing.loadUserAnnotations();
+          #{'window.dodona.codeListing.loadUserAnnotations();' if submission.annotated? || (!user_is_student && submission.annotations.any?)}
           window.dodona.codeListing.showAnnotations();
         });
       HEREDOC

--- a/app/models/annotation.rb
+++ b/app/models/annotation.rb
@@ -33,7 +33,7 @@ class Annotation < ApplicationRecord
 
   scope :by_submission, ->(submission_id) { where(submission_id: submission_id) }
   scope :by_user, ->(user_id) { where(user_id: user_id) }
-  scope :released, -> { where(evaluation_id: nil).or(where(evaluations: { released: true })) }
+  scope :released, -> { left_joins(:evaluation).where(evaluation_id: nil).or(where(evaluations: { released: true })) }
   scope :by_course, ->(course_id) { where(submission: Submission.in_course(Course.find(course_id))) }
   scope :by_username, ->(name) { where(user: User.by_filter(name)) }
   scope :by_exercise_name, ->(name) { where(submission: Submission.by_exercise_name(name)) }
@@ -64,7 +64,7 @@ class Annotation < ApplicationRecord
   end
 
   def destroy_notification
-    Notification.find_by(notifiable: submission)&.destroy unless submission.annotations.left_joins(:evaluation).released.any?
+    Notification.find_by(notifiable: submission)&.destroy unless submission.annotations.released.any?
   end
 
   def set_last_updated_by
@@ -80,6 +80,6 @@ class Annotation < ApplicationRecord
   end
 
   def reset_submission_annotated
-    submission.update(annotated: false) unless submission.annotations.left_joins(:evaluation).released.any?
+    submission.update(annotated: false) unless submission.annotations.released.any?
   end
 end

--- a/app/models/evaluation.rb
+++ b/app/models/evaluation.rb
@@ -24,12 +24,15 @@ class Evaluation < ApplicationRecord
   has_many :exercises, through: :evaluation_exercises
   has_many :score_items, through: :evaluation_exercises
 
+  has_many :annotated_submissions, -> { distinct }, through: :annotations, source: :submission
+
   validates :deadline, presence: true
   validate :deadline_in_past
 
   before_save :manage_feedbacks
   before_destroy :destroy_notification
   after_save :manage_user_notifications
+  after_save :annotate_submissions, if: :released?
 
   def users=(new_users)
     removed = users - new_users
@@ -158,5 +161,9 @@ class Evaluation < ApplicationRecord
 
   def destroy_notification
     Notification.where(notifiable: self)&.destroy_all
+  end
+
+  def annotate_submissions
+    annotated_submissions.update_all(annotated: true)
   end
 end

--- a/app/models/evaluation.rb
+++ b/app/models/evaluation.rb
@@ -164,6 +164,6 @@ class Evaluation < ApplicationRecord
   end
 
   def annotate_submissions
-    annotated_submissions.update_all(annotated: true)
+    annotated_submissions.update_all(annotated: true) # rubocop:disable Rails/SkipsModelValidations
   end
 end

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -2,17 +2,19 @@
 #
 # Table name: submissions
 #
-#  id          :integer          not null, primary key
-#  exercise_id :integer
-#  user_id     :integer
-#  summary     :string(255)
-#  created_at  :datetime         not null
-#  updated_at  :datetime         not null
-#  status      :integer
-#  accepted    :boolean          default(FALSE)
-#  course_id   :integer
-#  fs_key      :string(24)
-#  number      :integer
+#  id                        :integer          not null, primary key
+#  exercise_id               :integer
+#  user_id                   :integer
+#  summary                   :string(255)
+#  created_at                :datetime         not null
+#  updated_at                :datetime         not null
+#  status                    :integer
+#  accepted                  :boolean          default(FALSE)
+#  course_id                 :integer
+#  fs_key                    :string(24)
+#  number                    :integer
+#  released_annotation_count :integer          default(0), not null
+#  annotated                 :boolean          default(FALSE), not null
 #
 
 class Submission < ApplicationRecord
@@ -200,10 +202,6 @@ class Submission < ApplicationRecord
 
   def evaluate?
     @evaluate
-  end
-
-  def annotated?
-    annotations.left_joins(:evaluation).released.any?
   end
 
   def skip_rate_limit_check?

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -2,19 +2,18 @@
 #
 # Table name: submissions
 #
-#  id                        :integer          not null, primary key
-#  exercise_id               :integer
-#  user_id                   :integer
-#  summary                   :string(255)
-#  created_at                :datetime         not null
-#  updated_at                :datetime         not null
-#  status                    :integer
-#  accepted                  :boolean          default(FALSE)
-#  course_id                 :integer
-#  fs_key                    :string(24)
-#  number                    :integer
-#  released_annotation_count :integer          default(0), not null
-#  annotated                 :boolean          default(FALSE), not null
+#  id          :integer          not null, primary key
+#  exercise_id :integer
+#  user_id     :integer
+#  summary     :string(255)
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  status      :integer
+#  accepted    :boolean          default(FALSE)
+#  course_id   :integer
+#  fs_key      :string(24)
+#  number      :integer
+#  annotated   :boolean          default(FALSE), not null
 #
 
 class Submission < ApplicationRecord

--- a/app/policies/annotation_policy.rb
+++ b/app/policies/annotation_policy.rb
@@ -4,7 +4,7 @@ class AnnotationPolicy < ApplicationPolicy
       if user&.zeus?
         scope.all
       elsif user
-        common = scope.joins(:submission).left_joins(:evaluation)
+        common = scope.joins(:submission)
         common.released.where(submissions: { user: user }).or(common.where(submissions: { course_id: user.administrating_courses.map(&:id) }))
       else
         scope.none

--- a/db/migrate/20230202123413_add_annotated_to_submission.rb
+++ b/db/migrate/20230202123413_add_annotated_to_submission.rb
@@ -1,5 +1,8 @@
 class AddAnnotatedToSubmission < ActiveRecord::Migration[7.0]
   def change
     add_column :submissions, :annotated, :boolean, default: false, null: false
+
+    # Run in console, to update existing submissions.
+    # Submission.where(id: Annotation.released.select(:submission_id).distinct).update_all(annotated: true)
   end
 end

--- a/db/migrate/20230202123413_add_annotated_to_submission.rb
+++ b/db/migrate/20230202123413_add_annotated_to_submission.rb
@@ -1,0 +1,5 @@
+class AddAnnotatedToSubmission < ActiveRecord::Migration[7.0]
+  def change
+    add_column :submissions, :annotated, :boolean, default: false, null: false
+  end
+end

--- a/db/migrate/20230202123413_add_annotated_to_submission.rb
+++ b/db/migrate/20230202123413_add_annotated_to_submission.rb
@@ -2,7 +2,6 @@ class AddAnnotatedToSubmission < ActiveRecord::Migration[7.0]
   def change
     add_column :submissions, :annotated, :boolean, default: false, null: false
 
-    # Run in console, to update existing submissions.
-    # Submission.where(id: Annotation.released.select(:submission_id).distinct).update_all(annotated: true)
+    Submission.where(id: Annotation.released.select(:submission_id).distinct).update_all(annotated: true)
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -493,7 +493,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_02_123413) do
     t.integer "course_id"
     t.string "fs_key", limit: 24
     t.integer "number"
-    t.integer "released_annotation_count", default: 0, null: false
     t.boolean "annotated", default: false, null: false
     t.index ["accepted"], name: "index_submissions_on_accepted"
     t.index ["course_id"], name: "index_submissions_on_course_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_30_132327) do
+ActiveRecord::Schema[7.0].define(version: 2023_02_02_123413) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -493,6 +493,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_30_132327) do
     t.integer "course_id"
     t.string "fs_key", limit: 24
     t.integer "number"
+    t.integer "released_annotation_count", default: 0, null: false
+    t.boolean "annotated", default: false, null: false
     t.index ["accepted"], name: "index_submissions_on_accepted"
     t.index ["course_id"], name: "index_submissions_on_course_id"
     t.index ["exercise_id", "status", "course_id"], name: "ex_st_co_idx"

--- a/test/factories/submissions.rb
+++ b/test/factories/submissions.rb
@@ -2,17 +2,19 @@
 #
 # Table name: submissions
 #
-#  id          :integer          not null, primary key
-#  exercise_id :integer
-#  user_id     :integer
-#  summary     :string(255)
-#  created_at  :datetime         not null
-#  updated_at  :datetime         not null
-#  status      :integer
-#  accepted    :boolean          default(FALSE)
-#  course_id   :integer
-#  fs_key      :string(24)
-#  number      :integer
+#  id                        :integer          not null, primary key
+#  exercise_id               :integer
+#  user_id                   :integer
+#  summary                   :string(255)
+#  created_at                :datetime         not null
+#  updated_at                :datetime         not null
+#  status                    :integer
+#  accepted                  :boolean          default(FALSE)
+#  course_id                 :integer
+#  fs_key                    :string(24)
+#  number                    :integer
+#  released_annotation_count :integer          default(0), not null
+#  annotated                 :boolean          default(FALSE), not null
 #
 
 FactoryBot.define do

--- a/test/factories/submissions.rb
+++ b/test/factories/submissions.rb
@@ -2,19 +2,18 @@
 #
 # Table name: submissions
 #
-#  id                        :integer          not null, primary key
-#  exercise_id               :integer
-#  user_id                   :integer
-#  summary                   :string(255)
-#  created_at                :datetime         not null
-#  updated_at                :datetime         not null
-#  status                    :integer
-#  accepted                  :boolean          default(FALSE)
-#  course_id                 :integer
-#  fs_key                    :string(24)
-#  number                    :integer
-#  released_annotation_count :integer          default(0), not null
-#  annotated                 :boolean          default(FALSE), not null
+#  id          :integer          not null, primary key
+#  exercise_id :integer
+#  user_id     :integer
+#  summary     :string(255)
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  status      :integer
+#  accepted    :boolean          default(FALSE)
+#  course_id   :integer
+#  fs_key      :string(24)
+#  number      :integer
+#  annotated   :boolean          default(FALSE), not null
 #
 
 FactoryBot.define do

--- a/test/models/submission_test.rb
+++ b/test/models/submission_test.rb
@@ -2,17 +2,19 @@
 #
 # Table name: submissions
 #
-#  id          :integer          not null, primary key
-#  exercise_id :integer
-#  user_id     :integer
-#  summary     :string(255)
-#  created_at  :datetime         not null
-#  updated_at  :datetime         not null
-#  status      :integer
-#  accepted    :boolean          default(FALSE)
-#  course_id   :integer
-#  fs_key      :string(24)
-#  number      :integer
+#  id                        :integer          not null, primary key
+#  exercise_id               :integer
+#  user_id                   :integer
+#  summary                   :string(255)
+#  created_at                :datetime         not null
+#  updated_at                :datetime         not null
+#  status                    :integer
+#  accepted                  :boolean          default(FALSE)
+#  course_id                 :integer
+#  fs_key                    :string(24)
+#  number                    :integer
+#  released_annotation_count :integer          default(0), not null
+#  annotated                 :boolean          default(FALSE), not null
 #
 
 require 'test_helper'
@@ -419,6 +421,20 @@ class SubmissionTest < ActiveSupport::TestCase
 
     course.series.second.update!(visibility: :hidden)
     assert_nil submission.series
+  end
+
+  test 'Annotations should be counted once an evaluation is released' do
+    submission = create :submission, status: :correct, course: courses(:course1)
+    assert_not submission.reload.annotated?
+    a = create :annotation, submission: submission
+    assert submission.reload.annotated?
+    a.destroy
+    assert_not submission.reload.annotated?
+    evaluation = create :evaluation
+    create :annotation, submission: submission, evaluation: evaluation
+    assert_not submission.reload.annotated?
+    evaluation.update!(released: true)
+    assert submission.reload.annotated?
   end
 
   class StatisticsTest < ActiveSupport::TestCase

--- a/test/models/submission_test.rb
+++ b/test/models/submission_test.rb
@@ -2,19 +2,18 @@
 #
 # Table name: submissions
 #
-#  id                        :integer          not null, primary key
-#  exercise_id               :integer
-#  user_id                   :integer
-#  summary                   :string(255)
-#  created_at                :datetime         not null
-#  updated_at                :datetime         not null
-#  status                    :integer
-#  accepted                  :boolean          default(FALSE)
-#  course_id                 :integer
-#  fs_key                    :string(24)
-#  number                    :integer
-#  released_annotation_count :integer          default(0), not null
-#  annotated                 :boolean          default(FALSE), not null
+#  id          :integer          not null, primary key
+#  exercise_id :integer
+#  user_id     :integer
+#  summary     :string(255)
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  status      :integer
+#  accepted    :boolean          default(FALSE)
+#  course_id   :integer
+#  fs_key      :string(24)
+#  number      :integer
+#  annotated   :boolean          default(FALSE), not null
 #
 
 require 'test_helper'


### PR DESCRIPTION
This pull request caches `annotated?` for every submission in the database. The goal is to avoid a lot of queries that check if a submission is annotated.

This query was third in our server time usage:
![image](https://user-images.githubusercontent.com/21177904/216293413-68e6eab7-1bad-4f46-886b-92566a70ec12.png)
The cause was the check if a submission has annotations on every page were submissions are listed. (And for example on the activity page, this is loaded every time a user submits)

I also updated the `released` scope to also include `left_joins(:evaluations)` as this was a mandatory addition to get this scope working and thus always included when this scope was used.

I also used the new boolean to check whether annotations should be fetched on submission show.

I left the migration query in this time as it took only 52002.3ms on Naos and the impact is larger then in #4378 because we also use it to determine if annotations should be fetched.

- [x] Tests were added


replaces #4378 