### PR TITLE
Allow editing repositories for repository admins

### DIFF
--- a/app/policies/repository_policy.rb
+++ b/app/policies/repository_policy.rb
@@ -22,7 +22,7 @@ class RepositoryPolicy < ApplicationPolicy
   end
 
   def update?
-    user&.zeus?
+    user&.repository_admin?(record)
   end
 
   def destroy?


### PR DESCRIPTION
This pull request enables repository editing for repository admins. All relevant warnings and checks are already present, we have just forgotten to enable this in the past.

![image](https://user-images.githubusercontent.com/21177904/216567717-28018271-0147-4128-b80e-9a9438be348b.png)

Part of #4362 
