### PR TITLE
Fix second divider in profile menu for different fonts

### DIFF
--- a/app/assets/stylesheets/bootstrap_style_overrides.css.scss
+++ b/app/assets/stylesheets/bootstrap_style_overrides.css.scss
@@ -113,6 +113,10 @@ code {
   @include shadow-z5;
 }
 
+.dropdown-divider {
+  overflow: visible;
+}
+
 // tables
 .table {
   margin-bottom: 0;


### PR DESCRIPTION
This pull request fixes the second divider in the profile menu for different fonts.

I tested this by setting my font smaller than the default size, which caused the same problem as #4219

The fix (with smaller fonts):
![2023-02-27_14-11](https://user-images.githubusercontent.com/56410697/221576129-51ac1b61-3699-4f8b-94e7-df61845982d1.png)

This doesn't break the dividers used in 2 other places:
![2023-02-27_14-14](https://user-images.githubusercontent.com/56410697/221576297-52118fbb-d7f9-4acb-b13a-93c2d543cea4.png)![2023-02-27_14-16](https://user-images.githubusercontent.com/56410697/221576293-7abf6596-41ac-4603-836e-77885660d12b.png)

Closes #4219