### PR TITLE
Fix mestra deploy

### DIFF
--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -65,7 +65,7 @@ class Repository < ApplicationRecord
   scope :featured, -> { where(featured: true) }
 
   def full_path
-    Pathname.new File.join(ACTIVITY_LOCATIONS, path)
+    Pathname.new File.join(ACTIVITY_LOCATIONS, path || "")
   end
 
   def public_path

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -65,7 +65,7 @@ class Repository < ApplicationRecord
   scope :featured, -> { where(featured: true) }
 
   def full_path
-    Pathname.new File.join(ACTIVITY_LOCATIONS, path || "")
+    Pathname.new File.join(ACTIVITY_LOCATIONS, path)
   end
 
   def public_path

--- a/config/deploy/mestra.rb
+++ b/config/deploy/mestra.rb
@@ -20,9 +20,9 @@ namespace :deploy do
   before :restart, :reset_db do
     on roles(:web) do
       within release_path do
-        execute :rm, '-r', 'data/exercises/*'
-        execute :rm, '-r', 'data/judges/*'
-        execute :rm, '-r', 'data/storage/*'
+        execute :rm, '-rf', 'data/exercises/*'
+        execute :rm, '-rf', 'data/judges/*'
+        execute :rm, '-rf', 'data/storage/*'
         execute :rake, 'db:reset'
       end
     end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -273,6 +273,7 @@ if Rails.env.development?
   puts "Create & clone activity repository (#{Time.now - start})"
   Delayed::Worker.delay_jobs = ->(job) { 'git' != job.queue }
   activity_repo = Repository.create name: 'Example Python Activities', remote: 'git@github.com:dodona-edu/example-exercises.git', judge: python_judge, allowed_courses: courses, featured: true
+  puts activity_repo.errors.full_messages unless activity_repo.valid?
   activity_repo.process_activities
 
   big_activity_repo = Repository.create name: 'A lot of python activities', remote: 'git@github.com:dodona-edu/example-exercises.git', judge: python_judge, allowed_courses: courses


### PR DESCRIPTION
This pull request forces the removal of directories, even if they do not exist yet.
This is only required when a previous deployment failed.

The actual underlying bug that caused the first change was the github keys having changed, and git throwing on error on the  clone command.
I left in the logging line that gave me this info, as it is an optional log on a failure to create a repo.
