### PR TITLE
Improve the UX for restoring boilerplate

### DIFF
--- a/app/assets/javascripts/exercise.ts
+++ b/app/assets/javascripts/exercise.ts
@@ -461,6 +461,7 @@ function initExerciseShow(exerciseId: number, programmingLanguage: string, logge
 
             editor.setValue(rawBoilerplate);
             editor.focus();
+            editor.clearSelection();
             restoreWarning.hidden = true;
         });
     }

--- a/app/views/activities/show.html.erb
+++ b/app/views/activities/show.html.erb
@@ -115,9 +115,9 @@ end %>
                 </div>
               <% end %>
               <% if !@edit_submission && !@solution && @last_submission %>
-                <div class="alert alert-info" id="restore-boilerplate">
+                <div class="callout callout-info mt-0" id="restore-boilerplate">
                   <%= t ".preloaded_info" %>
-                  <a >
+                  <a class="link-primary">
                     <%= t(@activity.boilerplate ? ".preloaded_restore" : ".preloaded_clear") %>
                   </a>
                 </div>

--- a/config/locales/views/activities/en.yml
+++ b/config/locales/views/activities/en.yml
@@ -96,7 +96,7 @@ en:
       read_at: "Marked as read on %{timestamp}"
       preloaded_info: "We have preloaded your latest submission into the editor."
       preloaded_clear: Clear editor.
-      preloaded_restore: Restore the boilerplate code.
+      preloaded_restore: Restore the initial code.
     series_activities_add_table:
       course_added_to_usable: "Adding this exercise will allow this course to use all of the private exercises in this exercise's repository. Are you sure?"
     edit:

--- a/config/locales/views/activities/nl.yml
+++ b/config/locales/views/activities/nl.yml
@@ -96,7 +96,7 @@ nl:
       read_at: "Gelezen op %{timestamp}"
       preloaded_info: We hebben jouw laatste oplossing ingeladen in de editor.
       preloaded_clear: Maak de editor leeg.
-      preloaded_restore: Herstel de boilerplate-code.
+      preloaded_restore: Zet de voorbeeldcode terug.
     series_activities_add_table:
       course_added_to_usable: "Deze oefening toevoegen zal deze cursus toegang geven tot alle privé oefeningen in de repository van deze oefening. Ben je zeker?"
     edit:

--- a/test/system/activities_test.rb
+++ b/test/system/activities_test.rb
@@ -42,8 +42,8 @@ class ActivitiesTest < ApplicationSystemTestCase
     Exercise.any_instance.stubs(:boilerplate).returns('boilerplate')
     create(:submission, exercise: @instance, user: @user, status: :correct, code: 'print("hello")')
     visit exercise_path(id: @instance.id)
-    assert_text 'Restore the boilerplate code.'
-    find('a', text: 'Restore the boilerplate code.').click
+    assert_text 'Restore the initial code.'
+    find('a', text: 'Restore the initial code.').click
     assert_text 'boilerplate'
   end
 
@@ -55,8 +55,8 @@ class ActivitiesTest < ApplicationSystemTestCase
     create(:submission, exercise: @instance, user: @user, status: :correct, code: 'print("😀")')
     visit exercise_path(id: @instance.id)
     assert_text 'print("😀")'
-    assert_text 'Restore the boilerplate code.'
-    find('a', text: 'Restore the boilerplate code.').click
+    assert_text 'Restore the initial code.'
+    find('a', text: 'Restore the initial code.').click
     assert_text '`<script>alert("😀")</script>`'
   end
 end


### PR DESCRIPTION
This pull request contains multiple minor UX improvements for restoring boilerplate code.

1. Replace alert with a callout: it attracts less attention as this should no be a primary action
2. Simplify the link text. 'Boilerplate' is not a novice friendly term. Closes #4512
3. Do not select newly loaded boilerplate. Closes #4548 
![Peek 2023-04-06 14-13](https://user-images.githubusercontent.com/21177904/230375655-0b58cbb6-da37-47d6-b271-aba948ebf222.gif)
