### PR TITLE
Don't count unreviewed submissions for released evaluations

### DIFF
--- a/app/helpers/pages_helper.rb
+++ b/app/helpers/pages_helper.rb
@@ -28,8 +28,9 @@ module PagesHelper
       }
     end
 
-    if course.feedbacks.incomplete.count > 0
-      linked_feedback = course.feedbacks.incomplete.first
+    incomplete_unreleased_feedbacks = course.feedbacks.joins(:evaluation).where(evaluation: { released: false }).incomplete
+    if incomplete_unreleased_feedbacks.count > 0
+      linked_feedback = incomplete_unreleased_feedbacks.first
       result << {
         title: I18n.t('pages.course_card.incomplete-feedbacks', count: course.feedbacks.incomplete.count),
         link: evaluation_feedback_path(I18n.locale, linked_feedback.evaluation, linked_feedback),

--- a/test/helpers/pages_helper_test.rb
+++ b/test/helpers/pages_helper_test.rb
@@ -46,5 +46,11 @@ class PagesHelperTest < ActiveSupport::TestCase
       f.save
     end
     assert_equal 2, homepage_course_admin_notifications(course).count
+
+    # released evaluation
+    e.feedbacks.first.update(completed: false)
+    assert_equal 3, homepage_course_admin_notifications(course).count
+    e.update(released: true)
+    assert_equal 2, homepage_course_admin_notifications(course).count
   end
 end


### PR DESCRIPTION
This pull request removes the count of unreviewed submissions from the homepage for released evaluations.

Closes #4612 .
