### PR TITLE
Allow some deviation from the code coverage

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -5,9 +5,11 @@ coverage:
   status:
     project:
       rails:
+        threshold: 0.25%
         flags:
           - rails
       system:
+        threshold: 0.25%
         flags:
           - system
       javascript:


### PR DESCRIPTION
This pull request allows some deviation on the rails and system test coverage.

The actually problem is that our test coverage does not seem to be deterministic. This results in minor coverage deviations even if no code has changed.

Allowing these deviations will resolve package bumps with failing codecov status.
