### PR TITLE
Split up deployment queues and fix secret inheritance

### DIFF
--- a/.github/workflows/deploy-production-safe.yml
+++ b/.github/workflows/deploy-production-safe.yml
@@ -1,7 +1,7 @@
 name: Deploy production
 
 # Queue the deploy, but don't cancel any currently running workflows
-concurrency: deploy-production
+concurrency: deploy-production-safe
 
 on:
   workflow_dispatch:
@@ -18,3 +18,4 @@ jobs:
   deploy-production:
     needs: [run-tests, deploy-naos, run-linting]
     uses: ./.github/workflows/deploy-production.yml
+    secrets: inherit


### PR DESCRIPTION
This pull request tries to fix this cancellation: https://github.com/dodona-edu/dodona/actions/runs/5119022577/jobs/9203838169

It was potentially caused because the workflows use the same queue. But I am not completely sure
