### PR TITLE
Fix relative time indication for submission history

### DIFF
--- a/app/assets/javascripts/i18n/translations.json
+++ b/app/assets/javascripts/i18n/translations.json
@@ -429,6 +429,7 @@
       "with": "with"
     },
     "time": {
+      "ago": "%{time} ago",
       "am": "am",
       "formats": {
         "annotation": "MMMM DD, YYYY HH:mm",
@@ -445,13 +446,15 @@
         "us": "%m/%d/%Y %I:%M %p"
       },
       "pm": "pm",
+      "today": "today",
       "units": {
         "day": "%{smart_count} day |||| %{smart_count} days",
         "hour": "%{smart_count} hour |||| %{smart_count} hours",
         "min": "%{smart_count} minute |||| %{smart_count} minutes",
         "sec": "%{smart_count} second |||| %{smart_count} seconds",
         "week": "%{smart_count} week |||| %{smart_count} weeks"
-      }
+      },
+      "yesterday": "yesterday"
     }
   },
   "nl": {
@@ -884,6 +887,7 @@
       "with": "met"
     },
     "time": {
+      "ago": "%{time} geleden",
       "am": "'s ochtends",
       "formats": {
         "annotation": "D MMMM YYYY, HH:mm",
@@ -899,13 +903,15 @@
         "submission": "%d %B %Y %H:%M:%S"
       },
       "pm": "'s middags",
+      "today": "vandaag",
       "units": {
         "day": "%{smart_count} dag |||| %{smart_count} dagen",
         "hour": "%{smart_count} uur |||| %{smart_count} uren",
         "min": "%{smart_count} minuut |||| %{smart_count} minuten",
         "sec": "%{smart_count} seconde |||| %{smart_count} seconden",
         "week": "%{smart_count} week |||| %{smart_count} weken"
-      }
+      },
+      "yesterday": "gisteren"
     }
   }
 }

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -1,5 +1,6 @@
 class SubmissionsController < ApplicationController
   include SeriesHelper
+  include TimeHelper
   include ActionView::Helpers::DateHelper
 
   before_action :set_submission, only: %i[show download evaluate edit media]
@@ -83,7 +84,7 @@ class SubmissionsController < ApplicationController
     @submissions_time_stamps = []
     prev = nil
     @submissions.each do |s|
-      current = s.created_at.before?(1.day.ago) ? "#{time_ago_in_words(s.created_at)} #{t '.ago'}" : (t '.today')
+      current = days_ago_in_words(s.created_at)
       if current == prev
         @submissions_time_stamps.push nil
       else

--- a/app/helpers/time_helper.rb
+++ b/app/helpers/time_helper.rb
@@ -1,0 +1,13 @@
+module TimeHelper
+  include ActionView::Helpers::DateHelper
+  def days_ago_in_words(time)
+    if time.today?
+      t 'time.today'
+    elsif time.yesterday?
+      t 'time.yesterday'
+    else
+      # need to use I18n.t here because the minitest helper dos not support kwargs yet for t
+      I18n.t 'time.ago', time: time_ago_in_words(time)
+    end
+  end
+end

--- a/config/locales/defaults/en.yml
+++ b/config/locales/defaults/en.yml
@@ -44,6 +44,9 @@ en:
       read_state: '%B %d, %Y %H:%M:%S'
       question: '%B %d, %Y %H:%M:%S'
       plain_time: '%H:%M'
+    yesterday: "yesterday"
+    today: "today"
+    ago: "%{time} ago"
   controllers:
     created: "%{model} was successfully created."
     updated: "%{model} was successfully updated."

--- a/config/locales/defaults/nl.yml
+++ b/config/locales/defaults/nl.yml
@@ -45,6 +45,9 @@ nl:
       read_state: '%d %B %Y %H:%M:%S'
       question: '%d %B %Y %H:%M:%S'
       plain_time: '%H:%M'
+    yesterday: "gisteren"
+    today: "vandaag"
+    ago: "%{time} geleden"
   controllers:
     created: "%{model} werd succesvol aangemaakt."
     updated: "%{model} werd succesvol aangepast."

--- a/config/locales/views/submissions/en.yml
+++ b/config/locales/views/submissions/en.yml
@@ -36,7 +36,6 @@ en:
       course: Course
       handed_in: Handed in
       ago: ago
-      today: today
       status: Status
       result: Result
       code: Code

--- a/config/locales/views/submissions/nl.yml
+++ b/config/locales/views/submissions/nl.yml
@@ -36,7 +36,6 @@ nl:
       course: Cursus
       handed_in: Ingediend
       ago: geleden
-      today: vandaag
       status: Status
       result: Resultaat
       code: Code

--- a/test/helpers/time_helper_test.rb
+++ b/test/helpers/time_helper_test.rb
@@ -1,0 +1,15 @@
+require 'test_helper'
+
+class TimeHelperTest < ActiveSupport::TestCase
+  include TimeHelper
+
+  test 'days ago in words' do
+    I18n.with_locale(:en) do
+      time = Time.zone.now
+      assert_equal 'today', days_ago_in_words(time)
+      assert_equal 'yesterday', days_ago_in_words(1.day.ago)
+      assert_equal '2 days ago', days_ago_in_words(2.days.ago)
+    end
+  end
+
+end

--- a/test/helpers/time_helper_test.rb
+++ b/test/helpers/time_helper_test.rb
@@ -11,5 +11,4 @@ class TimeHelperTest < ActiveSupport::TestCase
       assert_equal '2 days ago', days_ago_in_words(2.days.ago)
     end
   end
-
 end


### PR DESCRIPTION
This pull request fixes the relative time indication shown on the submission detail page.

The goal of this more custom version of time_ago_in_words was to avoid to many different groupings for recent submissions.
But I grouped to many times under today. Introducing yesterday fixes this.

![image](https://user-images.githubusercontent.com/21177904/226566557-97f5cad9-bb62-4f37-9721-bfd6695ade48.png)

- [x] Tests were added

Closes #4490
