### PR TITLE
Only close annotation form on focus loss when empty

### DIFF
--- a/app/assets/javascripts/components/annotations/annotation_form.ts
+++ b/app/assets/javascripts/components/annotations/annotation_form.ts
@@ -50,6 +50,8 @@ export class AnnotationForm extends watchMixin(ShadowlessLitElement) {
     @property({ state: true })
     _savedAnnotationTitle: string;
     @property({ state: true })
+    _savedAnnotationSearchInput = "";
+    @property({ state: true })
     saveAnnotation = false;
 
     get savedAnnotationTitle(): string {
@@ -69,6 +71,15 @@ export class AnnotationForm extends watchMixin(ShadowlessLitElement) {
         },
         savedAnnotationId: () => {
             this._savedAnnotationId = this.savedAnnotationId || "";
+        },
+        saveAnnotation: () => {
+            this.listenForCloseIfEmpty();
+        },
+        _annotationText: () => {
+            this.listenForCloseIfEmpty();
+        },
+        _savedAnnotationSearchInput: () => {
+            this.listenForCloseIfEmpty();
         }
     };
 
@@ -108,11 +119,21 @@ export class AnnotationForm extends watchMixin(ShadowlessLitElement) {
         }
     }
 
+    get isEmpty(): boolean {
+        return this._annotationText.length === 0 && !this.saveAnnotation && this._savedAnnotationSearchInput.length === 0;
+    }
+
+    listenForCloseIfEmpty(): void {
+        if (this.isEmpty) {
+            this.listenForClose();
+        } else {
+            this.stopListeningForClose();
+        }
+    }
+
     connectedCallback(): void {
         super.connectedCallback();
-        if (!this.annotationText) {
-            this.listenForClose();
-        }
+        this.listenForCloseIfEmpty();
     }
 
     disconnectedCallback(): void {
@@ -125,15 +146,11 @@ export class AnnotationForm extends watchMixin(ShadowlessLitElement) {
             this._annotationText = e.detail.text;
         }
         this._savedAnnotationId = e.detail.id;
+        this._savedAnnotationSearchInput = e.detail.title;
     }
 
     handleTextInput(): void {
         this._annotationText = this.inputRef.value.value;
-        if (this._annotationText.length > 0) {
-            this.stopListeningForClose();
-        } else {
-            this.listenForClose();
-        }
     }
 
     handleCancel(): void {

--- a/test/javascript/code_listing.test.ts
+++ b/test/javascript/code_listing.test.ts
@@ -385,3 +385,30 @@ test("click on comment button", async () => {
     await userEvent.click(annotationButton);
     expect(document.querySelectorAll("d-annotation-form").length).toBe(1);
 });
+
+test("empty form should close on click outside", async () => {
+    codeListing.initAnnotateButtons();
+    await nextFrame();
+    expect(document.querySelectorAll("d-annotation-form").length).toBe(0);
+    const annotationButton: HTMLButtonElement = document.querySelector(".annotation-button .btn");
+    await userEvent.click(annotationButton);
+    expect(document.querySelectorAll("d-annotation-form").length).toBe(1);
+    await userEvent.click(document.body);
+    expect(document.querySelectorAll("d-annotation-form").length).toBe(0);
+});
+
+test("form should not close when it has content", async () => {
+    codeListing.initAnnotateButtons();
+    await nextFrame();
+    expect(document.querySelectorAll("d-annotation-form").length).toBe(0);
+    const annotationButton: HTMLButtonElement = document.querySelector(".annotation-button .btn");
+    await userEvent.click(annotationButton);
+    expect(document.querySelectorAll("d-annotation-form").length).toBe(1);
+    const textarea: HTMLTextAreaElement = document.querySelector("d-annotation-form textarea");
+    await userEvent.type(textarea, "This is a test");
+    await userEvent.click(document.body);
+    expect(document.querySelectorAll("d-annotation-form").length).toBe(1);
+    await userEvent.clear(textarea);
+    await userEvent.click(document.body);
+    expect(document.querySelectorAll("d-annotation-form").length).toBe(0);
+});


### PR DESCRIPTION
This pull request improves the empty check to look at all form fields instead of only `_annotationText`. 
Detecting changes in the form fields now also uses lit reactivity (Using `watch`), which makes sure the listen for close is always called when the form fields change. (independent of how they are changed)

- [x] Tests were added

Closes #4942
