### PR TITLE
Process rows and columns for python judge annotations

### DIFF
--- a/app/helpers/renderers/pythia_renderer.rb
+++ b/app/helpers/renderers/pythia_renderer.rb
@@ -267,6 +267,9 @@ class PythiaRenderer < FeedbackTableRenderer
   def convert_lint_message(message)
     {
       row: message[:line] - 1,
+      column: message[:column],
+      rows: message[:rows],
+      columns: message[:columns],
       type: convert_lint_type(message[:type]),
       text: message[:description],
       externalUrl: message[:externalUrl]


### PR DESCRIPTION
This pull request updates the pythia renderer to make sure it also processes row and column data for annotations.

This allows the annotations made by the pythia judge to be marked in the source code.

Related changes in the judge: https://github.com/dodona-edu/judge-pythia/pull/56

