### PR TITLE
Extend allowed tags and attributes (svg)

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -144,8 +144,12 @@ module ApplicationHelper
   end
 
   def sanitize(html)
-    @tags ||= Rails::Html::SafeListSanitizer.allowed_tags.to_a + %w[table thead tbody tr td th colgroup col style svg circle line rect path summary details]
-    @attributes ||= Rails::Html::SafeListSanitizer.allowed_attributes.to_a + %w[style target data-bs-toggle data-parent data-tab data-line data-element id x1 y1 x2 y2 stroke stroke-width fill cx cy r]
+    @tags ||= Rails::Html::SafeListSanitizer.allowed_tags.to_a 
+      + %w[table thead tbody tr td th colgroup col style summary details]
+      + %w[svg g style circle line rect path polygon text]
+    @attributes ||= Rails::Html::SafeListSanitizer.allowed_attributes.to_a 
+      + %w[style target data-bs-toggle data-parent data-tab data-line data-element id]
+      + %w[viewbox width height version style class id x y rx ry x1 y1 x2 y2 d points fill stroke stroke-width cx cy r font-size font-family font-weight font-variant]
 
     # Filters allowed tags and attributes
     sanitized = ActionController::Base.helpers.sanitize html,

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -145,11 +145,11 @@ module ApplicationHelper
 
   def sanitize(html)
     @tags ||= Rails::Html::SafeListSanitizer.allowed_tags.to_a +
-      %w[table thead tbody tr td th colgroup col style summary details] +
-      %w[svg g style circle line rect path polygon text]
+              %w[table thead tbody tr td th colgroup col style summary details] +
+              %w[svg g style circle line rect path polygon text]
     @attributes ||= Rails::Html::SafeListSanitizer.allowed_attributes.to_a +
-      %w[style target data-bs-toggle data-parent data-tab data-line data-element id] +
-      %w[viewbox width height version style class transform id x y rx ry x1 y1 x2 y2 d points fill stroke stroke-width cx cy r font-size font-family font-weight font-variant]
+                    %w[style target data-bs-toggle data-parent data-tab data-line data-element id] +
+                    %w[viewbox width height version style class transform id x y rx ry x1 y1 x2 y2 d points fill stroke stroke-width cx cy r font-size font-family font-weight font-variant]
 
     # Filters allowed tags and attributes
     sanitized = ActionController::Base.helpers.sanitize html,

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -144,12 +144,12 @@ module ApplicationHelper
   end
 
   def sanitize(html)
-    @tags ||= Rails::Html::SafeListSanitizer.allowed_tags.to_a 
-      + %w[table thead tbody tr td th colgroup col style summary details]
-      + %w[svg g style circle line rect path polygon text]
-    @attributes ||= Rails::Html::SafeListSanitizer.allowed_attributes.to_a 
-      + %w[style target data-bs-toggle data-parent data-tab data-line data-element id]
-      + %w[viewbox width height version style class id x y rx ry x1 y1 x2 y2 d points fill stroke stroke-width cx cy r font-size font-family font-weight font-variant]
+    @tags ||= Rails::Html::SafeListSanitizer.allowed_tags.to_a +
+      %w[table thead tbody tr td th colgroup col style summary details] +
+      %w[svg g style circle line rect path polygon text]
+    @attributes ||= Rails::Html::SafeListSanitizer.allowed_attributes.to_a +
+      %w[style target data-bs-toggle data-parent data-tab data-line data-element id] +
+      %w[viewbox width height version style class transform id x y rx ry x1 y1 x2 y2 d points fill stroke stroke-width cx cy r font-size font-family font-weight font-variant]
 
     # Filters allowed tags and attributes
     sanitized = ActionController::Base.helpers.sanitize html,

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -98,7 +98,7 @@ class ApplicationHelperTest < ActiveSupport::TestCase
 
   test 'sanitize helper should allow a selection of svg tags' do
     dirty_html = <<~HTML
-      <svg viewbox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" width="300" height="100" version="1.1">
+      <svg viewbox="0 0 100 100" width="300" height="100" version="1.1">
         <style>line,circle{stroke-width:3px;stroke:black;stroke-linecap:round}</style>
         <style>test{stroke-width:3px;stroke:black;stroke-linecap:round}</style>
         <g id="group1" transform="translate(50,50)">

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -96,6 +96,25 @@ class ApplicationHelperTest < ActiveSupport::TestCase
     assert_equal dirty_html, clean_html
   end
 
+  test 'sanitize helper should allow a selection of svg tags' do
+    dirty_html = <<~HTML
+      <svg viewbox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" width="300" height="100" version="1.1">
+        <style>line,circle{stroke-width:3px;stroke:black;stroke-linecap:round}</style>
+        <style>test{stroke-width:3px;stroke:black;stroke-linecap:round}</style>
+        <g id="group1" transform="translate(50,50)">
+          <circle cx="0" cy="0" r="40" fill="none"></circle>
+          <line class="test" x1="0" y1="0" x2="0" y2="-40"></line>
+        </g>
+        <rect x="0" y="0" rx="1" ry="1" width="100" height="100" fill="none" stroke="black" stroke-width="3px"></rect>
+        <polygon points="0,0 100,0 100,100 0,100"></polygon>
+        <path d="M0,0 L100,0 L100,100 L0,100 Z"></path>
+        <text x="0" y="0" font-size="14px" font-weight="bold" font-variant="normal" font-family="serif">Hello</text>
+      </svg>
+    HTML
+    clean_html = sanitize dirty_html
+    assert_equal dirty_html, clean_html
+  end
+
   test 'language tags are used correctly' do
     def current_user
       create :user


### PR DESCRIPTION
This pull request adds additional SVG tags:
`<g>` `<polygon>` `<text>`

And attributes:
`viewbox` `width` `height` `version` `class ` `transform` `x` `y` `rx` `ry` `d` `points` `font-size` `font-family` `font-weight` `font-variant`

- [x] Tests were added
- [ ] Documentation update can be found at dodona-edu/dodona-edu.github.io#