### PR TITLE
Allow HOGent to sign in without SAML

### DIFF
--- a/app/controllers/auth/authentication_controller.rb
+++ b/app/controllers/auth/authentication_controller.rb
@@ -17,7 +17,7 @@ class Auth::AuthenticationController < Devise::SessionsController
       # Provider.find_by(identifier: '33d8cf3c-2f14-48c0-9ad6-5d2825533673'), # AP
       Provider.find_by(identifier: 'b6e080ea-adb9-4c79-9303-6dcf826fb854'), # Artevelde
       # Provider.find_by(identifier: 'c2a59f2b-5d20-4b2a-a9a3-7a8605b14e3f'), # Erasmus
-      Provider.find_by(entity_id: 'https://idp.hogent.be/idp'), # HoGent
+      Provider.find_by(identifier: "5cf7310e-091a-4bc5-acd7-26c721d4cccd"), # HoGent
       Provider.find_by(identifier: '4ded4bb1-6bff-42b3-aed7-6a36a503bf7a'), # HoWest
       # Provider.find_by(identifier: '850f9344-e078-467e-9c5e-84d82f208ac7'), # HS Leiden
       # Provider.find_by(identifier: 'ed1fc57f-8a97-47e7-9de1-9302dfd786ae'), # KdG

--- a/app/controllers/auth/omniauth_callbacks_controller.rb
+++ b/app/controllers/auth/omniauth_callbacks_controller.rb
@@ -137,6 +137,14 @@ class Auth::OmniauthCallbacksController < Devise::OmniauthCallbacksController
       # If we found an existing user, which already has an identity for this provider
       # This will require a manual intervention by the development team, notify the user and the team
       return redirect_duplicate_email_for_provider! if user&.providers&.exists?(id: provider.id)
+
+      if (user&.institution_id == 4) && user&.providers&.exists?(id: 210) && (provider.id == 166)
+        # HOGent SAML provider (id = 210) is broken
+        # We simplify the account linking process by not requiring verification
+        # We will just link the user to the new provider
+        identity = Identity.create(identifier: auth_uid, provider: 166, user: user)
+        return sign_in!(identity)
+      end
       # If we found an existing user with the same username or email within the same institution
       # We will ask the user to verify if this was the user they wanted to sign in to
       # if yes => redirect to a previously used provider for this user


### PR DESCRIPTION
This pull request removes the account verification step for linking HOGent accounts. 
We do this because the SAML sign in method is currently broken.

The main sign in button now redirects to office365 as well.

I would prefer not to this. so we'll wait a bit to see if the HOGent can fix the SAML integration fast.