### PR TITLE
Fix user nil error for saved annotations

### DIFF
--- a/app/policies/saved_annotation_policy.rb
+++ b/app/policies/saved_annotation_policy.rb
@@ -42,17 +42,17 @@ class SavedAnnotationPolicy < ApplicationPolicy
 
   def show?
     # EDIT AFTER CLOSED BETA
-    record.user_id == user.id && user_admin_of_beta_course? && record_in_beta_course?
+    user_admin_of_beta_course? && record_in_beta_course? && record&.user_id == user.id
   end
 
   def update?
     # EDIT AFTER CLOSED BETA
-    record.user_id == user.id && user_admin_of_beta_course? && record_in_beta_course? && record&.user_id == user.id
+    user_admin_of_beta_course? && record_in_beta_course? && record&.user_id == user.id
   end
 
   def destroy?
     # EDIT AFTER CLOSED BETA
-    record.user_id == user.id && user_admin_of_beta_course? && record_in_beta_course? && record&.user_id == user.id
+    user_admin_of_beta_course? && record_in_beta_course? && record&.user_id == user.id
   end
 
   def permitted_attributes


### PR DESCRIPTION
This pull request fixes a bug in saved_annotations.show when no user is present. By changing the order of checks, the check will fail on `user_admin_of_beta_course?` instead of crashing on `record.user_id == user.id`
