### PR TITLE
Fix the restore boilerplate button

### DIFF
--- a/app/assets/javascripts/exercise.ts
+++ b/app/assets/javascripts/exercise.ts
@@ -454,7 +454,12 @@ function initExerciseShow(exerciseId: number, programmingLanguage: string, logge
 
         const resetButton = restoreWarning.querySelector("a");
         resetButton.addEventListener("click", () => {
-            editor.setValue(boilerplate);
+            // the boilerplate has been escaped, so we need to unescape it
+            const wrapper = document.createElement("div");
+            wrapper.innerHTML = boilerplate;
+            const rawBoilerplate = wrapper.textContent || wrapper.innerText || "";
+
+            editor.setValue(rawBoilerplate);
             editor.focus();
             restoreWarning.hidden = true;
         });

--- a/app/views/activities/show.html.erb
+++ b/app/views/activities/show.html.erb
@@ -182,7 +182,7 @@ end %>
             <%= @course&.id || "null" %>,
             <%= raw "\"#{@series&.deadline&.httpdate}\"" || "null" %>,
             "<%= submissions_url %>",
-            `<%= (@activity.exercise? && raw(@activity.boilerplate&.gsub!('`', '\\\\`')))|| "" %>`,
+            `<%= (@activity.exercise? && @activity.boilerplate&.gsub('`', '\\\\`'))|| "" %>`,
         );
     });
 </script>

--- a/babel.config.js
+++ b/babel.config.js
@@ -40,7 +40,7 @@ module.exports = function (api) {
             "@babel/plugin-syntax-dynamic-import",
             "@babel/plugin-transform-for-of",
             isTestEnv && "babel-plugin-dynamic-import-node",
-            isDevelopmentEnv && ["istanbul", { include: ["app/assets/javascripts/**/*.{js,ts}"] }],
+            isDevelopmentEnv && ["istanbul", { include: ["app/assets/javascripts/**/*.{js,ts}"], coverageGlobalScopeFunc: false, coverageGlobalScope: "window" }],
             "@babel/plugin-transform-destructuring",
             ["@babel/plugin-proposal-class-properties", { loose: true }],
             ["@babel/plugin-proposal-decorators", { decoratorsBeforeExport: true }],

--- a/test/system/activities_test.rb
+++ b/test/system/activities_test.rb
@@ -39,22 +39,24 @@ class ActivitiesTest < ApplicationSystemTestCase
   end
 
   test 'should show message to restore boilerplate if latest submission is shown' do
-    @instance.stubs(:boilerplate).returns('boilerplate') do
-      create(:submission, exercise: @instance, user: @user, status: :correct, code: 'print("hello")')
-      visit exercise_path(id: @instance.id)
-      assert_text 'Restore boilerplate'
-    end
+    Exercise.any_instance.stubs(:boilerplate).returns('boilerplate')
+    create(:submission, exercise: @instance, user: @user, status: :correct, code: 'print("hello")')
+    visit exercise_path(id: @instance.id)
+    assert_text 'Restore the boilerplate code.'
+    find('a', text: 'Restore the boilerplate code.').click
+    assert_text 'boilerplate'
   end
 
   test 'should not break on complex unicode characters' do
-    @instance.stubs(:boilerplate).returns('`<script>alert("😀")</script>`') do
-      visit exercise_path(id: @instance.id)
-      assert_text '`<script>alert("😀")</script>`'
+    Exercise.any_instance.stubs(:boilerplate).returns('`<script>alert("😀")</script>`')
+    visit exercise_path(id: @instance.id)
+    assert_text '`<script>alert("😀")</script>`'
 
-      create(:submission, exercise: @instance, user: @user, status: :correct, code: 'print("😀")')
-      visit exercise_path(id: @instance.id)
-      assert_text 'print("😀")'
-      assert_text 'Restore boilerplate'
-    end
+    create(:submission, exercise: @instance, user: @user, status: :correct, code: 'print("😀")')
+    visit exercise_path(id: @instance.id)
+    assert_text 'print("😀")'
+    assert_text 'Restore the boilerplate code.'
+    find('a', text: 'Restore the boilerplate code.').click
+    assert_text '`<script>alert("😀")</script>`'
   end
 end


### PR DESCRIPTION
This pull request fixes the restore boilerplate button.
It also fixes the related tests, which is why I missed it being broken.

It also includes an unrelated fix that allows istanbul to work correctly inside iframes. This bug was development only and appeared in #4526.  More info can be found in this issue: https://github.com/istanbuljs/babel-plugin-istanbul/issues/281

- [x] Tests were added

Closes #4527 
