### PR TITLE
Greatly reduce lag caused by annotation hover

### DIFF
--- a/app/assets/javascripts/components/annotations/machine_annotation.ts
+++ b/app/assets/javascripts/components/annotations/machine_annotation.ts
@@ -31,8 +31,8 @@ export class MachineAnnotation extends ShadowlessLitElement {
     render(): TemplateResult {
         return html`
             <div class="annotation machine-annotation ${this.data.type}"
-                 @mouseenter="${() => annotationState.hoveredAnnotation = this.data}"
-                 @mouseleave="${() => annotationState.hoveredAnnotation = null}">
+                 @mouseenter="${() => annotationState.setHovered(this.data, true)}"
+                 @mouseleave="${() => annotationState.setHovered(this.data, false)}">
                 <div class="annotation-header">
                     <span class="annotation-meta">
                         ${I18n.t(`js.annotation.type.${this.data.type}`)}

--- a/app/assets/javascripts/components/annotations/thread.ts
+++ b/app/assets/javascripts/components/annotations/thread.ts
@@ -88,8 +88,8 @@ export class Thread extends i18nMixin(ShadowlessLitElement) {
     render(): TemplateResult {
         return this.data ? html`
             <div class="thread ${annotationState.isVisible(this.data) ? "" : "hidden"}"
-                 @mouseenter="${() => annotationState.hoveredAnnotation = this.data}"
-                 @mouseleave="${() => annotationState.hoveredAnnotation = null}"
+                 @mouseenter="${() => annotationState.setHovered(this.data, true)}"
+                 @mouseleave="${() => annotationState.setHovered(this.data, false)}"
             >
                 <d-user-annotation .data=${this.data}></d-user-annotation>
                 ${this.data.responses.map(response => html`


### PR DESCRIPTION
This pull request fixes the lag caused by the on hover visualisation.
Example of lag: https://dodona.ugent.be/nl/feedbacks/12480030

This was caused by how I used the statesystem:
Everyone listened to the same variable (hoveredAnnotation), which triggered a rerender of all marked code when the hover state changed.

I updated this to use a map, so every marking listens to a unique key for their annotation. So only the relevant ellements get updated.

This use case suggest a more object orientated approach for the state would be usefull (now we use immutable data objects). That would make 'annotation.isHovered' a unique key to listen to for each annotation.

But that would be a larger refactor instead of a fast bugfix. Something to look into in the future.
