### PR TITLE
Update github workflow job names

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   ruby:
-    name: Ruby
+    name: Lint Ruby
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -26,7 +26,7 @@ jobs:
         bundle exec rubocop -c  .rubocop.yml
 
   javascript:
-    name: JavaScript
+    name: Lint JavaScript
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -46,7 +46,7 @@ jobs:
         yarn typeCheck
 
   css:
-    name: CSS
+    name: Lint CSS
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   ruby:
-    name: Ruby
+    name: Test Ruby
     env:
       RAILS_ENV: "test"
       TEST_DATABASE_URL: "mysql2://root:dodona@127.0.0.1:3306/dodona_test"
@@ -59,7 +59,7 @@ jobs:
         flags: rails
 
   javascript:
-    name: JavaScript
+    name: Test JavaScript
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -81,7 +81,7 @@ jobs:
         flags: javascript
 
   system:
-    name: System
+    name: Test System
     env:
       DISABLE_SPRING: "true"
       RAILS_ENV: "test"


### PR DESCRIPTION
This pull request updates the names of the jobs within a workflow to make them unique and more specific.

The reason to do this, is to be able to use these jobs in combination with branch protections.
The branch protections as they are previously set up didn't work. The tests succeeded but the branch protections don't detect the status:
![image](https://github.com/dodona-edu/dodona/assets/21177904/b87314f7-c69a-49ef-9798-808de553e6a7)

This is due to the issue described here: https://stackoverflow.com/a/76229512/7769243

We thus need to specify the jobs by using their job name only.

Which is why I updated the relevant job name to be more unique and more specific.

I have also updated the branch protections to use these new names.

PS: there are other potential solutions in the stackoverflow thread but I preferred this one.