### PR TITLE
Only show own repositories on the index page for teachers

### DIFF
--- a/app/assets/stylesheets/components/table.css.scss
+++ b/app/assets/stylesheets/components/table.css.scss
@@ -134,6 +134,15 @@ tr.gu-mirror {
     text-align: center;
     color: $on-surface-muted;
   }
+
+  td.empty {
+    white-space: break-spaces;
+    text-align: center;
+    padding: 16px;
+    line-height: 22px;
+    width: 100%;
+    color: $on-surface-muted;
+  }
 }
 
 #scoresheet-table-wrapper td {

--- a/app/controllers/repositories_controller.rb
+++ b/app/controllers/repositories_controller.rb
@@ -7,8 +7,9 @@ class RepositoriesController < ApplicationController
   # GET /repositories.json
   def index
     authorize Repository
-    @repositories = Repository.all
-    @title = I18n.t('repositories.index.title')
+    @repositories = policy_scope(Repository.all)
+    @repositories = @repositories.has_admin(current_user) unless current_user&.zeus?
+    @title = current_user&.zeus? ? I18n.t('repositories.index.title_zeus') : I18n.t('repositories.index.title')
   end
 
   # GET /repositories/1

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -274,6 +274,10 @@ class User < ApplicationRecord
     @repository_admin.include?(repository.id)
   end
 
+  def a_repository_admin?
+    zeus? || repositories.any?
+  end
+
   def personal?
     institution.nil?
   end

--- a/app/views/repositories/index.html.erb
+++ b/app/views/repositories/index.html.erb
@@ -64,7 +64,7 @@
             <% end %>
             <% if @repositories.empty? %>
                <tr>
-                  <td colspan="6" class="empty"><%= t ".empty" %></td>
+                  <td colspan="6" class="empty"><%= t ".empty_html" %></td>
                 </tr>
             <% end %>
             </tbody>

--- a/app/views/repositories/index.html.erb
+++ b/app/views/repositories/index.html.erb
@@ -2,7 +2,7 @@
   <div class="col-12">
     <div class="card">
       <div class="card-title card-title-colored">
-        <h2 class="card-title-text"><%= t ".title" %></h2>
+        <h2 class="card-title-text"><%= @title %></h2>
         <% if policy(Repository).new? %>
           <div class="card-title-fab">
             <%= render 'application/fab_link', url: new_repository_path, icon: 'plus' %>

--- a/app/views/repositories/index.html.erb
+++ b/app/views/repositories/index.html.erb
@@ -62,6 +62,11 @@
                 </td>
               </tr>
             <% end %>
+            <% if @repositories.empty? %>
+               <tr>
+                  <td colspan="6" class="empty"><%= t ".empty" %></td>
+                </tr>
+            <% end %>
             </tbody>
           </table>
         </div>

--- a/config/locales/views/repositories/en.yml
+++ b/config/locales/views/repositories/en.yml
@@ -18,7 +18,7 @@ en:
       empty_html: "You don't have any repositories yet.<br/>Click on the plus button to create your first repository or ask a repository admin you know to add you as an administrator."
     new:
       title: Add an exercise repository
-      help_html: "You can find a guide with more information on managing repositories in <a href='https://docs.dodona.be/nl/guides/teachers/new-exercise-repo/#_1-een-git-repository-aanmaken'>our documentation</a>."
+      help_html: "You can find a guide with more information on managing repositories in <a href='https://docs.dodona.be/en/guides/teachers/new-exercise-repo/#_1-create-a-git-repository'>our documentation</a>."
     show:
       repository: Repository
       empty_repo_title: "Getting started"

--- a/config/locales/views/repositories/en.yml
+++ b/config/locales/views/repositories/en.yml
@@ -15,6 +15,7 @@ en:
       edit: "Edit"
       delete: "Delete"
       admin: "You are an administrator of this repository"
+      empty: "You don't have any repositories yet.\nClick on the plus button to create you first repository or ask a repository admin you know to add you as an administrator."
     new:
       title: Add an exercise repository
       help_html: "You can find a guide with more information on managing repositories in <a href='https://docs.dodona.be/nl/guides/teachers/new-exercise-repo/#_1-een-git-repository-aanmaken'>our documentation</a>."

--- a/config/locales/views/repositories/en.yml
+++ b/config/locales/views/repositories/en.yml
@@ -15,7 +15,7 @@ en:
       edit: "Edit"
       delete: "Delete"
       admin: "You are an administrator of this repository"
-      empty: "You don't have any repositories yet.\nClick on the plus button to create you first repository or ask a repository admin you know to add you as an administrator."
+      empty_html: "You don't have any repositories yet.<br/>Click on the plus button to create you first repository or ask a repository admin you know to add you as an administrator."
     new:
       title: Add an exercise repository
       help_html: "You can find a guide with more information on managing repositories in <a href='https://docs.dodona.be/nl/guides/teachers/new-exercise-repo/#_1-een-git-repository-aanmaken'>our documentation</a>."

--- a/config/locales/views/repositories/en.yml
+++ b/config/locales/views/repositories/en.yml
@@ -15,7 +15,7 @@ en:
       edit: "Edit"
       delete: "Delete"
       admin: "You are an administrator of this repository"
