### PR TITLE
Allow more retries on activity_status deadlock errors

### DIFF
--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -450,7 +450,7 @@ class Activity < ApplicationRecord
     begin
       ActivityStatus.find_or_create_by(activity: self, series: series, user: user)
     rescue StandardError
-      # https://github.com/dodona-edu/dodona/issues/1877
+      # https://github.com/dodona-edu/dodona/pull/4903
       raise unless tries < 3
 
       tries += 1

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -446,14 +446,14 @@ class Activity < ApplicationRecord
   end
 
   def activity_status_for!(user, series = nil)
-    first_try = true
+    tries = 0
     begin
       ActivityStatus.find_or_create_by(activity: self, series: series, user: user)
     rescue StandardError
       # https://github.com/dodona-edu/dodona/issues/1877
-      raise unless first_try
+      raise unless tries < 3
 
-      first_try = false
+      tries += 1
       retry
     end
   end


### PR DESCRIPTION
This pull request allows for more retries when trying to find or create an activity status.

Closes https://github.com/dodona-edu/dodona/issues/4479 and #4671

Other solutions tried in https://github.com/dodona-edu/dodona/pull/4547 brought their own hard to solve mysql connection issues, see the discussion in #4671


