### PR TITLE
Check lower limit for memory_limit setting

### DIFF
--- a/app/models/exercise.rb
+++ b/app/models/exercise.rb
@@ -163,7 +163,7 @@ class Exercise < Activity
       c = config
       c['evaluation'] ||= {}
       c['evaluation']['memory_limit'] = 10_000_000 # 10 MB
-      store_config(c, "raised memory limit for #{name}\n\nThe underlying system used to evaluate submissions does not allow a memory limity lower than 6MB.")
+      store_config(c, "raised memory limit for #{name}\n\nThe underlying system used to evaluate submissions does not allow a memory limit lower than 6MB.")
     end
   end
 

--- a/app/models/exercise.rb
+++ b/app/models/exercise.rb
@@ -159,11 +159,11 @@ class Exercise < Activity
       store_config(c, "lowered memory limit for #{name}\n\nThe workers running the student's code only have 4 GB of memory " \
                       "and can run 6 students' code at the same time. The maximum memory limit is 500 MB so that if 6 students submit " \
                       'bad code at the same time, there is still 1 GB of memory left for Dodona itself and the operating system.')
-    elsif limit < 6_000_000 # 6 MB
+    elsif limit < 10_000_000 # 10 MB
       c = config
       c['evaluation'] ||= {}
       c['evaluation']['memory_limit'] = 10_000_000 # 10 MB
-      store_config(c, "raised memory limit for #{name}\n\nThe underlying system used to evaluate submissions does not allow a memory limit lower than 6MB.")
+      store_config(c, "raised memory limit for #{name}\n\nMemory limits under 10MB are not allowed.")
     end
   end
 

--- a/app/models/exercise.rb
+++ b/app/models/exercise.rb
@@ -148,14 +148,23 @@ class Exercise < Activity
 
   def check_memory_limit
     return unless ok?
-    return unless merged_config.fetch('evaluation', {}).fetch('memory_limit', 0) > 500_000_000 # 500MB
 
-    c = config
-    c['evaluation'] ||= {}
-    c['evaluation']['memory_limit'] = 500_000_000
-    store_config(c, "lowered memory limit for #{name}\n\nThe workers running the student's code only have 4 GB of memory " \
-                    "and can run 6 students' code at the same time. The maximum memory limit is 500 MB so that if 6 students submit " \
-                    'bad code at the same time, there is still 1 GB of memory left for Dodona itself and the operating system.')
+    limit = merged_config.fetch('evaluation', {}).fetch('memory_limit', nil)
+    return if limit.nil?
+
+    if limit > 500_000_000 # 500MB
+      c = config
+      c['evaluation'] ||= {}
+      c['evaluation']['memory_limit'] = 500_000_000
+      store_config(c, "lowered memory limit for #{name}\n\nThe workers running the student's code only have 4 GB of memory " \
+                      "and can run 6 students' code at the same time. The maximum memory limit is 500 MB so that if 6 students submit " \
+                      'bad code at the same time, there is still 1 GB of memory left for Dodona itself and the operating system.')
+    elsif limit < 6_000_000 # 6 MB
+      c = config
+      c['evaluation'] ||= {}
+      c['evaluation']['memory_limit'] = 10_000_000 # 10 MB
+      store_config(c, "raised memory limit for #{name}\n\nThe underlying system used to evaluate submissions does not allow a memory limity lower than 6MB.")
+    end
   end
 
   def self.move_relations(from, to)

--- a/test/models/repository_test.rb
+++ b/test/models/repository_test.rb
@@ -250,6 +250,16 @@ class EchoRepositoryTest < ActiveSupport::TestCase
     assert_equal 500_000_000, JSON.parse(File.read(File.join(@remote.path, @echo.path, 'config.json')))['evaluation']['memory_limit']
   end
 
+  test 'should overwrite memory limit that is too low' do
+    @remote.update_json("#{@echo.path}/config.json", 'set a very low memory limit') do |json|
+      json['evaluation']['memory_limit'] = 10
+      json
+    end
+    @repository.reset
+    @repository.process_activities
+    assert_equal 10_000_000, JSON.parse(File.read(File.join(@remote.path, @echo.path, 'config.json')))['evaluation']['memory_limit']
+  end
+
   test 'should convert to content page' do
     assert @echo.submissions.empty?
     @remote.update_json("#{@echo.path}/config.json", 'convert to content page') do |json|

--- a/test/testhelpers/remote_helper.rb
+++ b/test/testhelpers/remote_helper.rb
@@ -33,11 +33,8 @@ class TempRepository < GitRepository
   end
 
   def update_file(rel_path, msg = nil)
-    File.open(File.join(@path, rel_path), 'r+') do |f|
-      contents = f.read
-      f.seek(0, IO::SEEK_SET)
-      f.write(yield contents)
-    end
+    contents = File.read(File.join(@path, rel_path))
+    File.write(File.join(@path, rel_path), (yield contents))
     msg ||= "update #{rel_path}"
     commit msg
   end


### PR DESCRIPTION
Docker does not allow a limit below 6MB, which results in internal errors if people try to use one that low anyway.

- [x] Tests were added
