### PR TITLE
Fix docker images not being shut down

### DIFF
--- a/app/runners/submission_runner.rb
+++ b/app/runners/submission_runner.rb
@@ -164,7 +164,7 @@ class SubmissionRunner
       while Time.zone.now - before_time < time_limit
         before_stats = Time.zone.now
         # Check if container is still running
-        if !Rails.env.test? && (Docker::Container.any? { |c| c.id.starts_with?(container.id) || container.id.starts_with?(container.id) } && container.refresh!.info['State']['Running'])
+        if !Rails.env.test? && (Docker::Container.all.any? { |c| c.id.starts_with?(container.id) || container.id.starts_with?(container.id) } && container.refresh!.info['State']['Running']) # rubocop:disable Rails/RedundantActiveRecordAllMethod
           # If we don't pass these extra options gathering stats takes 1+ seconds (https://github.com/moby/moby/issues/23188#issuecomment-223211481)
           stats = container.stats({ 'one-shot': true, stream: false })
           memory = [stats['memory_stats']['usage'] / (1024.0 * 1024.0), memory].max if stats['memory_stats']&.fetch('usage', nil)


### PR DESCRIPTION
This pull request fixes infinitely running docker images.

It reverts changes made in #4979, suggested by rubocop, which were incorrect. The `any` function does not exist on `Docker::Container`
![image](https://github.com/dodona-edu/dodona/assets/21177904/47e131c8-eea6-4248-bdba-c1efa0baff6d)

The rubocop issue is already reported https://github.com/rubocop/rubocop-rails/issues/1124
With a potential fix https://github.com/rubocop/rubocop-rails/pull/1127