### PR TITLE
Replace most_recent_correct by most_resent submissions filter

### DIFF
--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -195,6 +195,6 @@ class SubmissionsController < ApplicationController
 
     # this cannot use has_scope, because we need the scopes in this method
     # to be applied before this one
-    @submissions = @submissions.most_recent_correct_per_user if params[:most_recent_correct_per_user]
+    @submissions = @submissions.most_recent_per_user if params[:most_recent_per_user]
   end
 end

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -85,8 +85,8 @@ class Submission < ApplicationRecord
     HEREDOC
   }
 
-  scope :most_recent_correct_per_user, lambda { |*|
-    correct.group(:user_id).most_recent
+  scope :most_recent_per_user, lambda { |*|
+    group(:user_id).most_recent
   }
 
   scope :least_recent, lambda {

--- a/app/views/submissions/index.html.erb
+++ b/app/views/submissions/index.html.erb
@@ -38,7 +38,7 @@
         <% if current_user&.course_admin?(@course) %>
           <%
              actions << {icon: 'replay', text: t(".reevaluate_submissions"), confirm: t(".confirm_reevaluate_submissions"), action: mass_rejudge_submissions_path(user_id: @user&.id, activity_id: @activity&.id, course_id: @course&.id, series_id: @series&.id, judge_id: @judge&.id)} if policy(Submission).mass_rejudge?
-             actions << {icon: 'done', text: t('.most_recent_correct'), search: {most_recent_correct_per_user: true}} if @activity
+             actions << {icon: 'done', text: t('.most_recent'), search: {most_recent_per_user: true}} if @activity
              actions << {icon: 'file-eye', text: t('.watch_submissions'), search: {refresh: true}, click: 'window.dodona.toggleIndexReload()'}
           %>
         <% end %>

--- a/config/locales/views/submissions/en.yml
+++ b/config/locales/views/submissions/en.yml
@@ -21,7 +21,7 @@ en:
       for: for
       from: from
       read-states: Read activity log
-      most_recent_correct: Most recent correct submissions per user
+      most_recent: Most recent submissions per user
       watch_submissions: Automatically reload submissions
       reevaluate_submissions: Retest submissions
       confirm_reevaluate_submissions: Are you sure you want to retest these submissions?

--- a/config/locales/views/submissions/nl.yml
+++ b/config/locales/views/submissions/nl.yml
@@ -22,7 +22,7 @@ nl:
       from: van
       read-states: Gelezen activiteiten
       watch_submissions: Oplossingen automatisch herladen
-      most_recent_correct: Meest recente correcte oplossing per gebruiker
+      most_recent: Meest recente oplossing per gebruiker
       reevaluate_submissions: Oplossingen hertesten
       confirm_reevaluate_submissions: Ben je zeker dat je deze oplossingen wil hertesten?
       reevaluating_submissions:

--- a/test/controllers/submissions_controller_test.rb
+++ b/test/controllers/submissions_controller_test.rb
@@ -27,7 +27,7 @@ class SubmissionsControllerTest < ActionDispatch::IntegrationTest
     # most_recent works
     create :correct_submission, user: users.first
 
-    get course_activity_submissions_url c, e, most_recent_correct_per_user: true, format: :json
+    get course_activity_submissions_url c, e, most_recent_per_user: true, status: :correct, format: :json
 
     results = response.parsed_body
     result_ids = results.pluck('id')


### PR DESCRIPTION
This pull request removes `most_recent_correct_per_user` scope from submissions and replaces it by `most_recent_per_user`.

Due to the fixed order of filter execution, the old functionality can still be achieved by filtering both on `most_recent_per_user` and the status `correct`.

![image](https://user-images.githubusercontent.com/21177904/225622545-8479f5ed-d406-41bc-bfc6-e00d00104d1a.png)

Order of filter execution could be hard to interpret as an end user. If anyone has any suggestions how to explain this to the user in the UI, please give them.

As it is a rather hidden/advanced option anyway, I wouldn't mind shipping it as is without further clarification.

Closes #1441 .
