### PR TITLE
Add copy code button to code fragments in descriptions

### DIFF
--- a/app/assets/javascripts/components/copy_button.ts
+++ b/app/assets/javascripts/components/copy_button.ts
@@ -1,0 +1,56 @@
+import { ShadowlessLitElement } from "components/shadowless_lit_element";
+import { html, PropertyValues, TemplateResult } from "lit";
+import { customElement, property } from "lit/decorators.js";
+import { initTooltips, ready } from "util.js";
+
+@customElement("d-copy-button")
+export class CopyButton extends ShadowlessLitElement {
+    @property({ type: String })
+    code: string;
+
+    @property({ state: true })
+    status: "idle" | "success" | "error" = "idle";
+
+    async copyCode(): Promise<void> {
+        try {
+            await navigator.clipboard.writeText(this.code);
+            this.status = "success";
+        } catch (err) {
+            this.status = "error";
+        }
+    }
+
+    get tooltip(): string {
+        switch (this.status) {
+        case "success":
+            return I18n.t("js.copy-success");
+        case "error":
+            return I18n.t("js.copy-fail");
+        default:
+            return I18n.t("js.code.copy-to-clipboard");
+        }
+    }
+
+    protected updated(_changedProperties: PropertyValues): void {
+        super.updated(_changedProperties);
+        initTooltips(this);
+    }
+
+    constructor() {
+        super();
+
+        // Reload when I18n is loaded
+        ready.then(() => this.requestUpdate());
+    }
+
+    protected render(): TemplateResult {
+        return html`<button class="btn btn-icon copy-btn"
+                            @click=${() => this.copyCode()}
+                            @focusout=${() => this.status = "idle"}
+                            data-bs-placement="top"
+                            data-bs-toggle="tooltip"
+                            title="${this.tooltip}">
+                <i class="mdi mdi-clipboard-outline"></i>
+            </button>`;
+    }
+}

