### PR TITLE
Make submission page wider (on smaller screens)

### DIFF
--- a/app/views/submissions/show.html.erb
+++ b/app/views/submissions/show.html.erb
@@ -1,6 +1,6 @@
 <%= render 'navbar_links' %>
 <div class="row justify-content-center">
-  <div class="col-lg-8 col-xxl-9 col-12">
+  <div class="col-md-10 col-12">
     <div class="card">
       <div class="card-title card-title-colored">
         <h2 class="card-title-text"><%= t ".submission_results" %></h2>


### PR DESCRIPTION
This pull request makes the submission page a bit wider. More specifically, when the screen becomes smaller than 1400px, the margins shouldn't be too big. The width is now more in line with e.g. the course page (also for screen sizes bigger than 1400px, see below).

For screen size <1400px  (comparison with the course page):
![2023-03-11_13-23_1](https://user-images.githubusercontent.com/56410697/224484582-352a3bdf-5b80-4193-977a-3d29090a61c1.png)
![2023-03-11_13-23](https://user-images.githubusercontent.com/56410697/224484584-e8baa482-c6f6-4ef0-ad1e-5fc6f5c4d018.png)

For screens bigger than 1400px the submission page is also slightly wider now (let me know if you'd like to keep it as it was before):

**Before:**
![2023-03-11_13-22](https://user-images.githubusercontent.com/56410697/224484635-713e0a96-c487-41ce-8c01-47bdb4e92863.png)
 **After**:
![2023-03-11_13-21](https://user-images.githubusercontent.com/56410697/224484643-5570a3e3-c6c5-47fa-8083-a1bd178a0bec.png)


Closes #4191
