### PR TITLE
scoresheet.js: remove jquery and convert to typescript

### DIFF
--- a/app/assets/javascripts/scoresheet.js
+++ b/app/assets/javascripts/scoresheet.js
@@ -1,8 +1,0 @@
-function initScoresheetLinks() {
-    $("#scoresheet-selector").on("change", function () {
-        window.location.href = $(this.options[this.selectedIndex]).data("url") + window.location.search;
-    });
-}
-
-export { initScoresheetLinks };
-

--- a/app/assets/javascripts/scoresheet.ts
+++ b/app/assets/javascripts/scoresheet.ts
@@ -1,0 +1,8 @@
+function initScoresheetLinks(): void {
+    document.querySelector("#scoresheet-selector").addEventListener("change", e => {
+        window.location.href = e.currentTarget.options[e.currentTarget.selectedIndex].dataset.url + window.location.search;
+    });
+}
+
+export { initScoresheetLinks };
+


### PR DESCRIPTION
This pull request removes jquery from `scoresheet.js` and converts it to typescript

This is progress on #3590 
