### PR TITLE
Bump excon gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -165,7 +165,7 @@ GEM
     exception_notification (4.5.0)
       actionmailer (>= 5.2, < 8)
       activesupport (>= 5.2, < 8)
-    excon (0.92.3)
+    excon (0.100.0)
     execjs (2.8.1)
     factory_bot (6.2.1)
       activesupport (>= 5.0.0)


### PR DESCRIPTION
Because of https://github.com/upserve/docker-api/issues/583, running a docker container could fail depending on the URI gem bundled with the user's ruby. This is fixed in later excon versions.

