### PR TITLE
Use json_schemer to validate schema

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,7 @@ gem 'image_processing', '~> 1.12.2'
 gem 'bootsnap', '~> 1.16.0', require: false
 
 # used to validate container responses
-gem 'json-schema', '~> 3.0.0'
+gem 'json_schemer', '~> 0.2.24'
 
 # delayed jobs
 gem 'delayed_job_active_record', '~> 4.1.7'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -160,6 +160,8 @@ GEM
     docker-api (2.2.0)
       excon (>= 0.47.0)
       multi_json
+    ecma-re-validator (0.4.0)
+      regexp_parser (~> 2.2)
     ed25519 (1.3.0)
     erubi (1.12.0)
     exception_notification (4.5.0)
@@ -185,6 +187,7 @@ GEM
     glob (0.4.0)
     globalid (1.1.0)
       activesupport (>= 5.0)
+    hana (1.3.7)
     has_scope (0.8.1)
       actionpack (>= 5.2)
       activesupport (>= 5.2)
@@ -220,8 +223,11 @@ GEM
       bindata
       faraday (~> 2.0)
       faraday-follow_redirects
-    json-schema (3.0.0)
-      addressable (>= 2.8)
+    json_schemer (0.2.24)
+      ecma-re-validator (~> 0.3)
+      hana (~> 1.3)
+      regexp_parser (~> 2.0)
+      uri_template (~> 0.7)
     jwt (2.7.0)
     kramdown (2.4.0)
       rexml
@@ -466,6 +472,7 @@ GEM
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.4.2)
+    uri_template (0.7.0)
     validate_email (0.1.6)
       activemodel (>= 3.0)
       mail (>= 2.2.5)
@@ -536,7 +543,7 @@ DEPENDENCIES
   image_processing (~> 1.12.2)
   jbuilder (~> 2.11.5)
   jsbundling-rails (~> 1.1.1)
-  json-schema (~> 3.0.0)
+  json_schemer (~> 0.2.24)
   jwt (~> 2.7.0)
   kramdown (~> 2.4.0)
   kramdown-parser-gfm (~> 1.1.0)


### PR DESCRIPTION
This pull request swaps the gem used to do JSON Schema validation.

This is much faster, especially for judges using the partial format.

Progress towards #4579.
