### PR TITLE
Changed from 'paste' to 'copy' icon.

### DIFF
--- a/app/assets/javascripts/components/copy_button.ts
+++ b/app/assets/javascripts/components/copy_button.ts
@@ -64,7 +64,7 @@ export class CopyButton extends ShadowlessLitElement {
                             data-bs-placement="top"
                             data-bs-toggle="tooltip"
                             title="${this.tooltip}">
-                <i class="mdi mdi-clipboard-outline"></i>
+                <i class="mdi mdi-content-copy"></i>
             </button>`;
     }
 }

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -128,7 +128,7 @@ module ApplicationHelper
                type: 'button',
                title: t('js.copy-to-clipboard'),
                data: { clipboard_target: selector } do
-      tag.i(class: 'mdi mdi-clipboard-outline')
+      tag.i(class: 'mdi mdi-content-copy')
     end
   end
 

--- a/app/helpers/renderers/feedback_code_renderer.rb
+++ b/app/helpers/renderers/feedback_code_renderer.rb
@@ -23,7 +23,7 @@ class FeedbackCodeRenderer
       if @code.present?
         # Not possible to use clipboard_button_for here since the behaviour is different.
         @builder.button(class: 'btn btn-icon copy-btn', id: "copy-to-clipboard-#{@instance}", title: I18n.t('js.code.copy-to-clipboard'), 'data-bs-toggle': 'tooltip', 'data-bs-placement': 'top') do
-          @builder.i(class: 'mdi mdi-clipboard-outline') {}
+          @builder.i(class: 'mdi mdi-content-copy') {}
         end
       end
       @builder.script(type: 'application/javascript') do


### PR DESCRIPTION
Dodona uses the Material Design Icon `mdi-clipboard-outline` icon to symbolize "copy to clipboard". But that icon is widely recognized as a "paste" icon (The Material Design Icon `mdi-content-paste` is only a tiny bit longer).

Doesn't it make more sense to use `mdi-content-copy`? Proposing the following tiny changes.