### PR TITLE
Fix typo in monospace font variable

### DIFF
--- a/app/assets/stylesheets/bootstrap_css_variable_overrides.css.scss
+++ b/app/assets/stylesheets/bootstrap_css_variable_overrides.css.scss
@@ -107,7 +107,7 @@
 
   // font
   --bs-font-sans-serif: var(--d-font-sans-serif);
-  --bs-font-monospace: var(--d-font-family-monospace);
+  --bs-font-monospace: var(--d-font-monospace);
   --bs-gradient: linear-gradient(180deg, rgba(255, 255, 255, 0.15), rgba(255, 255, 255, 0));
   --bs-body-font-family: var(--bs-font-sans-serif);
   --bs-body-font-size: var(--d-font-size-base);


### PR DESCRIPTION
This pull request fixes a naming bug caused by #4745 
