### PR TITLE
Fix course year dropdown on homepage

### DIFF
--- a/app/javascript/packs/application_pack.js
+++ b/app/javascript/packs/application_pack.js
@@ -37,9 +37,7 @@ import { initClipboard } from "copy";
 import { FaviconManager } from "favicon";
 import "components/saved_annotations/saved_annotation_list";
 import "components/saved_annotations/saved_annotations_sidecard";
-import "components/standalone-dropdown-filter";
 import "components/progress_bar";
-import "components/loading_bar";
 
 // Initialize clipboard.js
 initClipboard();

--- a/app/javascript/packs/search.js
+++ b/app/javascript/packs/search.js
@@ -8,5 +8,7 @@ import "components/search_token.ts";
 import "components/filter_button.ts";
 import "components/dropdown_filter";
 import "components/filter_tabs";
+import "components/standalone-dropdown-filter";
+import "components/loading_bar";
 
 window.dodona.searchQuery = searchQuery;

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -1,5 +1,6 @@
 <%= content_for :javascripts do %>
   <%= javascript_include_tag 'favorite_course_buttons' %>
+  <%= javascript_include_tag 'search' %>
 <% end %>
 <%= render partial: "pages/important_homepage_links" %>
 <div class="row">


### PR DESCRIPTION
This pull request fixes the course year dropdown which was broken by #4460 because the homepage used search components without importing `search.ts`
