### PR TITLE
Allow connection to mathjax in CSP

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -16,9 +16,10 @@ Rails.application.configure do
                          'https://*.googleapis.com',
                          'http://localhost:3035', 'ws://localhost:3035'
     else
-      policy.connect_src :self, Rails.configuration.tutor_url.to_s
+      policy.connect_src :self, Rails.configuration.tutor_url.to_s,
+                         'https://cdn.jsdelivr.net/npm/mathjax@3/'
     end
-  
+
     policy.font_src    :self, 'https://fonts.gstatic.com',
                        'https://cdn.jsdelivr.net/npm/@mdi/font@5.x/',
                        'https://cdn.jsdelivr.net/npm/mathjax@3/'


### PR DESCRIPTION
This pull request adds mathjax as a `connect-src` in our CSP.

This should fix the following bug.
![image](https://github.com/dodona-edu/dodona/assets/21177904/17e02e93-7553-4633-979e-071fd93c67a3)

We assume this bug occurs when screen readers are used.
