### PR TITLE
Speed up submission result construction

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,7 @@ gem 'image_processing', '~> 1.12.2'
 gem 'bootsnap', '~> 1.16.0', require: false
 
 # used to validate container responses
-gem 'json-schema', '~> 3.0.0'
+gem 'json_schemer', '~> 0.2.24'
 
 # delayed jobs
 gem 'delayed_job_active_record', '~> 4.1.7'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -160,6 +160,8 @@ GEM
     docker-api (2.2.0)
       excon (>= 0.47.0)
       multi_json
+    ecma-re-validator (0.4.0)
+      regexp_parser (~> 2.2)
     ed25519 (1.3.0)
     erubi (1.12.0)
     exception_notification (4.5.0)
@@ -185,6 +187,7 @@ GEM
     glob (0.4.0)
     globalid (1.1.0)
       activesupport (>= 5.0)
+    hana (1.3.7)
     has_scope (0.8.1)
       actionpack (>= 5.2)
       activesupport (>= 5.2)
@@ -220,8 +223,11 @@ GEM
       bindata
       faraday (~> 2.0)
       faraday-follow_redirects
-    json-schema (3.0.0)
-      addressable (>= 2.8)
+    json_schemer (0.2.24)
+      ecma-re-validator (~> 0.3)
+      hana (~> 1.3)
+      regexp_parser (~> 2.0)
+      uri_template (~> 0.7)
     jwt (2.7.0)
     kramdown (2.4.0)
       rexml
@@ -466,6 +472,7 @@ GEM
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.4.2)
+    uri_template (0.7.0)
     validate_email (0.1.6)
       activemodel (>= 3.0)
       mail (>= 2.2.5)
@@ -536,7 +543,7 @@ DEPENDENCIES
   image_processing (~> 1.12.2)
   jbuilder (~> 2.11.5)
   jsbundling-rails (~> 1.1.1)
-  json-schema (~> 3.0.0)
+  json_schemer (~> 0.2.24)
   jwt (~> 2.7.0)
   kramdown (~> 2.4.0)
   kramdown-parser-gfm (~> 1.1.0)

--- a/app/runners/result_constructor.rb
+++ b/app/runners/result_constructor.rb
@@ -1,5 +1,5 @@
 require 'json' # JSON support
-require 'json-schema' # json schema validation, from json-schema gem
+require 'json_schemer' # json schema validation
 
 class ResultConstructorError < StandardError
   attr_accessor :title, :description
@@ -12,8 +12,8 @@ class ResultConstructorError < StandardError
 end
 
 class ResultConstructor
-  FULL_SCHEMA = JSON.parse(Rails.public_path.join('schemas/judge_output.json').read)
-  PART_SCHEMA = JSON.parse(Rails.public_path.join('schemas/partial_output.json').read)
+  FULL_SCHEMER = JSONSchemer.schema(Rails.public_path.join('schemas/judge_output.json'))
+  PART_SCHEMER = JSONSchemer.schema(Rails.public_path.join('schemas/partial_output.json'))
 
   LEVELSA = %i[judgement tab context testcase test].freeze
   LEVELSH = { judgement: 0, tab: 1, context: 2, testcase: 3, test: 4 }.freeze
@@ -29,9 +29,9 @@ class ResultConstructor
     raise ResultConstructorError, 'No judge output' if judge_output.empty?
 
     split_jsons(judge_output).each do |json|
-      if JSON::Validator.validate(PART_SCHEMA, json)
+      if PART_SCHEMER.valid?(json.deep_stringify_keys)
         update(json)
-      elsif JSON::Validator.validate(FULL_SCHEMA, json)
+      elsif FULL_SCHEMER.valid?(json.deep_stringify_keys)
         @result = json
       else
         raise ResultConstructorError.new(

--- a/config/application.rb
+++ b/config/application.rb
@@ -47,5 +47,8 @@ module Dodona
     config.active_storage.queues.purge    = :default
 
     config.action_view.default_form_builder = "StandardFormBuilder"
+
+    # Should the slower but fuller validation of judge results happen
+    config.slow_judge_results_validation = true
   end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -145,4 +145,7 @@ Rails.application.configure do
   config.action_mailer.deliver_later_queue_name = 'default'
 
   config.submissions_storage_path = Rails.root.join('data', 'storage', 'submissions')
+
+  # Should the slower but fuller validation of judge results happen
+  config.slow_judge_results_validation = false
 end

--- a/public/schemas/judge_output.json
+++ b/public/schemas/judge_output.json
@@ -88,7 +88,7 @@
         "type":    { "$ref": "#/definitions/severity" },
         "rows":    { "$ref": "#/definitions/index" },
         "columns": { "$ref": "#/definitions/index" },
-        "externalUrl":    { "type": "string" }
+        "externalUrl":    { "type": ["string", "null"] }
       }
     },
     "test-format": {


### PR DESCRIPTION
This pull request modifies how we construct results from the judge output for a submission.

First, it replaces the JSON Schema validator library with another one, which already speeds things up a lot (locally, it went from 5.5s to 0.5s).

Secondly, it modifies the logic to (in production) only validate once at the end, instead of for each command.

I am not 100% convinced if the second part is necessary, since the speedup is fairly small, but the code is uglier in my opinion (and there is then a difference between development/production in an important part of the code).



<!-- If there are visual changes, add a screenshot -->

- [x] Tests were added

Closes #4579 .
