### PR TITLE
Avoid 403 errors when a user cannot access linked saved annotations

### DIFF
--- a/app/assets/javascripts/state/SavedAnnotations.ts
+++ b/app/assets/javascripts/state/SavedAnnotations.ts
@@ -43,6 +43,11 @@ class SavedAnnotationState extends State {
     private async fetch(id: number): Promise<SavedAnnotation> {
         const url = `${URL}/${id}.json`;
         const response = await fetch(url);
+
+        if (response.status === 403) {
+            return undefined;
+        }
+
         this.byId.set(id, await response.json());
         return this.byId.get(id);
     }

--- a/app/assets/javascripts/state/SavedAnnotations.ts
+++ b/app/assets/javascripts/state/SavedAnnotations.ts
@@ -43,7 +43,6 @@ class SavedAnnotationState extends State {
     private async fetch(id: number): Promise<SavedAnnotation> {
         const url = `${URL}/${id}.json`;
         const response = await fetch(url);
-
         this.byId.set(id, await response.json());
         return this.byId.get(id);
     }

--- a/app/assets/javascripts/state/SavedAnnotations.ts
+++ b/app/assets/javascripts/state/SavedAnnotations.ts
@@ -44,10 +44,6 @@ class SavedAnnotationState extends State {
         const url = `${URL}/${id}.json`;
         const response = await fetch(url);
 
-        if (response.status === 403) {
-            return undefined;
-        }
-
         this.byId.set(id, await response.json());
         return this.byId.get(id);
     }

--- a/app/views/annotations/_annotation.json.jbuilder
+++ b/app/views/annotations/_annotation.json.jbuilder
@@ -1,4 +1,4 @@
-json.extract! annotation, :id, :line_nr, :annotation_text, :user_id, :submission_id, :saved_annotation_id, :created_at, :updated_at, :course_id, :column, :rows, :columns
+json.extract! annotation, :id, :line_nr, :annotation_text, :user_id, :submission_id, :created_at, :updated_at, :course_id, :column, :rows, :columns
 json.row annotation.line_nr || 0
 if annotation.is_a?(Question)
   json.extract! annotation, :question_state
@@ -41,3 +41,5 @@ json.responses annotation.responses do |response|
   json.partial! response, as: :annotation
 end
 json.thread_root_id annotation.thread_root_id
+
+json.saved_annotation_id annotation.saved_annotation_id if annotation.saved_annotation.present? && SavedAnnotationPolicy.new(current_user, annotation.saved_annotation).show?

--- a/app/views/annotations/_annotation.json.jbuilder
+++ b/app/views/annotations/_annotation.json.jbuilder
@@ -42,4 +42,5 @@ json.responses annotation.responses do |response|
 end
 json.thread_root_id annotation.thread_root_id
 
+# Only include the saved annotation id if the user is allowed to see it
 json.saved_annotation_id annotation.saved_annotation_id if annotation.saved_annotation.present? && SavedAnnotationPolicy.new(current_user, annotation.saved_annotation).show?


### PR DESCRIPTION
This pull request fixes console error logs when visiting a page with saved annotations you cannot see.

