### PR TITLE
Fix selections growing to include annotations after selection end

### DIFF
--- a/app/assets/javascripts/components/annotations/selectionHelpers.ts
+++ b/app/assets/javascripts/components/annotations/selectionHelpers.ts
@@ -188,9 +188,15 @@ export async function triggerSelectionEnd(): Promise<void> {
     if (!selection.isCollapsed && !anyRangeInAnnotation(selection)) {
         userAnnotationState.selectedRange = selectedRangeFromSelection(selection);
         if (userAnnotationState.selectedRange) {
-            const selectionType = annotationState.isQuestionMode ? "question" : "annotation";
-            document.querySelector(".code-table")?.classList.add(`selection-color-${selectionType}`);
-            document.body.classList.remove("no-selection-outside-code");
+            // we might not have started with the selection inside the code
+            // But we ended with a code selection, so apply the selection classes
+            addSelectionClasses();
+
+            // Next time the selection is changed, remove the selection classes
+            const unsubscribe = userAnnotationState.subscribe( () => {
+                removeSelectionClasses();
+                unsubscribe();
+            }, "selectedRange");
         } else {
             removeSelectionClasses();
         }

--- a/app/assets/javascripts/components/annotations/selectionHelpers.ts
+++ b/app/assets/javascripts/components/annotations/selectionHelpers.ts
@@ -169,11 +169,13 @@ function addSelectionClasses(): void {
     const selectionType = annotationState.isQuestionMode ? "question" : "annotation";
     document.querySelector(".code-table")?.classList.add(`selection-color-${selectionType}`);
     document.body.classList.add("no-selection-outside-code");
+    document.body.classList.add("no-selection-inside-annotations");
 }
 
 function removeSelectionClasses(): void {
     document.querySelector(".code-table")?.classList.remove("selection-color-annotation", "selection-color-question");
     document.body.classList.remove("no-selection-outside-code");
+    document.body.classList.remove("no-selection-inside-annotations");
 }
 
 export async function triggerSelectionEnd(): Promise<void> {
@@ -189,8 +191,10 @@ export async function triggerSelectionEnd(): Promise<void> {
         userAnnotationState.selectedRange = selectedRangeFromSelection(selection);
         if (userAnnotationState.selectedRange) {
             // we might not have started with the selection inside the code
-            // But we ended with a code selection, so apply the selection classes
+            // But we ended with a code selection, so add the selection classes
             addSelectionClasses();
+            // starting a new selection outside the code should be allowed
+            document.body.classList.remove("no-selection-outside-code");
 
             // Next time the selection is changed, remove the selection classes
             const unsubscribe = userAnnotationState.subscribe( () => {

--- a/app/assets/stylesheets/components/code_listing.css.scss
+++ b/app/assets/stylesheets/components/code_listing.css.scss
@@ -565,3 +565,9 @@ d-selection-marker {
     }
   }
 }
+
+.no-selection-inside-annotations {
+  d-code-listing-row td d-annotations-cell {
+    user-select: none;
+  }
+}


### PR DESCRIPTION
This pull request closes #4748

This change does have the side effect that as long as a selection is active within the code, selection of annotations is blocked. You have to first end the current selection before you can select them again.
