### PR TITLE
Introduce blockqoute styling

### DIFF
--- a/app/assets/stylesheets/components.css.scss
+++ b/app/assets/stylesheets/components.css.scss
@@ -121,3 +121,8 @@ h6 .small,
   line-height: 1;
   color: var(--d-on-surface-muted);
 }
+
+blockquote {
+  border-left: var(--d-divider) 3px solid;
+  color: var(--d-on-surface-muted);
+}


### PR DESCRIPTION
This pull request introduces styling for blockquotes that is similar to how github handles them.

![image](https://github.com/dodona-edu/dodona/assets/21177904/6bdb6395-93ae-4255-a8e6-b36fea495d41)
![image](https://github.com/dodona-edu/dodona/assets/21177904/af2a9373-bd15-4f59-bfec-fbf221fdd09b)

Closes #4878
