### PR TITLE
Set version number during capistrano deploy

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -118,11 +118,12 @@ namespace :deploy do
   end
 end
 
+version = Time.now.strftime("%y.%m.%d-%H:%M")
+
 namespace :deploy do
-  before :publishing, :asset_stuff do
-    on roles :web do
+  before :publishing, :set_version do
+    on roles :app do
       within release_path do
-        version = Time.now.strftime("%y.%m.%d-%H:%M")
         execute :sed, "-i 's/VERSION = .*/VERSION = \"#{version}\".freeze/' config/initializers/00_version.rb"
       end
     end

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -123,7 +123,7 @@ namespace :deploy do
     on roles :web do
       within release_path do
         version = Time.now.strftime("%y.%m.%d-%H:%M")
-        execute :sed, "-i", "s/VERSION = .*/VERSION = \"#{version}\".freeze/", "config/initializers/00_version.rb"
+        execute :sed, "-i 's/VERSION = .*/VERSION = \"#{version}\".freeze/' config/initializers/00_version.rb"
       end
     end
   end

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -119,7 +119,7 @@ namespace :deploy do
 end
 
 namespace :deploy do
-  before :publishing do
+  before :publishing, :asset_stuff do
     on roles :web do
       within release_path do
         version = Time.now.strftime("%y.%m.%d-%H:%M")

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -117,3 +117,14 @@ namespace :deploy do
     end
   end
 end
+
+namespace :deploy do
+  before :publishing do
+    on roles :web do
+      within release_path do
+        version = Time.now.strftime("%y.%m.%d-%H:%M")
+        execute :sed, "-i 's/VERSION = .*/VERSION = \"#{version}\".freeze/' config/initializers/00_version.rb"
+      end
+    end
+  end
+end

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -123,7 +123,7 @@ namespace :deploy do
     on roles :web do
       within release_path do
         version = Time.now.strftime("%y.%m.%d-%H:%M")
-        execute :sed, "-i 's/VERSION = .*/VERSION = \"#{version}\".freeze/' config/initializers/00_version.rb"
+        execute :sed, "-i", "s/VERSION = .*/VERSION = \"#{version}\".freeze/", "config/initializers/00_version.rb"
       end
     end
   end


### PR DESCRIPTION
This pull request overwrites the version config file on Capistrano deploy to make sure it uses a fixed timestamp of deploy time.

part of #4673 
