### PR TITLE
Constrain annotations to start within the length of the line

### DIFF
--- a/app/assets/javascripts/components/annotations/line_of_code.ts
+++ b/app/assets/javascripts/components/annotations/line_of_code.ts
@@ -81,12 +81,17 @@ export class LineOfCode extends ShadowlessLitElement {
 
         let start = 0;
         if (this.row === firstRow) {
-            start = annotation.column || 0;
+            // In rare cases, machine annotations start past the end of the line, resulting in errors if we don't constrain them to be in the line
+            if (annotation.column !== undefined && annotation.column !== null && annotation.column >= 0 && annotation.column < this.codeLength) {
+                start = annotation.column;
+            } else {
+                start = 0;
+            }
         }
 
         let length = this.codeLength - start;
         if (this.row === lastRow) {
-            if (annotation.column !== undefined && annotation.column !== null) {
+            if (annotation.column !== undefined && annotation.column !== null && annotation.column >= 0 && annotation.column < this.codeLength) {
                 const defaultLength = isMachineAnnotation ? 0 : this.codeLength - start;
                 length = annotation.columns || defaultLength;
             }


### PR DESCRIPTION
I opted to just highlight the whole line if we encounter one of these annotations. It could of course also be an option to try to highlight past the last character of a line.

Closes #4920.