--- a/app/assets/javascripts/components/copy_button.ts
+++ b/app/assets/javascripts/components/copy_button.ts
@@ -9,7 +9,7 @@ export class CopyButton extends ShadowlessLitElement {
     codeElement: HTMLElement;
 
     get code(): string {
-        return this.codeElement.textContent.trim();
+        return this.codeElement.textContent;
     }
 
     @property({ state: true })

--- a/app/assets/javascripts/components/copy_button.ts
+++ b/app/assets/javascripts/components/copy_button.ts
@@ -3,6 +3,13 @@ import { html, PropertyValues, TemplateResult } from "lit";
 import { customElement, property } from "lit/decorators.js";
 import { initTooltips, ready } from "util.js";
 
+/**
+ * A button that copies the text content of a given element to the clipboard.
+ * The button is styled as a small icon button.
+ * The button is a tooltip that shows the current status of the copy operation.
+ *
+ * @property {HTMLElement} codeElement - The element whose text content is copied to the clipboard.
+ */
 @customElement("d-copy-button")
 export class CopyButton extends ShadowlessLitElement {
     @property({ type: Object })

--- a/app/assets/javascripts/components/copy_button.ts
+++ b/app/assets/javascripts/components/copy_button.ts
@@ -8,6 +8,8 @@ import { initTooltips, ready } from "util.js";
  * The button is styled as a small icon button.
  * The button is a tooltip that shows the current status of the copy operation.
  *
+ * @element d-copy-button
+ *
  * @property {HTMLElement} codeElement - The element whose text content is copied to the clipboard.
  */
 @customElement("d-copy-button")

--- a/app/assets/javascripts/components/copy_button.ts
+++ b/app/assets/javascripts/components/copy_button.ts
@@ -9,7 +9,7 @@ export class CopyButton extends ShadowlessLitElement {
     codeElement: HTMLElement;
 
     get code(): string {
-        return this.codeElement.textContent;
+        return this.codeElement.textContent.trim();
     }
 
     @property({ state: true })

--- a/app/assets/javascripts/components/copy_button.ts
+++ b/app/assets/javascripts/components/copy_button.ts
@@ -5,8 +5,12 @@ import { initTooltips, ready } from "util.js";
 
 @customElement("d-copy-button")
 export class CopyButton extends ShadowlessLitElement {
-    @property({ type: String })
-    code: string;
+    @property({ type: Object })
+    codeElement: HTMLElement;
+
+    get code(): string {
+        return this.codeElement.textContent;
+    }
 
     @property({ state: true })
     status: "idle" | "success" | "error" = "idle";
@@ -16,6 +20,7 @@ export class CopyButton extends ShadowlessLitElement {
             await navigator.clipboard.writeText(this.code);
             this.status = "success";
         } catch (err) {
+            window.getSelection().selectAllChildren(this.codeElement);
             this.status = "error";
         }
     }

--- a/app/assets/javascripts/exercise.ts
+++ b/app/assets/javascripts/exercise.ts
@@ -3,6 +3,8 @@ import { initTooltips, updateURLParameter, fetch } from "util.js";
 import { Toast } from "./toast";
 import GLightbox from "glightbox";
 import { IFrameMessageData } from "iframe-resizer";
+import { render } from "lit";
+import { CopyButton } from "components/copy_button";
 
 function showLightbox(content): void {
     const lightbox = new GLightbox(content);
@@ -110,9 +112,23 @@ function initMathJax(): void {
     };
 }
 
+function initCodeFragments(): void {
+    const codeElements = document.querySelectorAll("code");
+    codeElements.forEach(codeElement => {
+        const code = codeElement.textContent;
+
+        const copyButton = new CopyButton();
+        copyButton.code = code;
+
+        render(copyButton, codeElement, { renderBefore: codeElement.firstChild });
+        initTooltips(codeElement);
+    });
+}
+
 function initExerciseDescription(): void {
     initLightboxes();
     centerImagesAndTables();
+    initCodeFragments();
 }
 
 function initExerciseShow(exerciseId: number, programmingLanguage: string, loggedIn: boolean, editorShown: boolean, courseId: number, _deadline: string, baseSubmissionsUrl: string): void {

--- a/app/assets/javascripts/exercise.ts
+++ b/app/assets/javascripts/exercise.ts
@@ -115,10 +115,8 @@ function initMathJax(): void {
 function initCodeFragments(): void {
     const codeElements = document.querySelectorAll("code");
     codeElements.forEach(codeElement => {
-        const code = codeElement.textContent;
-
         const copyButton = new CopyButton();
-        copyButton.code = code;
+        copyButton.codeElement = codeElement;
 
         render(copyButton, codeElement, { renderBefore: codeElement.firstChild });
         initTooltips(codeElement);

--- a/app/assets/javascripts/exercise.ts
+++ b/app/assets/javascripts/exercise.ts
@@ -113,8 +113,8 @@ function initMathJax(): void {
 }
 
 function initCodeFragments(): void {
-    const codeElements = document.querySelectorAll("code");
-    codeElements.forEach(codeElement => {
+    const codeElements = document.querySelectorAll("pre code");
+    codeElements.forEach((codeElement: HTMLElement) => {
         const copyButton = new CopyButton();
         copyButton.codeElement = codeElement;
 

--- a/app/assets/javascripts/exercise.ts
+++ b/app/assets/javascripts/exercise.ts
@@ -118,7 +118,7 @@ function initCodeFragments(): void {
         const copyButton = new CopyButton();
         copyButton.codeElement = codeElement;
 
-        render(copyButton, codeElement, { renderBefore: codeElement.firstChild });
+        render(copyButton, codeElement.parentElement, { renderBefore: codeElement });
         initTooltips(codeElement);
     });
 }

--- a/app/assets/stylesheets/components/btn.css.scss
+++ b/app/assets/stylesheets/components/btn.css.scss
@@ -138,7 +138,7 @@
     cursor: default;
   }
 
-  &:not(.btn-icon-filled) &:not(.disabled-with-tooltip) {
+  &:not(.btn-icon-filled, .disabled-with-tooltip) {
     &:hover,
     &:focus,
     &:active {

--- a/app/assets/stylesheets/models/activities.css.scss
+++ b/app/assets/stylesheets/models/activities.css.scss
@@ -186,16 +186,13 @@ center img {
   }
 }
 
-pre code {
-  display: inline-block;
+pre {
   position: relative;
-  width: 100%;
-  min-height: 23px;
 
   d-copy-button {
     position: absolute;
     right: 0;
-    top: -8px;
+    top: 0;
     background-color: $code-bg;
   }
 }

--- a/app/assets/stylesheets/models/activities.css.scss
+++ b/app/assets/stylesheets/models/activities.css.scss
@@ -185,3 +185,15 @@ center img {
     padding-top: 0;
   }
 }
+
+code {
+  display: inline-block;
+  position: relative;
+  width: 100%;
+
+  d-copy-button {
+    position: absolute;
+    right: 0;
+    top: -8px;
+  }
+}

--- a/app/assets/stylesheets/models/activities.css.scss
+++ b/app/assets/stylesheets/models/activities.css.scss
@@ -198,6 +198,3 @@ code:has(d-copy-button) {
     top: -8px;
   }
 }
-
-pre:has(d-copy-button) {
-}

--- a/app/assets/stylesheets/models/activities.css.scss
+++ b/app/assets/stylesheets/models/activities.css.scss
@@ -196,5 +196,6 @@ pre code {
     position: absolute;
     right: 0;
     top: -8px;
+    background-color: $code-bg;
   }
 }

--- a/app/assets/stylesheets/models/activities.css.scss
+++ b/app/assets/stylesheets/models/activities.css.scss
@@ -186,14 +186,18 @@ center img {
   }
 }
 
-code {
+code:has(d-copy-button) {
   display: inline-block;
   position: relative;
   width: 100%;
+  min-height: 23px;
 
   d-copy-button {
     position: absolute;
     right: 0;
     top: -8px;
   }
+}
+
+pre:has(d-copy-button) {
 }

--- a/app/assets/stylesheets/models/activities.css.scss
+++ b/app/assets/stylesheets/models/activities.css.scss
@@ -186,7 +186,7 @@ center img {
   }
 }
 
-code {
+pre code {
   display: inline-block;
   position: relative;
   width: 100%;

--- a/app/assets/stylesheets/models/activities.css.scss
+++ b/app/assets/stylesheets/models/activities.css.scss
@@ -186,7 +186,7 @@ center img {
   }
 }
 
-code:has(d-copy-button) {
+code {
   display: inline-block;
   position: relative;
   width: 100%;

--- a/app/helpers/activity_helper.rb
+++ b/app/helpers/activity_helper.rb
@@ -80,7 +80,7 @@ module ActivityHelper
                class: 'dodona-iframe',
                scrolling: 'no',
                onload: resizeframe,
-               allow: 'fullscreen https://www.youtube.com https://www.youtube-nocookie.com https://player.vimeo.com/ ',
+               allow: 'clipboard-write; fullscreen https://www.youtube.com https://www.youtube-nocookie.com https://player.vimeo.com/ ',
                src: url,
                height: '500px'
   end

--- a/app/javascript/packs/description.js
+++ b/app/javascript/packs/description.js
@@ -1,6 +1,9 @@
 import { iframeResizerContentWindow } from "iframe-resizer";
 import { initExerciseDescription, initMathJax } from "exercise.ts";
 
+import { I18n } from "i18n/i18n";
+window.I18n = new I18n();
+
 window.iframeResizerContentWindow = iframeResizerContentWindow;
 window.dodona.initMathJax = initMathJax;
 window.dodona.initDescription = initExerciseDescription;

--- a/app/views/activities/description.html.erb
+++ b/app/views/activities/description.html.erb
@@ -31,5 +31,7 @@
   </div>
 </div>
 <script>
+  I18n = I18n || {};
+  I18n.locale = "<%= I18n.locale %>";
   dodona.ready.then(() => window.dodona.initDescription());
 </script>


### PR DESCRIPTION
This pull request adds a copy code button to code fragments in descriptions.

I matched on the `<pre><code></code></pre>` html tags in descriptions to match all logical cases. This tag is also correctly used by markdown.

![image](https://user-images.githubusercontent.com/21177904/225661618-965b2f2a-180b-48eb-9d4d-3f1a02d5a086.png)

Should the copying fail, it selects the text and suggests to use Ctrl + c

Closes #3532 
