### PR TITLE
Replace all mentions of dodona.ugent.be

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,1 @@
-custom: https://dodona.ugent.be/en/support-us
+custom: https://dodona.be/en/support-us

--- a/README.md
+++ b/README.md
@@ -8,20 +8,20 @@
 
 > Dodona is an online exercise platform for **learning to code**. It wants to teach students how to program in the most meaningful and effective way possible. Dodona acts as an **online co-teacher**, designed to give every student access to high quality education. The focus is on automatic corrections and giving **meaningful feedback** on the submitted solutions from students.
 
-This repository contains the source code of the web application. If you simply want to use Dodona, please go to [https://dodona.ugent.be](https://dodona.ugent.be).
+This repository contains the source code of the web application. If you simply want to use Dodona, please go to [https://dodona.be](https://dodona.be).
 
 The documentation for end users can be found at [https://docs.dodona.be](https://docs.dodona.be).
 
 ## Supporting Dodona
 
-Dodona is free to use for schools and we would like to keep it that way! Keeping this platform up and running takes a lot of time, just as supporting hundreds of schools and thousands of students. If you would like to fund Dodona, you can find more information on [https://dodona.ugent.be/en/support-us/](https://dodona.ugent.be/en/support-us/) or get in touch by emailing us at dodona@ugent.be.
+Dodona is free to use for schools and we would like to keep it that way! Keeping this platform up and running takes a lot of time, just as supporting hundreds of schools and thousands of students. If you would like to fund Dodona, you can find more information on [https://dodona.be/en/support-us/](https://dodona.be/en/support-us/) or get in touch by emailing us at dodona@ugent.be.
 
 ## Contacting us
 
 There are several ways to contact us:
 - To report a bug, please use [GitHub Issues](https://github.com/dodona-edu/dodona/issues).
 - If you have a question to which the answer might be of use to others, please use [GitHub Discussions](https://github.com/dodona-edu/dodona/discussions).
-- For more specific questions, use [our contact form](https://dodona.ugent.be/nl/contact/), send an email to [dodona@ugent.be](mailto:dodona@ugent.be) or come chat with us in our [general chat](https://matrix.to/#/#dodona-general:vanpetegem.me?via=vanpetegem.me&via=matrix.org&via=beardhatcode.be) or our [support chat](https://matrix.to/#/#dodona-support:vanpetegem.me?via=vanpetegem.me).
+- For more specific questions, use [our contact form](https://dodona.be/nl/contact/), send an email to [dodona@ugent.be](mailto:dodona@ugent.be) or come chat with us in our [general chat](https://matrix.to/#/#dodona-general:vanpetegem.me?via=vanpetegem.me&via=matrix.org&via=beardhatcode.be) or our [support chat](https://matrix.to/#/#dodona-support:vanpetegem.me?via=vanpetegem.me).
 
 ## Local development
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -250,7 +250,7 @@ class User < ApplicationRecord
   def email
     return self[:email] unless Current.demo_mode && Current.user != self
 
-    "#{first_name}.#{last_name}@dodona.ugent.be"
+    "#{first_name}.#{last_name}@dodona.be"
   end
 
   def short_name

--- a/app/views/pages/_about.html.erb
+++ b/app/views/pages/_about.html.erb
@@ -69,14 +69,14 @@
     "@context": "https://schema.org/",
     "@type": "Organization",
     "name": "Dodona",
-    "url": "https://dodona.ugent.be",
+    "url": "https://dodona.be",
     "sameAs": [
       "https://twitter.com/DodonaEdu",
       "https://github.com/dodona-edu"
     ],
     "email": "dodona@ugent.be",
-    "logo": "https://dodona.ugent.be/icon.png",
-    "image": "https://dodona.ugent.be/social-image.png",
+    "logo": "https://dodona.be/icon.png",
+    "image": "https://dodona.be/social-image.png",
     "slogan": "Learn to code for secondary and higher education."
   }
 </script>
@@ -85,8 +85,8 @@
     "@context": "https://schema.org/",
     "@type": "Website",
     "name": "Dodona",
-    "url": "https://dodona.ugent.be",
+    "url": "https://dodona.be",
     "version": "<%= Dodona::Application::VERSION %>",
-    "image": "https://dodona.ugent.be/social-image.png"
+    "image": "https://dodona.be/social-image.png"
   }
 </script>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -128,7 +128,7 @@ Rails.application.configure do
                             channel: '#notifications',
                             username: 'Dodona-server',
                             additional_parameters: {
-                              icon_url: 'https://dodona.ugent.be/icon.png',
+                              icon_url: 'https://dodona.be/icon.png',
                               mrkdwn: true
                             }
                         }

--- a/lib/SAML/metadata.rb
+++ b/lib/SAML/metadata.rb
@@ -147,13 +147,13 @@ module OmniAuth
           el.text = 'UGent - Dodona'
           el = org.add_element 'md:OrganizationURL',
                                'xml:lang' => 'en'
-          el.text = 'https://dodona.ugent.be'
+          el.text = 'https://dodona.be'
           el = org.add_element 'md:OrganizationURL',
                                'xml:lang' => 'nl'
-          el.text = 'https://dodona.ugent.be'
+          el.text = 'https://dodona.be'
           el = org.add_element 'md:OrganizationURL',
                                'xml:lang' => 'fr'
-          el.text = 'https://dodona.ugent.be'
+          el.text = 'https://dodona.be'
 
           cp = root.add_element 'md:ContactPerson',
                                 'contactType' => 'technical'

--- a/test/remotes/exercises/lasagna/exercises/series/ISBN/description/description.nl.html
+++ b/test/remotes/exercises/lasagna/exercises/series/ISBN/description/description.nl.html
@@ -41,7 +41,7 @@
     <h3>Pythia spreekt &#8230;</h3>
     <p>In onderstaande video legt Pythia uit hoe je deze opgave kunt aanpakken.
       Bekijk de video als opstapje naar het oplossen van de oefeningen over <a
-        href="https://dodona.ugent.be/nl/exercises/?filter=opgaven/reeks01">variabelen,
+        href="https://dodona.be/nl/exercises/?filter=opgaven/reeks01">variabelen,
         expressies en statements</a>.</p>
     <div class="dodona-centered-group"><iframe src="https://www.youtube.com/embed/Ne35kBQNLXg"
         allowfullscreen="" frameborder="0" height="315" width="560"></iframe></div>


### PR DESCRIPTION
This pull request replaces all mentions of dodona.ugent.be by dodona.be

The only mentions of dodona.ugent.be that remain are:
- A link to the server in the production deploy config
- The alt-host config in the production environment


This is the last step and thus Closes #3299
