### PR TITLE
Set version as timestamp during capistrano deploy

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,7 @@ class ApplicationController < ActionController::Base
   include ApplicationHelper
 
   MAX_STORED_URL_LENGTH = 1024
+  VERSION = YAML.load_file(Rails.root.join('config/version.yml'))['version'].freeze
 
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
   rescue_from ActionDispatch::Http::Parameters::ParseError, with: :bad_request
@@ -23,6 +24,8 @@ class ApplicationController < ActionController::Base
                 if: :sandbox?
 
   before_action :set_locale
+
+  before_action :set_version
 
   before_action :look_for_token, unless: :current_user
 
@@ -214,5 +217,9 @@ class ApplicationController < ActionController::Base
 
   def set_user_seen_at
     current_user.touch(:seen_at)
+  end
+
+  def set_version
+    @version = VERSION
   end
 end

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -15,8 +15,8 @@
     <%= link_to 'Status', status_path, target: "_blank", rel: "noopener" %>
     <%= link_to t("layout.footer.privacy_statement"), privacy_path %>
     <%= link_to t("layout.footer.your_data"), data_path %>
-    <% version_info = "Dodona #{Dodona::Application::VERSION}" %>
+    <% version_info = "Dodona #{@version}" %>
     <% version_info += " (ruby #{RUBY_VERSION} #{`which ruby`})" if Rails.env.development? || Rails.env.staging? %>
-    <%= link_to version_info, "https://docs.dodona.be/#{I18n.locale}/news/" %>
+    <%= link_to version_info, "https://github.com/orgs/dodona-edu/discussions/categories/release-notes" %>
   </div>
 </footer>

--- a/config/version.yml
+++ b/config/version.yml
@@ -1,0 +1,1 @@
+version: "dev"

--- a/lib/capistrano/tasks/write_version.rake
+++ b/lib/capistrano/tasks/write_version.rake
@@ -1,0 +1,12 @@
+set :version_file, "config/version.yml"
+
+namespace :my_tasks do
+  desc "Sets the timestamp in version_file"
+  task :set_version_info do
+    run "rm #{version_file}"
+    version = Time.now.strftime("%y.%m.%d%H%M")
+    run "echo 'version: #{version}' &gt;&gt; #{version_file}"
+  end
+end
+
+after 'deploy:symlink', 'my_tasks:set_version_info'


### PR DESCRIPTION
This pull request adds a new Capistrano task to save a formatted timestamp of deployment in a config  file.

This is used as the version number to be displayed in the app.

New versioning syntax used `"%y.%m.%d%H%M"`. This would match with monthly releases of the form `%y.%m`. Eg. `23.07`
part of #4673 
