### PR TITLE
Fix the 'hide learning activities' checkbox for series

### DIFF
--- a/app/views/series/_form.html.erb
+++ b/app/views/series/_form.html.erb
@@ -49,8 +49,7 @@
     <div class="field form-group row">
       <div class="offset-sm-3 col-sm-6">
         <div class="form-check">
-          <input type="hidden" value="1" name="series[progress_enabled]">
-          <%= check_box_tag "series[progress_enabled]", "0", !@series.progress_enabled, class: "form-check-input" %>
+          <%= f.check_box :progress_enabled, {checked: !@series.progress_enabled, class: "form-check-input" }, '0', '1' %>
           <%= f.label :progress_enabled, t('.class_progress_disable'), class: 'form-check-label' %>
         </div>
       </div>
@@ -61,8 +60,7 @@
     <div class="field form-group row">
       <div class="col-sm-6 offset-sm-3">
         <div class="form-check">
-          <input type="hidden" value="1" name="series[activities_visible]">
-          <%= check_box_tag "series[activities_visible]", "0", !@series.activities_visible, class: "form-check-input" %>
+          <%= f.check_box :activities_visible, {checked: !@series.activities_visible, class: "form-check-input" }, '0', '1' %>
           <%= f.label :activities_visible, t('.hide_activities'), class:"form-check-label" %>
         </div>
       </div>
@@ -73,7 +71,6 @@
     <div class="field form-group row">
       <div class="col-sm-6 offset-sm-3">
         <div class="form-check">
-          <input type="hidden" value="1" name="series[activities_visible]">
           <%= f.check_box :activity_numbers_enabled, class: "form-check-input" %>
           <%= f.label :activity_numbers_enabled, t('.activity_numbers_enabled'), class:"form-check-label" %>
         </div>


### PR DESCRIPTION
Fixes a bug reported by @freyavs when working on https://github.com/dodona-edu/dodona/pull/4431

To solve the bug only removing the last line was required. But I chose to also refactor the inverted check boxes themselves, because the old method with multiple hidden inputs made it hard to understand what was expected from the code and also harder to debug.