### PR TITLE
Simplify full line annotation markers

### DIFF
--- a/app/assets/javascripts/components/annotations/annotation_marker.ts
+++ b/app/assets/javascripts/components/annotations/annotation_marker.ts
@@ -117,6 +117,11 @@ export class AnnotationMarker extends LitElement {
             :host {
                 position: relative;
                 ${this.annotationStyles}
+                text-decoration-skip-ink: none;
+            }
+            ::slotted(*) {
+                ${this.annotationStyles}
+                text-decoration-skip-ink: none;
             }
         </style><slot>${this.machineAnnotationMarkerSVG}</slot>`;
     }


### PR DESCRIPTION
This pull request creates only a single marker for annotations that span a full line.

In a complex example that reduced the number of rendered marker webcomponents from 948 to 433

<!-- If there are visual changes, add a screenshot -->

- [ ] Tests were added
- [ ] Documentation update can be found at dodona-edu/dodona-edu.github.io#
- [ ] We learned with dolos that using ... isn't a good idea with variable length arrays. This had unexpected performance implications.
- [ ] Don recreate tooltips every time

Closes # .
