### PR TITLE
Get rid of html encode method

### DIFF
--- a/app/assets/javascripts/components/datalist_input.ts
+++ b/app/assets/javascripts/components/datalist_input.ts
@@ -3,8 +3,6 @@ import { html, PropertyValues, TemplateResult } from "lit";
 import { ShadowlessLitElement } from "components/meta/shadowless_lit_element";
 import { ref, Ref, createRef } from "lit/directives/ref.js";
 import { watchMixin } from "components/meta/watch_mixin";
-import { unsafeHTML } from "lit/directives/unsafe-html.js";
-import { htmlEncode } from "util.js";
 
 export type Option = {label: string, value: string, extra?: string};
 
@@ -171,10 +169,15 @@ export class DatalistInput extends watchMixin(ShadowlessLitElement) {
         this.getElementsByClassName("active")[0]?.scrollIntoView({ block: "nearest" });
     }
 
-    mark(s: string): TemplateResult {
-        return this.filter ?
-            html`${unsafeHTML(htmlEncode(s).replace(new RegExp(this.filter, "gi"), m => `<b>${m}</b>`))}` :
-            html`${s}`;
+    mark(s: string): (TemplateResult | string)[] | string {
+        if (!this.filter) {
+            return s;
+        }
+
+        // using group syntax () to preserve matches in the split string
+        const regex = new RegExp(`(${this.filter})`, "gi");
+        // split the string on the regex, and make the matches bold
+        return s.split(regex).map(p => regex.test(p) ? html`<b>${p}</b>` : p);
     }
 
     render(): TemplateResult {

--- a/app/assets/javascripts/util.js
+++ b/app/assets/javascripts/util.js
@@ -202,12 +202,6 @@ const entityMap = {
     "=": "&#x3D;"
 };
 
-function htmlEncode(str) {
-    return String(str).replace(/[&<>"'`=/]/g, function (s) {
-        return entityMap[s];
-    });
-}
-
 /**
  * Returns the first parent of an element that has at least all of the given classes.
  * Returns null if no such parent exists.
@@ -244,6 +238,5 @@ export {
     setDocumentTitle,
     initDatePicker,
     ready,
-    htmlEncode,
     getParentByClassName,
 };

--- a/app/assets/javascripts/util.js
+++ b/app/assets/javascripts/util.js
@@ -190,18 +190,6 @@ const ready = new Promise(resolve => {
     }
 });
 
-// source https://github.com/janl/mustache.js/blob/master/mustache.js#L73
-const entityMap = {
-    "&": "&amp;",
-    "<": "&lt;",
-    ">": "&gt;",
-    "\"": "&quot;",
-    "'": "&#39;",
-    "/": "&#x2F;",
-    "`": "&#x60;",
-    "=": "&#x3D;"
-};
-
 /**
  * Returns the first parent of an element that has at least all of the given classes.
  * Returns null if no such parent exists.


### PR DESCRIPTION
This pull request removes the html-encode method, as it could have potentially been unsafe and was not required.

