### PR TITLE
Fix search by username in account linking flow

### DIFF
--- a/app/controllers/auth/omniauth_callbacks_controller.rb
+++ b/app/controllers/auth/omniauth_callbacks_controller.rb
@@ -270,7 +270,7 @@ class Auth::OmniauthCallbacksController < Devise::OmniauthCallbacksController
 
   def find_user_in_institution
     # Attempt to find user by its username and institution id
-    user = User.from_username_and_institution(auth_uid, provider.institution_id)
+    user = User.from_username_and_institution(auth_username || auth_uid, provider.institution_id)
     # Try to find the user using the email address and institution id.
     user = User.from_email_and_institution(auth_email, provider.institution_id) if user.blank?
     user


### PR DESCRIPTION
This pull request fixes finding a user by username in the account linking flow.

The search now uses the same values as:
![image](https://github.com/dodona-edu/dodona/assets/21177904/4e25f853-32fc-4c2e-94c9-91ed0a13e571)
Which is the goal as we want to prevent duplicate username errors.

- [x] a new test is added for this case

Closes #4966
