### PR TITLE
Show zero indexed machine annotations on first line instead of global

### DIFF
--- a/app/assets/javascripts/state/MachineAnnotations.ts
+++ b/app/assets/javascripts/state/MachineAnnotations.ts
@@ -24,7 +24,7 @@ class MachineAnnotationState extends State {
         this.byMarkedLine.clear();
         for (const annotation of annotations) {
             const markedLength = annotation.rows ?? 1;
-            const line = annotation.row ? annotation.row + markedLength : 0;
+            const line = annotation.row ? annotation.row + markedLength : 1;
             if (this.byLine.has(line)) {
                 this.byLine.get(line)?.push(annotation);
             } else {


### PR DESCRIPTION
old
![image](https://github.com/dodona-edu/dodona/assets/21177904/44bc2a49-3beb-4b72-9fe0-d2a74b6e7408)
new
![image](https://github.com/dodona-edu/dodona/assets/21177904/a9582db5-66b9-4a0a-a117-ed12e82930dc)


Closes #4645.
