### PR TITLE
Automatically trigger github action to deploy on pull request merge

### DIFF
--- a/.github/workflows/test-and-deploy-production.yml
+++ b/.github/workflows/test-and-deploy-production.yml
@@ -5,17 +5,36 @@ concurrency: test-and-deploy-production
 
 on:
   workflow_dispatch:
+  pull_request:
+    types:
+      - closed
+    branches:
+      - main
 
 jobs:
+  should-deploy:
+    if: ${{ github.event.action != 'pull_request' || (
+      github.event.action == 'pull_request' &&
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.base.ref == 'main'&&
+      !contains(github.event.pull_request.labels.*.name == 'no deploy') &&
+      !contains(github.event.pull_request.labels.*.name == 'dependencies')
+    ) }}
+    runs-on: ubuntu-latest
+      steps:
+          - run: echo "Deploying to production"
   run-tests:
+    needs: [should-deploy]
     uses: ./.github/workflows/test.yml
     secrets: inherit
   run-linting:
+    needs: [should-deploy]
     uses: ./.github/workflows/lint.yml
   deploy-naos:
+    needs: [should-deploy]
     uses: ./.github/workflows/deploy-naos.yml
     secrets: inherit
   deploy-production:
-    needs: [run-tests, deploy-naos, run-linting]
+    needs: [should-deploy, run-tests, deploy-naos, run-linting]
     uses: ./.github/workflows/deploy-production.yml
     secrets: inherit


### PR DESCRIPTION
This pull request updates the 'test and deploy to production' github action to automatically trigger on merged pull requests.

A deploy is avoided if one of the labels is either  'no deploy' or 'dependencies'

part of #4673 