### PR TITLE
Group dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,17 @@ updates:
     prefix: ""
   labels:
     - "dependencies"
+  groups:
+    babel:
+      patterns:
+        - "@babel*"
+        - "babel*"
+    eslint:
+      patterns:
+        - "eslint*"
+    rails:
+      patterns:
+        - "@rails*"
 - package-ecosystem: github-actions
   directory: "/"
   schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,11 +11,6 @@ updates:
     prefix: ""
   labels:
     - "dependencies"
-  ignore:
-  - dependency-name: sprockets
-    versions:
-    - ">= 4.a"
-    - "< 5"
 - package-ecosystem: npm
   directory: "/"
   schedule:
@@ -27,11 +22,6 @@ updates:
     prefix: ""
   labels:
     - "dependencies"
-  ignore:
-  - dependency-name: webpack-cli
-    versions:
-    - ">= 4.a"
-    - "< 5"
 - package-ecosystem: github-actions
   directory: "/"
   schedule:


### PR DESCRIPTION
This pull request aims to cut down on the number of dependabot PRs by updating some dependencies in a single PR.

For now, I have created 3 groups: babel, eslint and rails.

More information about this feature can be found here: https://github.blog/changelog/2023-06-30-grouped-version-updates-for-dependabot-public-beta/
