### PR TITLE
Fix broken links from feedback tab to code-tab

### DIFF
--- a/app/assets/javascripts/submission.ts
+++ b/app/assets/javascripts/submission.ts
@@ -57,7 +57,11 @@ function initSubmissionShow(parentClass: string, mediaPath: string, token: strin
                 // prevent automatic scrolling to top of the page when clicking a link
                 e.preventDefault();
 
-                const tab = document.querySelector(`.feedback-table .nav-tabs > li a[href*='#tab-${tabName}']`);
+                const tabs = document.querySelectorAll(`.feedback-table .nav-tabs > li a[href*='#tab-${tabName}-']`);
+                if (tabs.length === 0) {
+                    return;
+                }
+                const tab = tabs[tabs.length - 1];
                 new bootstrap.Tab(tab).show();
 
                 if (line !== undefined) {

--- a/app/assets/javascripts/submission.ts
+++ b/app/assets/javascripts/submission.ts
@@ -58,11 +58,10 @@ function initSubmissionShow(parentClass: string, mediaPath: string, token: strin
                 e.preventDefault();
 
                 const tabs = document.querySelectorAll(`.feedback-table .nav-tabs > li a[href*='#tab-${tabName}-']`);
-                if (tabs.length === 0) {
-                    return;
+                if (tabs.length > 0) {
+                    const tab = tabs[tabs.length - 1];
+                    new bootstrap.Tab(tab).show();
                 }
-                const tab = tabs[tabs.length - 1];
-                new bootstrap.Tab(tab).show();
 
                 if (line !== undefined) {
                     dodona.codeListing.clearHighlights();

--- a/app/assets/javascripts/submission.ts
+++ b/app/assets/javascripts/submission.ts
@@ -57,7 +57,7 @@ function initSubmissionShow(parentClass: string, mediaPath: string, token: strin
                 // prevent automatic scrolling to top of the page when clicking a link
                 e.preventDefault();
 
-                const query = tabName ?
+                const query = tabName && tabName !== "code" ?
                     `.feedback-table .nav-tabs > li a[href*='#tab-${tabName}']` :
                     "#link-to-code-tab";
                 const tab = document.querySelector(query);

--- a/app/assets/javascripts/submission.ts
+++ b/app/assets/javascripts/submission.ts
@@ -51,17 +51,17 @@ function initSubmissionShow(parentClass: string, mediaPath: string, token: strin
         document.querySelectorAll("a.tab-link").forEach(t => {
             t.addEventListener("click", e => {
                 const link = e.currentTarget;
-                const tabName = link.dataset.tab || "code";
+                const tabName = link.dataset.tab;
                 const line = link.dataset.line;
 
                 // prevent automatic scrolling to top of the page when clicking a link
                 e.preventDefault();
 
-                const tabs = document.querySelectorAll(`.feedback-table .nav-tabs > li a[href*='#tab-${tabName}-']`);
-                if (tabs.length > 0) {
-                    const tab = tabs[tabs.length - 1];
-                    new bootstrap.Tab(tab).show();
-                }
+                const query = tabName ?
+                    `.feedback-table .nav-tabs > li a[href*='#tab-${tabName}']` :
+                    "#link-to-code-tab";
+                const tab = document.querySelector(query);
+                new bootstrap.Tab(tab).show();
 
                 if (line !== undefined) {
                     dodona.codeListing.clearHighlights();

--- a/app/helpers/renderers/feedback_table_renderer.rb
+++ b/app/helpers/renderers/feedback_table_renderer.rb
@@ -79,10 +79,12 @@ class FeedbackTableRenderer
                     end
           @builder.li do
             id = tab_id(t, i)
-            @builder.a(href: "##{id}", 'data-bs-toggle': 'tab', class: "tab-#{permission} #{'active' if i.zero?}", title: tooltip) do
+            # the pythonic devil has the code tab as a generic tab
+            is_code_tab = t[:data] && t[:data][:source_annotations]
+            @builder.a(href: "##{id}", 'data-bs-toggle': 'tab', class: "tab-#{permission} #{'active' if i.zero?}", title: tooltip, id: is_code_tab ? 'link-to-code-tab' : nil) do
               @builder.text!("#{(t[:description] || 'Test').upcase_first} ")
               # Choose between the pythonic devil and the deep blue sea.
-              badge_id = t[:data] && t[:data][:source_annotations] ? 'code' : id
+              badge_id = is_code_tab ? 'code' : id
               @builder.span(class: 'badge rounded-pill', id: "badge_#{badge_id}") do
                 @builder.text! tab_count(t)
               end
@@ -91,7 +93,7 @@ class FeedbackTableRenderer
         end
         if show_code_tab
           @builder.li(class: ('active' if submission[:groups].blank?)) do
-            @builder.a(href: '#tab-code--1', 'data-bs-toggle': 'tab') do
+            @builder.a(href: '#code-tab', 'data-bs-toggle': 'tab', id: 'link-to-code-tab') do
               @builder.text!("#{I18n.t('submissions.show.code')} ")
               @builder.span(class: 'badge rounded-pill', id: 'badge_code')
             end
@@ -101,7 +103,7 @@ class FeedbackTableRenderer
       @builder.div(class: 'tab-content') do
         @result[:groups].each_with_index { |t, i| tab(t, i) } if submission[:groups]
         if show_code_tab
-          @builder.div(class: "tab-pane #{'active' if submission[:groups].blank?}", id: 'tab-code--1') do
+          @builder.div(class: "tab-pane #{'active' if submission[:groups].blank?}", id: 'code-tab') do
             if submission[:annotations]
               @builder.div(class: 'linter') do
                 source(@code, submission[:annotations])

--- a/app/helpers/renderers/feedback_table_renderer.rb
+++ b/app/helpers/renderers/feedback_table_renderer.rb
@@ -91,7 +91,7 @@ class FeedbackTableRenderer
         end
         if show_code_tab
           @builder.li(class: ('active' if submission[:groups].blank?)) do
-            @builder.a(href: '#code-tab', 'data-bs-toggle': 'tab') do
+            @builder.a(href: '#tab-code--1', 'data-bs-toggle': 'tab') do
               @builder.text!("#{I18n.t('submissions.show.code')} ")
               @builder.span(class: 'badge rounded-pill', id: 'badge_code')
             end
@@ -101,7 +101,7 @@ class FeedbackTableRenderer
       @builder.div(class: 'tab-content') do
         @result[:groups].each_with_index { |t, i| tab(t, i) } if submission[:groups]
         if show_code_tab
-          @builder.div(class: "tab-pane #{'active' if submission[:groups].blank?}", id: 'code-tab') do
+          @builder.div(class: "tab-pane #{'active' if submission[:groups].blank?}", id: 'tab-code--1') do
             if submission[:annotations]
               @builder.div(class: 'linter') do
                 source(@code, submission[:annotations])

--- a/app/views/submissions/show.html.erb
+++ b/app/views/submissions/show.html.erb
@@ -16,8 +16,8 @@
         <%= render partial: 'description', locals: {submission: @submission} %>
         <script>
           dodona.ready.then(() => {
-            <%# Python judge has a code tab with href="#code-n" where n is the
-                number of tabs and for the other judges it is "#code-tab", so we
+            <%# Python judge has a code tab with href="#tab-code-n" where n is the
+                number of tabs and for the other judges it is "#tab-code--1", so we
                 can't generically handle code tabs, except for selecting the last
                 tab. %>
             if (window.location.hash === "#code") {

--- a/app/views/submissions/show.html.erb
+++ b/app/views/submissions/show.html.erb
@@ -17,7 +17,7 @@
         <script>
           dodona.ready.then(() => {
             <%# Python judge has a code tab with href="#tab-code-n" where n is the
-                number of tabs and for the other judges it is "#tab-code--1", so we
+                number of tabs and for the other judges it is "#code-tab", so we
                 can't generically handle code tabs, except for selecting the last
                 tab. %>
             if (window.location.hash === "#code") {


### PR DESCRIPTION
This pull request fixes the links to the code-tab from feedback tabs.

The bug in #4532 was caused because the tab names in the exercise start with the text _'code'_, eg:  https://dodona.ugent.be/nl/feedbacks/133341763/

The bug in https://github.com/dodona-edu/universal-judge/issues/285 was caused by the normal rendere using a different id for the code-tab than the pythia renderer.

Fixed both by giving the code tab a unique id.

Closes #4532 and https://github.com/dodona-edu/universal-judge/issues/285
