### PR TITLE
Fix big activity repo processing in the db seed

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -284,6 +284,9 @@ if Rails.env.development?
       FileUtils.cp_r(dir, dir + i.to_s)
     end
   end
+  # Add all these new activities to the git repository
+  Open3.capture3('git', 'add', "*", chdir: big_activity_repo.full_path.to_path)
+
   big_activity_repo.process_activities
 
   RepositoryAdmin.create(repository: activity_repo, user: zeus)


### PR DESCRIPTION
This pull request fixes the db seed script.
I don't understand why it used to work before, or what changed.

But right now git returns an exit status 1 when we try to commit after reprocessing the big activity repo, because the files that have been changed, are not added to git and thus there is nothing to commit. This exit status 1 results in an error being thrown and thus a failing seed script.

This problem was seed specific, because it is caused by use manually copying files in the seed and then not adding them to git. In production, all files in a repo will always be tracked by git, because git is the only instance creating new files in those directories.

Adding the new files to git after creating them solves the issue
