### PR TITLE
Ask for confirmation when making series visible

### DIFF
--- a/app/views/series/_series.html.erb
+++ b/app/views/series/_series.html.erb
@@ -139,19 +139,19 @@
   <% if current_user&.course_admin?(series.course) && series.hidden? %>
     <div class="alert alert-info hidden-print">
       <%= t "series.show.series_not_visible" %>
-      <%= t('series.show.make_visible_html', series_url: series_path(series, series: {visibility: :open}), method: :patch) %>
+      <%= link_to t("series.show.make_visible_text"), series_path(series, series: {visibility: :open}), method: :patch, data: {confirm: t('general.are_you_sure')} %>
     </div>
   <% end %>
   <% if current_user&.course_admin?(series.course) && series.closed? %>
     <div class="alert alert-info hidden-print">
       <%= t "series.show.series_not_accessible" %>
-      <%= t('series.show.make_visible_html', series_url: series_path(series, series: {visibility: :open}), method: :patch) %>
+      <%= link_to t("series.show.make_visible_text"), series_path(series, series: {visibility: :open}), method: :patch, data: {confirm: t('general.are_you_sure')} %>
     </div>
   <% end %>
   <% if current_user&.course_admin?(series.course) && !series.activities_visible %>
     <div class="alert alert-info hidden-print">
       <%= t "series.show.activities_not_visible" %>
-      <%= t('series.show.make_visible_html', series_url: series_path(series, series: {activities_visible: true}), method: :patch) %>
+      <%= link_to t("series.show.make_visible_text"), series_path(series, series: {activities_visible: true}), method: :patch, data: {confirm: t('general.are_you_sure')} %>
     </div>
   <% end %>
   <div class="tab-content">

--- a/config/locales/views/series/en.yml
+++ b/config/locales/views/series/en.yml
@@ -24,7 +24,7 @@ en:
       activities: Learning activities
       download_submissions: Export my submissions
       download_all_solutions: Export student submissions
-      make_visible_html: "<a href=%{series_url} data-method=\"patch\">Make visible</a> for students."
+      make_visible_text: Make visible for students.
       series_not_visible: This series is only visible for students using the secret link!
       series_not_accessible: This series is not accessible to students!
       activities_not_visible: The learning activities in this series are not visible to students!

--- a/config/locales/views/series/nl.yml
+++ b/config/locales/views/series/nl.yml
@@ -24,7 +24,7 @@ nl:
       activities: Leeractiviteiten
       download_submissions: Mijn oplossingen exporteren
       download_all_solutions: Oplossingen van studenten exporteren
-      make_visible_html: "<a href=%{series_url} data-method=\"patch\">Maak zichtbaar</a> voor studenten."
+      make_visible_text: "Maak zichtbaar voor studenten."
       series_not_visible: Deze reeks is enkel zichtbaar voor studenten via de geheime link!
       series_not_accessible: Deze reeks is niet toegankelijk voor studenten!
       activities_not_visible: De leeractiviteiten in deze reeks zijn niet zichtbaar voor studenten!


### PR DESCRIPTION
This pull request makes sure the user/admin is asked for confirmation when using the link on the main course for changing the visibility of the series.

There is a slight change, before:
![2023-02-26_15-37_2](https://user-images.githubusercontent.com/56410697/221418709-ce303b12-4728-40fe-b023-abc30ad0ba44.png)

Now the link is completely bold:
![2023-02-26_16-05](https://user-images.githubusercontent.com/56410697/221418816-6b2ac193-4a4b-4e3f-b457-b9ecf9a8a660.png)

Closes #4243 
