### PR TITLE
Do not redirect to repository media after login

### DIFF
--- a/app/controllers/repositories_controller.rb
+++ b/app/controllers/repositories_controller.rb
@@ -2,6 +2,7 @@ require 'set'
 
 class RepositoriesController < ApplicationController
   before_action :set_repository, only: %i[show edit update destroy public hook reprocess admins add_admin remove_admin courses add_course remove_course]
+  skip_before_action :store_current_location, only: %i[public]
 
   # GET /repositories
   # GET /repositories.json


### PR DESCRIPTION
This pull request fixes this page https://dodona.be/nl/courses/2407 redirecting to this image https://dodona.be/nl/repositories/61/public/CodersApprentice.png after login.

- [x] tested on naos
