### PR TITLE
Use `create_or_find_by`  to reduce activity status deadlocks

### DIFF
--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -450,7 +450,7 @@ class Activity < ApplicationRecord
     begin
       ActivityStatus.create_or_find_by(activity: self, series: series, user: user)
     rescue StandardError
-      # https://github.com/dodona-edu/dodona/issues/1877
+      # https://github.com/dodona-edu/dodona/pull/4547
       raise unless first_try
 
       first_try = false

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -448,7 +448,7 @@ class Activity < ApplicationRecord
   def activity_status_for!(user, series = nil)
     first_try = true
     begin
-      ActivityStatus.find_or_create_by(activity: self, series: series, user: user)
+      ActivityStatus.create_or_find_by(activity: self, series: series, user: user)
     rescue StandardError
       # https://github.com/dodona-edu/dodona/issues/1877
       raise unless first_try

--- a/app/models/activity_status.rb
+++ b/app/models/activity_status.rb
@@ -31,12 +31,10 @@ class ActivityStatus < ApplicationRecord
   belongs_to :series, optional: true
   belongs_to :user
 
-  validates :series_id_non_nil, uniqueness: { scope: %i[user_id activity_id] }, on: :create
-
   scope :in_series, ->(series) { where(series: series) }
   scope :for_user, ->(user) { where(user: user) }
 
-  before_validation :initialise_series_id_non_nil, if: -> { new_record? }
+  before_create :initialise_series_id_non_nil
   before_create :initialise_values_for_content_page, if: -> { activity.content_page? }
   before_create :initialise_values_for_exercise, if: -> { activity.exercise? }
 

--- a/app/models/series_membership.rb
+++ b/app/models/series_membership.rb
@@ -32,11 +32,11 @@ class SeriesMembership < ApplicationRecord
   def add_activity_statuses
     if activity.is_a? Exercise
       activity.submissions.where(course: series.course).distinct(:user_id).find_each do |submission|
-        ActivityStatus.create(series: series, activity: activity, user: submission.user)
+        ActivityStatus.create_or_find_by(series: series, activity: activity, user: submission.user)
       end
     else
       activity.activity_read_states.where(course: series.course).distinct(:user_id).find_each do |ars|
-        ActivityStatus.create(series: series, activity: activity, user: ars.user)
+        ActivityStatus.create_or_find_by(series: series, activity: activity, user: ars.user)
       end
     end
   end

--- a/test/models/activity_status_test.rb
+++ b/test/models/activity_status_test.rb
@@ -44,7 +44,10 @@ class ActivityStatusTest < ActiveSupport::TestCase
     activity = exercises(:python_exercise)
     user = users(:student)
     ActivityStatus.create(user: user, activity: activity, series: nil)
-    ActivityStatus.create(user: user, activity: activity, series: nil)
+    assert_equal 1, ActivityStatus.count
+    assert_raises ActiveRecord::RecordNotUnique do
+      ActivityStatus.create(user: user, activity: activity, series: nil)
+    end
     assert_equal 1, ActivityStatus.count
   end
 


### PR DESCRIPTION
This pull request replace `find_or_create_by` with `create_or_find_by` to reduce the number of deadlocks.

According to the [docs](https://api.rubyonrails.org/classes/ActiveRecord/Relation.html#method-i-create_or_find_by):
> This is similar to [find_or_create_by](https://api.rubyonrails.org/classes/ActiveRecord/Relation.html#method-i-find_or_create_by), but avoids the problem of stale reads between the SELECT and the INSERT, as that method needs to first query the table, then attempt to insert a row if none is found.

I left in the single retry attempt because a deadlock is still possible if an activity_status is deleted:
> While we avoid the race condition between SELECT -> INSERT from [find_or_create_by](https://api.rubyonrails.org/classes/ActiveRecord/Relation.html#method-i-find_or_create_by), we actually have another race condition between INSERT -> SELECT, which can be triggered if a DELETE between those two statements is run by another client. But for most applications, that's a significantly less likely condition to hit.

To be able to use this method, I had to remove the rails unique validation. We already have a database unique index for this, which throws the expected error. I adjusted one test, to fix it and to make sure this error gets thrown.

I also had to change the method in the one other place where activity status are created to be able to handle these new unique errors.

See #1877 for some history on this issue.

Closes #4479
