### PR TITLE
Allow mathjax to fail without breaking annotations

### DIFF
--- a/app/assets/javascripts/components/annotations/user_annotation.ts
+++ b/app/assets/javascripts/components/annotations/user_annotation.ts
@@ -115,8 +115,13 @@ export class UserAnnotation extends i18nMixin(ShadowlessLitElement) {
     protected updated(_changedProperties: PropertyValues): void {
         super.updated(_changedProperties);
 
-        // Ask MathJax to search for math in the annotations
-        window.MathJax.typeset();
+        try {
+            // Ask MathJax to search for math in the annotations
+            window.MathJax.typeset([this]);
+        } catch (e) {
+            // MathJax is not loaded
+            console.warn("MathJax is not loaded");
+        }
         // Reinitialize tooltips
         initTooltips(this);
     }

--- a/app/assets/javascripts/exercise.ts
+++ b/app/assets/javascripts/exercise.ts
@@ -12,7 +12,12 @@ function showLightbox(content): void {
     lightbox.on("slide_changed", () => {
         // There might have been math in the image captions, so ask
         // MathJax to search for new math (but only in the captions).
-        window.MathJax.typeset([".gslide-description"]);
+        try {
+            window.MathJax.typeset( Array.from(document.querySelectorAll(".gslide-description")));
+        } catch (e) {
+            // MathJax is not loaded
+            console.warn("MathJax is not loaded");
+        }
     });
     lightbox.open();
 

--- a/app/assets/javascripts/types/index.d.ts
+++ b/app/assets/javascripts/types/index.d.ts
@@ -5,7 +5,7 @@ declare interface Window {
 }
 
 declare class MathJaxObject {
-    typeset?(args?: string[]) :void;
+    typeset?(args?: string[] | Node[]) :void;
 
     tex: {
         inlineMath: string[][];

--- a/app/helpers/renderers/feedback_code_renderer.rb
+++ b/app/helpers/renderers/feedback_code_renderer.rb
@@ -59,7 +59,7 @@ class FeedbackCodeRenderer
 
     @builder.script(type: 'application/javascript') do
       @builder << <<~HEREDOC
-        window.MathJax.startup.promise.then(() => {
+        window.dodona.ready.then(() => {
           window.dodona.codeListing.initAnnotations(#{submission.id}, #{submission.course_id.to_json}, #{submission.exercise_id}, #{user.id}, #{@code.to_json}, #{@code.lines.length}, #{user_is_student});
           window.dodona.codeListing.addMachineAnnotations(#{messages.to_json});
           #{'window.dodona.codeListing.initAnnotateButtons();' if user_perm}


### PR DESCRIPTION
This pull request adds error handling code for when mathjax does not exist.

This should avoid our whole application breaking when mathjax is not available.

I also updated the calls to typeset, as the mathjax v3 now takes actual html elements as input instead of query strings.
