### PR TITLE
Avoid crash when calling a delayed job on a deleted question

### DIFF
--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -33,6 +33,15 @@ class Question < Annotation
   # Used to authorize the transitions
   attr_accessor :transition_to, :transition_from
 
+  def self.reset_in_progress(id)
+    return unless exists?(id)
+
+    question = find(id)
+    return unless question.question_state == 'in_progress'
+
+    question.update(question_state: 'unanswered')
+  end
+
   def to_partial_path
     'annotations/annotation'
   end
@@ -58,15 +67,9 @@ class Question < Annotation
     @transition_from = nil
   end
 
-  def reset_in_progress
-    return unless question_state == 'in_progress'
-
-    update(question_state: 'unanswered')
-  end
-
   def schedule_reset_in_progress
     return unless question_state == 'in_progress'
 
-    delay(run_at: 1.hour.from_now).reset_in_progress
+    Question.delay(run_at: 1.hour.from_now).reset_in_progress(id)
   end
 end

--- a/test/models/annotation_test.rb
+++ b/test/models/annotation_test.rb
@@ -154,4 +154,19 @@ class AnnotationTest < ActiveSupport::TestCase
     run_delayed_jobs
     assert q.reload.answered?
   end
+
+  test 'delayed job should not crash if question is deleted before execution' do
+    q = create :question, submission: @submission, user: @student
+    assert q.unanswered?
+
+    with_delayed_jobs do
+      q.update(question_state: :in_progress)
+      assert q.reload.in_progress?
+      q.destroy
+    end
+
+    assert_nil Question.find_by(id: q.id)
+
+    run_delayed_jobs
+  end
 end

--- a/test/testhelpers/delayed_job_helper.rb
+++ b/test/testhelpers/delayed_job_helper.rb
@@ -11,6 +11,9 @@ module DelayedJobHelper
   end
 
   def run_delayed_jobs
-    Delayed::Job.find_each(batch_size: 100) { |d| Delayed::Worker.new.run(d) }
+    Delayed::Job.find_each(batch_size: 100) do |d|
+      Delayed::Worker.new.run(d)
+      assert_nil d.last_error
+    end
   end
 end


### PR DESCRIPTION
Closes #4696
