### PR TITLE
Remove on hover highlight for annotations

### DIFF
--- a/app/assets/javascripts/components/annotations/annotation_marker.ts
+++ b/app/assets/javascripts/components/annotations/annotation_marker.ts
@@ -31,11 +31,10 @@ export class AnnotationMarker extends LitElement {
 
     static getStyle(annotation: AnnotationData): string {
         if (["error", "warning", "info"].includes(annotation.type)) {
-            return `text-decoration: wavy underline ${AnnotationMarker.colors[annotation.type]} ${annotationState.isHovered(annotation) ? 2 : 1}px;`;
+            return `text-decoration: wavy underline ${AnnotationMarker.colors[annotation.type]} 1px;`;
         } else {
-            const colorKey = annotationState.isHovered(annotation) ? `${annotation.type}-intense` : annotation.type;
             return `
-                background: ${AnnotationMarker.colors[colorKey]};
+                background: ${AnnotationMarker.colors[annotation.type]};
                 padding-top: 2px;
                 padding-bottom: 2px;
                 margin-top: -2px;
@@ -96,20 +95,12 @@ export class AnnotationMarker extends LitElement {
     }
 
     get sortedAnnotations(): AnnotationData[] {
-        return this.annotations.sort( (a, b) => {
-            if (annotationState.isHovered(a)) {
-                return -1;
-            } else if (annotationState.isHovered(b)) {
-                return 1;
-            } else {
-                return compareAnnotationOrders(a, b);
-            }
-        });
+        return this.annotations.sort( compareAnnotationOrders );
     }
 
     get machineAnnotationMarkerSVG(): TemplateResult | undefined {
         const firstMachineAnnotation = this.sortedAnnotations.find(a => !isUserAnnotation(a));
-        const size = annotationState.isHovered(firstMachineAnnotation) ? 20 : 14;
+        const size = 14;
         return firstMachineAnnotation && html`<svg style="position: absolute; top: ${16 - size/2}px; left: -${size/2}px" width="${size}" height="${size}" viewBox="0 0 24 24">
             <path fill="${AnnotationMarker.colors[firstMachineAnnotation.type]}" d="M7.41 15.41L12 10.83l4.59 4.58L18 14l-6-6l-6 6l1.41 1.41Z"/>
         </svg>`;

--- a/app/assets/javascripts/components/annotations/machine_annotation.ts
+++ b/app/assets/javascripts/components/annotations/machine_annotation.ts
@@ -30,9 +30,7 @@ export class MachineAnnotation extends ShadowlessLitElement {
 
     render(): TemplateResult {
         return html`
-            <div class="annotation machine-annotation ${this.data.type}"
-                 @mouseenter="${() => annotationState.setHovered(this.data, true)}"
-                 @mouseleave="${() => annotationState.setHovered(this.data, false)}">
+            <div class="annotation machine-annotation ${this.data.type}">
                 <div class="annotation-header">
                     <span class="annotation-meta">
                         ${I18n.t(`js.annotation.type.${this.data.type}`)}

--- a/app/assets/javascripts/components/annotations/thread.ts
+++ b/app/assets/javascripts/components/annotations/thread.ts
@@ -87,10 +87,7 @@ export class Thread extends i18nMixin(ShadowlessLitElement) {
 
     render(): TemplateResult {
         return this.data ? html`
-            <div class="thread ${annotationState.isVisible(this.data) ? "" : "hidden"}"
-                 @mouseenter="${() => annotationState.setHovered(this.data, true)}"
-                 @mouseleave="${() => annotationState.setHovered(this.data, false)}"
-            >
+            <div class="thread ${annotationState.isVisible(this.data) ? "" : "hidden"}">
                 <d-user-annotation .data=${this.data}></d-user-annotation>
                 ${this.data.responses.map(response => html`
                     <d-user-annotation .data=${response}></d-user-annotation>

--- a/app/assets/javascripts/state/Annotations.ts
+++ b/app/assets/javascripts/state/Annotations.ts
@@ -26,29 +26,6 @@ export function isUserAnnotation(annotation: AnnotationData): annotation is User
 class AnnotationState extends State {
     @stateProperty visibility: AnnotationVisibilityOptions = "all";
     @stateProperty isQuestionMode = false;
-    readonly isHoveredByKey = new StateMap<string, boolean>();
-
-    private getKeyFromAnnotation(annotation: AnnotationData): string {
-        if (annotation === undefined || annotation === null) {
-            return "";
-        }
-
-        if (isUserAnnotation(annotation)) {
-            return `${annotation.id}`;
-        }
-
-        return `${annotation.row}-${annotation.column}-${annotation.type}-${annotation.text}`;
-    }
-
-    setHovered(annotation: AnnotationData, hovered: boolean): void {
-        const key = this.getKeyFromAnnotation(annotation);
-        this.isHoveredByKey.set(key, hovered);
-    }
-
-    isHovered = (annotation: AnnotationData): boolean => {
-        const key = this.getKeyFromAnnotation(annotation);
-        return this.isHoveredByKey.get(key) ?? false;
-    };
 
     isVisible(annotation: AnnotationData): boolean {
         if (this.visibility === "none") {


### PR DESCRIPTION
This pull request removes the the highlighting of the code marking when the related annotation is hovered.

This rather minor feature is the cause of browser hanging on pages with a lot of annotations. Improving the speed is not trivial, so I sugget removing the feature until we have a better fix of the speed.

In the most ideal case this feature would be redone using css :has selector, but because this would involve dynamic class names this is non-trivial.

I have identified the following key issues to speed up the javascript case:
- limit the number of marking elements in the html. ([This example](https://dodona.ugent.be/nl/feedbacks/1970320832) has more then 900) This could be achieved by wrapping higher ancestors instead of each separate text-node. Which would also fix the non continuous wavy underline in a lot of cases.
- speed up the re render of a single marking element. This can be done by not recreating the tooltip every time. I tried this first, but this was rather finicky because updating instead of destroying the old tooltip led to some inconsistency in the triggering of mouse related events. I can probably fix this by spending some more time on it.


Closes #4749.
