### PR TITLE
Use given_name and family_name field provided by office365

### DIFF
--- a/config/initializers/office365.rb
+++ b/config/initializers/office365.rb
@@ -33,10 +33,18 @@ module OmniAuth
       uid { raw_info['oid'] }
 
       info do
+        if raw_info['family_name'] || raw_info['given_name']
+          last_name = raw_info['family_name'] || ''
+          first_name = raw_info['given_name'] || ''
+        else
+          last_name = raw_info['name']
+          first_name = ''
+        end
+
         {
             username: username,
-            first_name: raw_info['name'].split(' ').first,
-            last_name: raw_info['name'].split(' ').drop(1).join(' '),
+            first_name: first_name,
+            last_name: last_name,
             email: raw_info['email'],
             institution: raw_info['tid']
         }


### PR DESCRIPTION
This pull request uses the given_name and family_name field that is provided by office365.

Old behavior is kept in case these fields are not present. I did remove the name splitting logic from the office365 initializer as this logic was duplicated in the user model (and will thus still trigger if no given_name is present).

Closes #4504 
