### PR TITLE
Fix multiple repository related paper cuts

### DIFF
--- a/app/controllers/repositories_controller.rb
+++ b/app/controllers/repositories_controller.rb
@@ -42,6 +42,7 @@ class RepositoriesController < ApplicationController
   def create
     authorize Repository
     @repository = Repository.new(permitted_attributes(Repository))
+    @repository.email_receiver = current_user
     saved = @repository.save
     if saved
       Event.create(event_type: :exercise_repository, user: current_user, message: "#{@repository.name} (id: #{@repository.id})")

--- a/app/controllers/repositories_controller.rb
+++ b/app/controllers/repositories_controller.rb
@@ -46,7 +46,6 @@ class RepositoriesController < ApplicationController
     if saved
       Event.create(event_type: :exercise_repository, user: current_user, message: "#{@repository.name} (id: #{@repository.id})")
       RepositoryAdmin.create(user_id: current_user.id, repository_id: @repository.id)
-      @repository.delay(queue: 'git').process_activities_email_errors(user: current_user)
     end
 
     respond_to do |format|

--- a/app/models/concerns/gitable.rb
+++ b/app/models/concerns/gitable.rb
@@ -53,8 +53,8 @@ module Gitable
 
   def repo_is_accessible
     cmd = ['git', 'ls-remote', remote.shellescape]
-    _out, error, status = Open3.capture3(*cmd)
-    errors.add(:remote, error) unless status.success?
+    _out, _error, status = Open3.capture3(*cmd)
+    errors.add(:remote, I18n.t('activerecord.errors.models.gitable.repository.not_accessible')) unless status.success?
   end
 
   def github_remote?

--- a/app/models/concerns/gitable.rb
+++ b/app/models/concerns/gitable.rb
@@ -54,7 +54,7 @@ module Gitable
   def repo_is_accessible
     cmd = ['git', 'ls-remote', remote.shellescape]
     _out, _error, status = Open3.capture3(*cmd)
-    errors.add(:remote, I18n.t('activerecord.errors.models.gitable.repository.not_accessible')) unless status.success?
+    errors.add(:remote, I18n.t('activerecord.errors.models.gitable.repository.not_accessible_markdown')) unless status.success?
   end
 
   def github_remote?

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -105,7 +105,14 @@ class Repository < ApplicationRecord
     activity_dirs_below(full_path)
   end
 
+  def clone_repo
+    super
+    process_activities_email_errors if clone_complete?
+  end
+
   def process_activities_email_errors(kwargs = {})
+    kwargs[:user] = admins.first if kwargs.empty?
+
     process_activities
   rescue AggregatedConfigErrors => e
     ErrorMailer.json_error(e, **kwargs).deliver

--- a/app/views/activities/_activities_table.html.erb
+++ b/app/views/activities/_activities_table.html.erb
@@ -100,6 +100,11 @@
     </tbody>
   </table>
 </div>
+<% if local_assigns[:activities].empty? %>
+  <p class="text-center text-muted lead table-placeholder">
+    <%= t "activities.index.empty" %>
+  </p>
+<% end %>
 <% if activities.try(:total_pages) %>
   <center><%= page_navigation_links activities, true, "activities" %></center>
 <% end %>

--- a/app/views/judges/_form.html.erb
+++ b/app/views/judges/_form.html.erb
@@ -18,7 +18,7 @@
     <div class="col-sm-6">
       <%= f.text_field :remote,
                        class: "form-control",
-                       placeholder: "git@github.ugent.be/...",
+                       placeholder: "git@github.com/...",
                        disabled: judge.new_record?.! %>
     </div>
     <span class="help-block offset-sm-3 col-sm-6">

--- a/app/views/repositories/_form.html.erb
+++ b/app/views/repositories/_form.html.erb
@@ -7,7 +7,7 @@
       <h4><%= t('errors.validation_errors', :count => repository.errors.count) %></h4>
       <ul>
         <% repository.errors.full_messages.each do |message| %>
