### PR TITLE
Fix comma's at the end of activity labels 

### DIFF
--- a/app/views/activities/_labels.html.erb
+++ b/app/views/activities/_labels.html.erb
@@ -16,9 +16,11 @@
         <% end %>
         ...</span>
     <% elsif labels.any? %>
-      <%labels.each_with_index do |label, index| %><%#
-        %><d-filter-button param="labels" value="<%= label.name %>" multi><%= index == 0 ? "" : ", " %><%=label.name%></d-filter-button><%#
-      %><% end %>
+      <% labels.each_with_index do |label, index| %>
+        <d-filter-button param="labels" value="<%= label.name %>" multi>
+          <%= label.name %><%= "," unless index == labels.count - 1 %>
+        </d-filter-button>
+      <% end %>
     <% end %>
   </small>
 </div>

--- a/app/views/activities/_labels.html.erb
+++ b/app/views/activities/_labels.html.erb
@@ -16,7 +16,9 @@
         <% end %>
         ...</span>
     <% elsif labels.any? %>
-      <%= raw labels.map {|label| "<d-filter-button param='labels' value='#{label.name}' multi >#{label.name}</d-filter-button>"}.join(", ") %>
+      <%labels.each_with_index do |label, index| %><%#
+        %><d-filter-button param="labels" value="<%= label.name %>" multi><%=index == 0 ? "" : ", " %><%=label.name%></d-filter-button><%#
+      %><% end %>
     <% end %>
   </small>
 </div>

--- a/app/views/activities/_labels.html.erb
+++ b/app/views/activities/_labels.html.erb
@@ -17,7 +17,7 @@
         ...</span>
     <% elsif labels.any? %>
       <%labels.each_with_index do |label, index| %><%#
-        %><d-filter-button param="labels" value="<%= label.name %>" multi><%=index == 0 ? "" : ", " %><%=label.name%></d-filter-button><%#
+        %><d-filter-button param="labels" value="<%= label.name %>" multi><%= index == 0 ? "" : ", " %><%=label.name%></d-filter-button><%#
       %><% end %>
     <% end %>
   </small>

--- a/app/views/activities/_labels.html.erb
+++ b/app/views/activities/_labels.html.erb
@@ -16,11 +16,7 @@
         <% end %>
         ...</span>
     <% elsif labels.any? %>
-      <% labels.each do |label| %>
-        <d-filter-button param="labels" value="<%= label.name %>" multi>
-          <%= label.name %>,
-        </d-filter-button>
-      <% end %>
+      <%= raw labels.map {|label| "<d-filter-button param='labels' value='#{label.name}' multi >#{label.name}</d-filter-button>"}.join(", ") %>
     <% end %>
   </small>
 </div>


### PR DESCRIPTION
This pull request fixes the dynamic comma's in the activity labels list (e.g. in the exercices table).
![2023-02-16_20-13](https://user-images.githubusercontent.com/56410697/219465014-41f41b7e-760d-442b-ae4f-3fbe0c3192bb.png)

Closes #4220 
