### PR TITLE
Fix combination of line highlight and annotation color

### DIFF
--- a/app/assets/javascripts/i18n/translations.json
+++ b/app/assets/javascripts/i18n/translations.json
@@ -66,19 +66,19 @@
     "datetime": {
       "distance_in_words": {
         "about_x_hours": {
-          "one": "about 1 hour",
+          "one": "about %{count} hour",
           "other": "about %{count} hours"
         },
         "about_x_months": {
-          "one": "about 1 month",
+          "one": "about %{count} month",
           "other": "about %{count} months"
         },
         "about_x_years": {
-          "one": "about 1 year",
+          "one": "about %{count} year",
           "other": "about %{count} years"
         },
         "almost_x_years": {
-          "one": "almost 1 year",
+          "one": "almost %{count} year",
           "other": "almost %{count} years"
         },
         "half_a_minute": "half a minute",
@@ -87,31 +87,31 @@
           "other": "less than %{count} minutes"
         },
         "less_than_x_seconds": {
-          "one": "less than 1 second",
+          "one": "less than %{count} second",
           "other": "less than %{count} seconds"
         },
         "over_x_years": {
-          "one": "over 1 year",
+          "one": "over %{count} year",
           "other": "over %{count} years"
         },
         "x_days": {
-          "one": "1 day",
+          "one": "%{count} day",
           "other": "%{count} days"
         },
         "x_minutes": {
-          "one": "1 minute",
+          "one": "%{count} minute",
           "other": "%{count} minutes"
         },
         "x_months": {
-          "one": "1 month",
+          "one": "%{count} month",
           "other": "%{count} months"
         },
         "x_seconds": {
-          "one": "1 second",
+          "one": "%{count} second",
           "other": "%{count} seconds"
         },
         "x_years": {
-          "one": "1 year",
+          "one": "%{count} year",
           "other": "%{count} years"
         }
       },
@@ -605,23 +605,23 @@
           "other": "meer dan %{count} jaar"
         },
         "x_days": {
-          "one": "1 dag",
+          "one": "%{count} dag",
           "other": "%{count} dagen"
         },
         "x_minutes": {
-          "one": "1 minuut",
+          "one": "%{count} minuut",
           "other": "%{count} minuten"
         },
         "x_months": {
-          "one": "1 maand",
+          "one": "%{count} maand",
           "other": "%{count} maanden"
         },
         "x_seconds": {
-          "one": "1 seconde",
+          "one": "%{count} seconde",
           "other": "%{count} seconden"
         },
         "x_years": {
-          "one": "1 jaar",
+          "one": "%{count} jaar",
           "other": "%{count} jaar"
         }
       },

--- a/app/assets/stylesheets/components/code_listing.css.scss
+++ b/app/assets/stylesheets/components/code_listing.css.scss
@@ -91,17 +91,58 @@ $annotation-user-background-intense: color.mix($annotation-user, $background, 20
       }
 
       // Highlight for the line numbers.
-      .lineno.marked {
+      .lineno.marked .rouge-gutter {
         background-color: $warning-container;
-
-        // border-left: $code-warning-border-left solid $warning;
-        // Only do the line number, don't extend to the full height
-        background-clip: content-box;
       }
 
       // Highlight for the code itself.
       .lineno.marked .rouge-code pre {
         background-color: $warning-container;
+        width: 100%;
+        padding-top: 0;
+        padding-bottom: 0;
+        margin-top: 0;
+        margin-bottom: 0;
+      }
+
+      .lineno.marked .rouge-code d-annotation-marker {
+        padding: 0;
+        margin: 0;
+
+        --question-color: #{$warning-container};
+        --annotation-color: #{$warning-container};
+
+        pre {
+          background-color: inherit;
+
+          &.code-line-question {
+            background-color: $annotation-question-background-intense;
+          }
+
+          &.code-line-annotation {
+            background-color: $annotation-user-background-intense;
+          }
+        }
+      }
+
+      .lineno .rouge-code pre {
+        &.code-line-question {
+          background-color: $annotation-question-background-intense;
+          width: 100%;
+
+          d-annotation-marker {
+            background-color: $annotation-question-background-intense;
+          }
+        }
+
+        &.code-line-annotation {
+          background-color: $annotation-user-background-intense;
+          width: 100%;
+
+          d-annotation-marker {
+            background-color: $annotation-user-background-intense;
+          }
+        }
       }
 
       .annotation-button {
@@ -216,24 +257,6 @@ $annotation-user-background-intense: color.mix($annotation-user, $background, 20
           padding-bottom: 3px;
           margin-top: -2px;
           padding-top: 2px;
-
-          &.code-line-question {
-            background-color: $annotation-question-background-intense;
-            width: 100%;
-
-            d-annotation-marker {
-              background-color: $annotation-question-background-intense;
-            }
-          }
-
-          &.code-line-annotation {
-            background-color: $annotation-user-background-intense;
-            width: 100%;
-
-            d-annotation-marker {
-              background-color: $annotation-user-background-intense;
-            }
-          }
         }
       }
 

--- a/app/assets/stylesheets/components/code_listing.css.scss
+++ b/app/assets/stylesheets/components/code_listing.css.scss
@@ -105,6 +105,8 @@ $annotation-user-background-intense: color.mix($annotation-user, $background, 20
         margin-bottom: 0;
       }
 
+      // A highlight is more important then annotation background
+      // but less important then intense annotation background or selection markers
       .lineno.marked .rouge-code d-annotation-marker {
         padding: 0;
         margin: 0;
@@ -125,6 +127,7 @@ $annotation-user-background-intense: color.mix($annotation-user, $background, 20
         }
       }
 
+      // Highlight fully selected lines, also force all annotations in the line to the selection color
       .lineno .rouge-code pre {
         &.code-line-question {
           background-color: $annotation-question-background-intense;


### PR DESCRIPTION
This pull request fixes the overlapping styling of highlighted lines and annotations.

I chose the following priority order to determine which color to display:
1. current selection
2. hovered annotation
3. highlighted line
4. annotation

![Peek 2023-05-25 10-56](https://github.com/dodona-edu/dodona/assets/21177904/2e9f9cad-7815-487b-b4fe-f6367f04a23a)
![Peek 2023-05-25 10-55](https://github.com/dodona-edu/dodona/assets/21177904/ce6f3e85-7e45-46b6-b5e0-9b9f162bcb4a)

This pr also contains a change to the auto generated translations file, which had been reverted by accident in one of the recently reverted pr's.

Closes #4655.
