### PR TITLE
Fix Ufora LTI integration

### DIFF
--- a/lib/LTI/jwk.rb
+++ b/lib/LTI/jwk.rb
@@ -26,7 +26,7 @@ module LTI
     end
 
     def get_jwks_content(uri)
-      JWT::JWK::HTTPClient.new.get_content(uri)
+      HTTParty.get(uri , :headers => { 'Accept' => 'application/json' } ).body
     end
 
     private

--- a/lib/LTI/jwk.rb
+++ b/lib/LTI/jwk.rb
@@ -26,7 +26,7 @@ module LTI
     end
 
     def get_jwks_content(uri)
-      HTTPClient.new.get_content(uri)
+      JWT::JWK::HTTPClient.new.get_content(uri)
     end
 
     private


### PR DESCRIPTION
This pull request fixes the Ufora LTI integration.

The error thrown was: `Authentication failure! invalid_response: NameError, uninitialized constant LTI::JWK::HTTPClient`
I have no idea why it used to work before.

But it got solved by using the HTTParty gem - which we already required - to make the get request.

Tested on naos.
