### PR TITLE
Reprocess repository after editing the default judge

### DIFF
--- a/app/controllers/repositories_controller.rb
+++ b/app/controllers/repositories_controller.rb
@@ -173,7 +173,7 @@ class RepositoriesController < ApplicationController
       do_reprocess = true
       user_hash[:user] = @repository.admins.first
     end
-    @repository.delay(queue: 'git').process_activities_email_errors(**user_hash) if do_reprocess
+    @repository.process_activities_email_errors_delayed(**user_hash) if do_reprocess
 
     render plain: msg, status: :ok
   end

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -30,6 +30,8 @@ class Repository < ApplicationRecord
   before_create :create_full_path
   after_create :clone_repo_delayed
 
+  after_save :process_activities_email_errors_delayed, if: :saved_change_to_judge_id?
+
   belongs_to :judge
   has_many :activities, dependent: :restrict_with_error
   has_many :labels,
@@ -108,6 +110,10 @@ class Repository < ApplicationRecord
   def clone_repo
     super
     process_activities_email_errors if clone_complete?
+  end
+
+  def process_activities_email_errors_delayed(kwargs = {})
+    delay(queue: 'git').process_activities_email_errors(kwargs)
   end
 
   def process_activities_email_errors(kwargs = {})

--- a/app/views/repositories/_form.html.erb
+++ b/app/views/repositories/_form.html.erb
@@ -39,7 +39,13 @@
   <div class="field form-group row">
     <%= f.label :judge, :class => "col-sm-3 col-form-label" %>
     <div class="col-sm-6"><%= f.select :judge_id, Judge.all.collect {|j| [j.name, j.id]}, {}, {class: "form-select"} %></div>
-    <span class="help-block offset-sm-3 col-sm-6"><%= t ".judge_help" %></span>
+    <span class="help-block offset-sm-3 col-sm-6">
+      <% if repository.new_record? %>
+        <%= markdown t ".judge_help_markdown" %>
+      <% else %>
+        <%= markdown t ".judge_help_edit_markdown" %>
+      <% end %>
+    </span>
   </div>
 
   <% if f.permission?(:featured) %>

--- a/config/locales/views/repositories/en.yml
+++ b/config/locales/views/repositories/en.yml
@@ -2,7 +2,8 @@ en:
   repositories:
     form:
       remote_help: "The SSH clone URL of the exercise repository. Dodona needs read and write permissions to use the repository."
-      judge_help: "This judge will be used when the exercise doesn't specify one."
+      judge_help_markdown: "This judge will be used when the exercise doesn't specify one. You can find an overview of available judges in [our documentation](https://docs.dodona.be/en/references/judges/)."
+      judge_help_edit_markdown: "Changing the judge will change the judge of existing exercises that do not specify a judge themselves. You can find an overview of available judges in [our documentation](https://docs.dodona.be/en/references/judges/)."
       featured:
         title: "Featured"
         toggle-label: "Feature this repository"

--- a/config/locales/views/repositories/nl.yml
+++ b/config/locales/views/repositories/nl.yml
@@ -2,8 +2,8 @@ nl:
   repositories:
     form:
       remote_help: "De SSH 'clone url' van de repository waar de oefeningen te vinden zijn. Dodona heeft lees- en schrijfrechten nodig om de repository te gebruiken."
-      judge_help_markdown: "Deze judge zal gebruikt worden als de oefening zelf geen specifieert. Je vind een overzicht van de beschikbare judges in [onze documentatie](https://docs.dodona.be/nl/references/judges/)."
-      judge_help_edit_markdown: "Het aanpassen van de judge zal de judge van bestaande oefeningen die zelf geen judge specifieerden aanpassen. Je vind een overzicht van de beschikbare judges in [onze documentatie](https://docs.dodona.be/nl/references/judges/)."
+      judge_help_markdown: "Deze judge zal gebruikt worden als de oefening zelf geen specifieert. Je vindt een overzicht van de beschikbare judges in [onze documentatie](https://docs.dodona.be/nl/references/judges/)."
+      judge_help_edit_markdown: "Het aanpassen van de judge zal de judge van bestaande oefeningen die zelf geen judge specifieerden aanpassen. Je vindt een overzicht van de beschikbare judges in [onze documentatie](https://docs.dodona.be/nl/references/judges/)."
       featured:
         title: "Uitgelicht"
         toggle-label: "Deze repository uitlichten"

--- a/config/locales/views/repositories/nl.yml
+++ b/config/locales/views/repositories/nl.yml
@@ -2,7 +2,8 @@ nl:
   repositories:
     form:
       remote_help: "De SSH 'clone url' van de repository waar de oefeningen te vinden zijn. Dodona heeft lees- en schrijfrechten nodig om de repository te gebruiken."
-      judge_help: "Deze judge zal gebruikt worden als de oefening zelf geen specifieert."
+      judge_help_markdown: "Deze judge zal gebruikt worden als de oefening zelf geen specifieert. Je vind een overzicht van de beschikbare judges in [onze documentatie](https://docs.dodona.be/nl/references/judges/)."
+      judge_help_edit_markdown: "Het aanpassen van de judge zal de judge van bestaande oefeningen die zelf geen judge specifieerden aanpassen. Je vind een overzicht van de beschikbare judges in [onze documentatie](https://docs.dodona.be/nl/references/judges/)."
       featured:
         title: "Uitgelicht"
         toggle-label: "Deze repository uitlichten"

--- a/test/controllers/repositories_controller_test.rb
+++ b/test/controllers/repositories_controller_test.rb
@@ -31,6 +31,12 @@ class RepositoriesControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to(@instance)
   end
 
+  test 'should reprocess activities on judge change' do
+    Repository.any_instance.expects(:process_activities)
+    patch repository_path(@instance), params: { repository: { judge_id: create(:judge, :git_stubbed).id } }
+    assert_redirected_to(@instance)
+  end
+
   test 'should get public media' do
     request_public_image
   end

--- a/test/factories/repositories.rb
+++ b/test/factories/repositories.rb
@@ -31,6 +31,7 @@ FactoryBot.define do
 
       after :build do |repository|
         stub_git(repository)
+        repository.stubs(:process_activities)
       end
     end
   end


### PR DESCRIPTION
This pull request ensures that repositories are reprocessed after the default judge changed. It also mentions this info on the edit form, along with a link to a documentations about judges.

![image](https://user-images.githubusercontent.com/21177904/218055572-7f59181d-9bfc-4623-9c62-812222f53e61.png)
![image](https://user-images.githubusercontent.com/21177904/218055843-9e384d4e-67b6-428b-b584-f83ce2c82bca.png)


- [x] Tests were added
- [x] Documentation update can be found at dodona-edu/dodona-edu.github.io#231

Should not be merged before dodona-edu/dodona-edu.github.io#231

Closes #4402 .