-          <li><%= message %></li>
+          <li><%= markdown message %></li>
         <% end %>
       </ul>
     </div>

--- a/app/views/repositories/_form.html.erb
+++ b/app/views/repositories/_form.html.erb
@@ -25,7 +25,7 @@
     <div class="col-sm-6">
       <%= f.text_field :remote,
                        class: "form-control",
-                       placeholder: "git@github.ugent.be/...",
+                       placeholder: "git@github.com/...",
                        disabled: repository.new_record?.! %>
     </div>
     <span class="help-block offset-sm-3 col-sm-6">

--- a/app/views/repositories/show.html.erb
+++ b/app/views/repositories/show.html.erb
@@ -96,7 +96,7 @@
                   </tbody>
                 </table>
             <% else %>
-              <p class="lead text-center"><%= t ".public_files_placeholder"%></p>
+              <p class="lead text-center text-muted "><%= t ".public_files_placeholder"%></p>
             <% end %>
           </div>
         </div>

--- a/config/locales/models/en.yml
+++ b/config/locales/models/en.yml
@@ -10,6 +10,9 @@ en:
           attributes:
             activity:
               taken: You have already read this activity
+        gitable:
+          repository:
+            not_accessible: The repository is not accessible for our git user. Please double check if you have given the correct permissions. Take notice that it might take a while before a github/gitlab invitation is accepted by our team.
     models:
       course: Course
       activity: Activity

--- a/config/locales/models/en.yml
+++ b/config/locales/models/en.yml
@@ -12,7 +12,7 @@ en:
               taken: You have already read this activity
         gitable:
           repository:
-            not_accessible: The repository is not accessible for our git user. Please double check if you have given the correct permissions. Take notice that it might take a while before a github/gitlab invitation is accepted by our team.
+            not_accessible: The repository is not accessible for our git user. Please double check if you have given the correct permissions. Note that it might take a while before a GitHub/GitLab invitation is accepted by our team.
     models:
       course: Course
       activity: Activity

--- a/config/locales/models/en.yml
+++ b/config/locales/models/en.yml
@@ -12,7 +12,7 @@ en:
               taken: You have already read this activity
         gitable:
           repository:
-            not_accessible: The repository is not accessible for our git user. Please double check if you have given the correct permissions. Note that it might take a while before a GitHub/GitLab invitation is accepted by our team.
+            not_accessible_markdown: The repository is not accessible for our git user. Please double check if you have given the correct permissions. Note that it might take a while before a GitHub/GitLab invitation is accepted by our team. See [the documentation](https://docs.dodona.be/en/guides/teachers/new-exercise-repo/) for more information.
     models:
       course: Course
       activity: Activity

--- a/config/locales/models/nl.yml
+++ b/config/locales/models/nl.yml
@@ -10,6 +10,9 @@ nl:
           attributes:
             activity:
               taken: Je hebt deze activiteit al gelezen
+        gitable:
+          repository:
+            not_accessible: De repository is niet toegankelijk voor onze git-gebruiker. Controleer of je de juiste permissies hebt ingesteld. Hou er rekening mee dat het even kan duren voor een github/gitlab uitnodiging wordt geaccepteerd door ons team.
     models:
       course: Cursus
       activity: Activiteit

--- a/config/locales/models/nl.yml
+++ b/config/locales/models/nl.yml
@@ -12,7 +12,7 @@ nl:
               taken: Je hebt deze activiteit al gelezen
         gitable:
           repository:
-            not_accessible: De repository is niet toegankelijk voor onze git-gebruiker. Controleer of je de juiste permissies hebt ingesteld. Hou er rekening mee dat het even kan duren eer een uitnodiging voor GitHub/GitLab wordt geaccepteerd door ons team.
+            not_accessible_markdown: De repository is niet toegankelijk voor onze git-gebruiker. Controleer of je de juiste permissies hebt ingesteld. Hou er rekening mee dat het even kan duren eer een uitnodiging voor GitHub/GitLab wordt geaccepteerd door ons team. Bekijk [de documentatie](https://docs.dodona.be/nl/guides/teachers/new-exercise-repo/) voor meer informatie.
     models:
       course: Cursus
       activity: Activiteit

--- a/config/locales/models/nl.yml
+++ b/config/locales/models/nl.yml
@@ -12,7 +12,7 @@ nl:
               taken: Je hebt deze activiteit al gelezen
         gitable:
           repository:
-            not_accessible: De repository is niet toegankelijk voor onze git-gebruiker. Controleer of je de juiste permissies hebt ingesteld. Hou er rekening mee dat het even kan duren voor een github/gitlab uitnodiging wordt geaccepteerd door ons team.
+            not_accessible: De repository is niet toegankelijk voor onze git-gebruiker. Controleer of je de juiste permissies hebt ingesteld. Hou er rekening mee dat het even kan duren eer een uitnodiging voor GitHub/GitLab wordt geaccepteerd door ons team.
     models:
       course: Cursus
       activity: Activiteit

--- a/config/locales/views/activities/en.yml
+++ b/config/locales/views/activities/en.yml
@@ -43,6 +43,7 @@ en:
       path: "Path"
       class_progress: Class progress
       class_progress_visibility_disabled: "The class progress is not visible for students."
+      empty: "No activities found"
       progress_chart_info_tried:
         one: "One user started this exercise."
         other: "%{count} users started this exercise."

--- a/config/locales/views/activities/nl.yml
+++ b/config/locales/views/activities/nl.yml
@@ -43,6 +43,7 @@ nl:
       path: "Pad"
       class_progress: Voortgang groep
       class_progress_visibility_disabled: "De voortgang van de groep is niet zichtbaar voor studenten."
+      empty: "Geen activiteiten gevonden"
       progress_chart_info_tried:
         one: "Één gebruiker begon aan deze oefening."
         other: "%{count} gebruikers begonnen aan deze oefening."

--- a/test/controllers/repositories_controller_test.rb
+++ b/test/controllers/repositories_controller_test.rb
@@ -25,11 +25,6 @@ class RepositoriesControllerTest < ActionDispatch::IntegrationTest
 
   test_crud_actions
 
-  test 'should process activities on create' do
-    Repository.any_instance.expects(:process_activities)
-    create_request_expect
-  end
-
   test 'should reprocess activities' do
     Repository.any_instance.expects(:process_activities)
     get reprocess_repository_path(@instance)
@@ -205,6 +200,14 @@ class RepositoryGitControllerTest < ActionDispatch::IntegrationTest
   test 'webhook without commit info should update exercises' do
     post webhook_repository_path(@repository)
     assert_equal 'private', find_echo.access
+  end
+
+  test 'should process activities on create' do
+    Repository.any_instance.expects(:process_activities)
+    user = users(:staff)
+    judge = create :judge, :git_stubbed
+    sign_in user
+    post repositories_path, params: { repository: { name: 'test', remote: @remote.path, judge_id: judge.id } }
   end
 
   test 'should email during repository creation' do


### PR DESCRIPTION
This pull request fixes multiple paper cuts related to repositories.


- [x] The placeholder for the clone url on the repositories/new page mentions github.ugent.be. While correct, github.com would be more logical. From #4240
- [x] When adding a repo, add a better error message when permissions are missing. From #4240
New message:
![image](https://user-images.githubusercontent.com/21177904/217491583-7856d071-fa60-4efb-b7a9-a2a5755a8d1a.png)

- [x] The learning activities table (at least the one on the repo page) has no empty state. From #4240
New empty state:
![image](https://user-images.githubusercontent.com/21177904/216932644-02281846-3c34-4b64-b32a-d2708210a373.png)

- [x] When adding a repository, the existing exercises were not added automatically. From #4240
This issue was only present in staging and production, where the git worker queue allowed the tasks to be done simultaneously/out of order. This should now be forced to consecutive execution.


Part of #4362 .