-      empty_html: "You don't have any repositories yet.<br/>Click on the plus button to create you first repository or ask a repository admin you know to add you as an administrator."
+      empty_html: "You don't have any repositories yet.<br/>Click on the plus button to create your first repository or ask a repository admin you know to add you as an administrator."
     new:
       title: Add an exercise repository
       help_html: "You can find a guide with more information on managing repositories in <a href='https://docs.dodona.be/nl/guides/teachers/new-exercise-repo/#_1-een-git-repository-aanmaken'>our documentation</a>."

--- a/config/locales/views/repositories/en.yml
+++ b/config/locales/views/repositories/en.yml
@@ -8,7 +8,8 @@ en:
         toggle-label: "Feature this repository"
       remote_cant_be_edited_html: The clone URL can't be edited after the repository was created. Contact <a href="mailto:dodona@ugent.be">dodona@ugent.be</a> if it needs to be changed.
     index:
-      title: All exercise repositories
+      title_zeus: All exercise repositories
+      title: Your exercise repositories
       admins: "Edit administrators"
       courses: "Edit allowed courses"
       edit: "Edit"

--- a/config/locales/views/repositories/nl.yml
+++ b/config/locales/views/repositories/nl.yml
@@ -9,13 +9,13 @@ nl:
       remote_cant_be_edited_html: De clone URL kan niet aangepast worden nadat de repository werd aangemaakt. Contacteer <a href="mailto:dodona@ugent.be">dodona@ugent.be</a> als het toch aangepast moet worden.
     index:
       title_zeus: Alle oefeningen repository's
-      title: Jouw oefeningen repository's
+      title: Jouw oefeningenrepository's
       admins: "Beheerders aanpassen"
       courses: "Toegelaten cursussen aanpassen"
       edit: "Aanpassen"
       delete: "Verwijderen"
       admin: "Je bent beheerder van deze repository"
-      empty_html: "Je hebt nog geen repository's.<br/>Je kan een repository aanmaken via de plus knop, of je kan aan een repository beheerder vragen om je toe te voegen aan een repository."
+      empty_html: "Je hebt nog geen repository's.<br/>Je kan een repository aanmaken via de plus-knop, of je kan aan een repository-beheerder vragen om je toe te voegen aan een repository."
     new:
       title: Een repository met oefeningen toevoegen
       help_html: "Een handleiding met meer informatie over het beheren van een repository kan je in <a href='https://docs.dodona.be/nl/guides/teachers/new-exercise-repo/#_1-een-git-repository-aanmaken'>onze documentatie</a> terugvinden."

--- a/config/locales/views/repositories/nl.yml
+++ b/config/locales/views/repositories/nl.yml
@@ -15,6 +15,7 @@ nl:
       edit: "Aanpassen"
       delete: "Verwijderen"
       admin: "Je bent beheerder van deze repository"
+      empty: "Je hebt nog geen repository's.\nJe kan een repository aanmaken via de plus knop, of je kan aan een repository beheerder vragen om je toe te voegen aan een repository."
     new:
       title: Een repository met oefeningen toevoegen
       help_html: "Een handleiding met meer informatie over het beheren van een repository kan je in <a href='https://docs.dodona.be/nl/guides/teachers/new-exercise-repo/#_1-een-git-repository-aanmaken'>onze documentatie</a> terugvinden."

--- a/config/locales/views/repositories/nl.yml
+++ b/config/locales/views/repositories/nl.yml
@@ -15,7 +15,7 @@ nl:
       edit: "Aanpassen"
       delete: "Verwijderen"
       admin: "Je bent beheerder van deze repository"
-      empty: "Je hebt nog geen repository's.\nJe kan een repository aanmaken via de plus knop, of je kan aan een repository beheerder vragen om je toe te voegen aan een repository."
+      empty_html: "Je hebt nog geen repository's.<br/>Je kan een repository aanmaken via de plus knop, of je kan aan een repository beheerder vragen om je toe te voegen aan een repository."
     new:
       title: Een repository met oefeningen toevoegen
       help_html: "Een handleiding met meer informatie over het beheren van een repository kan je in <a href='https://docs.dodona.be/nl/guides/teachers/new-exercise-repo/#_1-een-git-repository-aanmaken'>onze documentatie</a> terugvinden."

--- a/config/locales/views/repositories/nl.yml
+++ b/config/locales/views/repositories/nl.yml
@@ -8,7 +8,8 @@ nl:
         toggle-label: "Deze repository uitlichten"
       remote_cant_be_edited_html: De clone URL kan niet aangepast worden nadat de repository werd aangemaakt. Contacteer <a href="mailto:dodona@ugent.be">dodona@ugent.be</a> als het toch aangepast moet worden.
     index:
-      title: Alle oefeningen repository's
+      title_zeus: Alle oefeningen repository's
+      title: Jouw oefeningen repository's
       admins: "Beheerders aanpassen"
       courses: "Toegelaten cursussen aanpassen"
       edit: "Aanpassen"


### PR DESCRIPTION
This pull request limits the repository index page to own repositories for non zeus users.

It is only limited on the index page, and not in the policy, as teachers are allowed to see the list of all repositories on other pages. (Eg as filter dropdown to search for exercises)


I also added an empty state to the repository page as this is now relevant.
![image](https://user-images.githubusercontent.com/21177904/216556883-23b1d2b3-94b6-423b-aa47-17d5b131a6d5.png)

part of #4362