### PR TITLE
Make wavy underline markings smaller

### DIFF
--- a/app/assets/javascripts/components/annotations/annotation_marker.ts
+++ b/app/assets/javascripts/components/annotations/annotation_marker.ts
@@ -19,6 +19,8 @@ import { StateController } from "state/state_system/StateController";
 export class AnnotationMarker extends LitElement {
     @property({ type: Array })
     annotations: Annotation[];
+    @property({ type: Boolean, attribute: "full-width" })
+    fullWidth = false;
 
     state = new StateController(this);
 
@@ -43,6 +45,12 @@ export class AnnotationMarker extends LitElement {
                 .${x} { background-color: var(--${x}-color)}
                 .${x}-intense {background-color: var(--${x}-intense-color)}
             `),
+            css`
+                .full-width {
+                    display: block;
+                    width: 100%;
+                }
+            `
         ];
     }
 
@@ -94,6 +102,6 @@ export class AnnotationMarker extends LitElement {
     }
 
     render(): TemplateResult {
-        return html`<span class="${this.annotationClasses}"><slot>${this.machineAnnotationMarkerSVG}</slot></span>`;
+        return html`<span class="${this.annotationClasses} ${this.fullWidth ? "full-width" : ""}"><slot>${this.machineAnnotationMarkerSVG}</slot></span>`;
     }
 }

--- a/app/assets/javascripts/components/annotations/annotation_marker.ts
+++ b/app/assets/javascripts/components/annotations/annotation_marker.ts
@@ -1,5 +1,5 @@
 import { customElement, property } from "lit/decorators.js";
-import { css, html, LitElement, TemplateResult, CSSResultGroup, unsafeCSS } from "lit";
+import { css, html, LitElement, TemplateResult, CSSResultGroup } from "lit";
 import {
     Annotation,
     compareAnnotationOrders,
@@ -26,32 +26,23 @@ export class AnnotationMarker extends LitElement {
 
     static get styles(): CSSResultGroup {
         // order matters here, the last defined class determines the color if multiple apply
-        const machineClasses = [unsafeCSS`info`, unsafeCSS`warning`, unsafeCSS`error`];
-        const userClasses = [unsafeCSS`annotation`, unsafeCSS`question`];
-        return [
-            ...machineClasses.map(x => css`
-                .${x} {
-                    background-image: var(--d-annotation-${x}-background);
-                    background-position: left bottom;
-                    background-repeat: repeat-x;
-                }
-                .${x}-intense {
-                    background-image: var(--d-annotation-${x}-background-intense);
-                    background-position: left bottom;
-                    background-repeat: repeat-x;
-                }
-            `),
-            ...userClasses.map(x => css`
-                .${x} { background-color: var(--${x}-color)}
-                .${x}-intense {background-color: var(--${x}-intense-color)}
-            `),
-            css`
-                .full-width {
-                    display: block;
-                    width: 100%;
-                }
-            `
-        ];
+        return css`
+            .info, .warning, .error,
+            .info-intense, .warning-intense, .error-intense {
+                background-position: left bottom;
+                background-repeat: repeat-x;
+            }
+            .info { background-image: var(--d-annotation-info-background) }
+            .warning { background-image: var(--d-annotation-warning-background) }
+            .error { background-image: var(--d-annotation-error-background) }
+            .info-intense { background-image: var(--d-annotation-info-background-intense) }
+            .warning-intense { background-image: var(--d-annotation-warning-background-intense) }
+            .error-intense { background-image: var(--d-annotation-error-background-intense) }
+            .annotation { background-color: var(--annotation-color) }
+            .question { background-color: var(--question-color) }
+            .annotation-intense { background-color: var(--annotation-intense-color) }
+            .question-intense { background-color: var(--question-intense-color) }
+            `;
     }
 
     static getClass(annotation: Annotation): string {

--- a/app/assets/javascripts/components/annotations/annotation_marker.ts
+++ b/app/assets/javascripts/components/annotations/annotation_marker.ts
@@ -34,13 +34,16 @@ export class AnnotationMarker extends LitElement {
 
     static getStyle(annotation: Annotation): string {
         if (["error", "warning", "info"].includes(annotation.type)) {
-            // shorthand notation does not work in safari
+            const strokeWidth = annotation.isHovered ? 1.7 : 0.7;
+            // -webkit is required for chrome
             return `
-                text-decoration-line: underline;
-                text-decoration-color: ${AnnotationMarker.colors[annotation.type]};
-                text-decoration-thickness: ${annotation.isHovered ? 2 : 1}px;
-                text-decoration-style: wavy;
-                text-decoration-skip-ink: none;
+                -webkit-mask-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="6" height="3">%3Cpath%20d%3D%22m0%202.5%20l2%20-1.5%20l1%200%20l2%201.5%20l1%200%22%20stroke%3D%22%23d12%22%20fill%3D%22none%22%20stroke-width%3D%22${strokeWidth}%22%2F%3E</svg>');
+                mask-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="6" height="3">%3Cpath%20d%3D%22m0%202.5%20l2%20-1.5%20l1%200%20l2%201.5%20l1%200%22%20stroke%3D%22%23d12%22%20fill%3D%22none%22%20stroke-width%3D%22${strokeWidth}%22%2F%3E</svg>');
+                -webkit-mask-position: left bottom;
+                mask-position: left bottom;
+                -webkit-mask-repeat: repeat-x;
+                mask-repeat: repeat-x;
+                background-color: ${AnnotationMarker.colors[annotation.type]};
             `;
         } else {
             const key = annotation.isHovered ? `${annotation.type}-intense` : annotation.type;

--- a/app/assets/javascripts/components/annotations/line_of_code.ts
+++ b/app/assets/javascripts/components/annotations/line_of_code.ts
@@ -168,7 +168,7 @@ export class LineOfCode extends ShadowlessLitElement {
         return html`
             <div class="code-layers">
                 ${ this.fullLineAnnotations.length > 0 ? html`
-                    <d-annotation-marker style="width: 100%; display: block" .annotations=${this.fullLineAnnotations}>
+                    <d-annotation-marker full-width="true" .annotations=${this.fullLineAnnotations}>
                         <pre class="code-line background-layer"><span></span>${backgroundLayer}</pre>
                     </d-annotation-marker>` : html`
                     <pre class="code-line background-layer">${backgroundLayer}</pre>

--- a/app/assets/stylesheets/base.css.scss
+++ b/app/assets/stylesheets/base.css.scss
@@ -2,10 +2,10 @@
 @import "../../../node_modules/bootstrap/scss/functions";
 
 // 2. Include any default variable overrides here
+@import "mixins.css.scss";
 @import "theme/m3-theme-light.css.scss";
 @import "theme/m3-theme-dark.css.scss";
 @import "bootstrap_variable_overrides.css.scss";
-@import "mixins.css.scss";
 @import "theme/rouge.css.scss";
 @import "theme/ace.css.scss";
 

--- a/app/assets/stylesheets/components/code_listing.css.scss
+++ b/app/assets/stylesheets/components/code_listing.css.scss
@@ -527,9 +527,6 @@
 
 d-annotation-marker,
 d-selection-marker {
-  --info-color: var(--d-annotation-info);
-  --warning-color: var(--d-annotation-warning);
-  --error-color: var(--d-annotation-error);
   --question-color: var(--d-annotation-question-background);
   --annotation-color: var(--d-annotation-user-background);
   --question-intense-color: var(--d-annotation-question-background-intense);

--- a/app/assets/stylesheets/mixins.css.scss
+++ b/app/assets/stylesheets/mixins.css.scss
@@ -1,3 +1,6 @@
+@use "sass:string";
+@use "sass:color";
+
 @mixin shadow-z0 {
   box-shadow: none;
 }
@@ -26,4 +29,11 @@
     0 8px 10px -5px rgba(0, 0, 0, 0.14),
     0 16px 24px 2px rgba(0, 0, 0, 0.098),
     0 6px 30px 5px rgba(0, 0, 0, 0.084);
+}
+
+// sets the variable equal to the url of a wavy svg with the specified color and stroke-width
+@mixin wavy-underline($variable, $color, $stroke-width) {
+  // this is a custom wavy svg that can be used as a background image
+  // the color is slightly hacked to get a proper url encode version of the color
+  #{$variable}: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="6" height="3">%3Cpath%20d%3D%22m0%202.5%20l2%20-1.5%20l1%200%20l2%201.5%20l1%200%22%20stroke%3D%22%23#{string.slice(color.ie-hex-str($color), 4)}%22%20fill%3D%22none%22%20stroke-width%3D%22#{$stroke-width}%22%2F%3E</svg>');
 }

--- a/app/assets/stylesheets/theme/m3-theme-dark.css.scss
+++ b/app/assets/stylesheets/theme/m3-theme-dark.css.scss
@@ -202,6 +202,15 @@
   --d-annotation-user-background: #{color.mix($success-70, $neutral-25, 8%)};
   --d-annotation-question-background-intense: #{color.mix($purple-80, $neutral-25, 20%)};
   --d-annotation-user-background-intense: #{color.mix($success-70, $neutral-25, 20%)};
+  --d-annotation-info-background: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="6" height="3"><path d="m0 2.5 l2 -1.5 l1 0 l2 1.5 l1 0" stroke="#{$info-80}" fill="none" stroke-width="#{0.7}"/></svg>');
+
+
+  @include wavy-underline(--d-annotation-warning-background, $warning-80, 0.7);
+  @include wavy-underline(--d-annotation-warning-background-intense, $warning-80, 1.7);
+  @include wavy-underline(--d-annotation-error-background, $danger-80, 0.7);
+  @include wavy-underline(--d-annotation-error-background-intense, $danger-80, 1.7);
+  @include wavy-underline(--d-annotation-info-background, $info-80, 0.7);
+  @include wavy-underline(--d-annotation-info-background-intense, $info-80, 1.7);
 
   .image-bright {
     // $gray-90 converted to filter using https://codepen.io/sosuke/pen/Pjoqqp

--- a/app/assets/stylesheets/theme/m3-theme-dark.css.scss
+++ b/app/assets/stylesheets/theme/m3-theme-dark.css.scss
@@ -202,8 +202,6 @@
   --d-annotation-user-background: #{color.mix($success-70, $neutral-25, 8%)};
   --d-annotation-question-background-intense: #{color.mix($purple-80, $neutral-25, 20%)};
   --d-annotation-user-background-intense: #{color.mix($success-70, $neutral-25, 20%)};
-  --d-annotation-info-background: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="6" height="3"><path d="m0 2.5 l2 -1.5 l1 0 l2 1.5 l1 0" stroke="#{$info-80}" fill="none" stroke-width="#{0.7}"/></svg>');
-
 
   @include wavy-underline(--d-annotation-warning-background, $warning-80, 0.7);
   @include wavy-underline(--d-annotation-warning-background-intense, $warning-80, 1.7);

--- a/app/assets/stylesheets/theme/m3-theme-dark.css.scss
+++ b/app/assets/stylesheets/theme/m3-theme-dark.css.scss
@@ -205,8 +205,8 @@
 
   @include wavy-underline(--d-annotation-warning-background, $warning-80, 0.7);
   @include wavy-underline(--d-annotation-warning-background-intense, $warning-80, 1.7);
-  @include wavy-underline(--d-annotation-error-background, $danger-80, 0.7);
-  @include wavy-underline(--d-annotation-error-background-intense, $danger-80, 1.7);
+  @include wavy-underline(--d-annotation-error-background, $danger-70, 0.7);
+  @include wavy-underline(--d-annotation-error-background-intense, $danger-70, 1.7);
   @include wavy-underline(--d-annotation-info-background, $info-80, 0.7);
   @include wavy-underline(--d-annotation-info-background-intense, $info-80, 1.7);
 

--- a/app/assets/stylesheets/theme/m3-theme-light.css.scss
+++ b/app/assets/stylesheets/theme/m3-theme-light.css.scss
@@ -3,6 +3,7 @@
 
 @use "sass:color";
 @import "theme/m3-theme.css.scss";
+@import "mixins.css.scss";
 
 :root,
 [data-bs-theme="light"] {
@@ -216,6 +217,13 @@
   --d-annotation-user-background: #{color.mix($success-60, $neutral-98, 8%)};
   --d-annotation-question-background-intense: #{color.mix($purple-40, $neutral-98, 20%)};
   --d-annotation-user-background-intense: #{color.mix($success-60, $neutral-98, 20%)};
+
+  @include wavy-underline(--d-annotation-warning-background, $warning-70, 0.7);
+  @include wavy-underline(--d-annotation-warning-background-intense, $warning-70, 1.7);
+  @include wavy-underline(--d-annotation-error-background, $danger-60, 0.7);
+  @include wavy-underline(--d-annotation-error-background-intense, $danger-60, 1.7);
+  @include wavy-underline(--d-annotation-info-background, $info-40, 0.7);
+  @include wavy-underline(--d-annotation-info-background-intense, $info-40, 1.7);
 
   .image-bright {
     // $gray-10 converted to filter using https://codepen.io/sosuke/pen/Pjoqqp


### PR DESCRIPTION
This pull request replaces wavy underline with custom svg styling. I copied the svg from codemirror.

The background image has to be defined within the theme as we cannot use css variables inside the image. I wrote a mixin to avoid a lot of duplicate sass.

The styles are also moved to static css classes, which should render more efficiently.

## Chrome
### Old
![image](https://github.com/dodona-edu/dodona/assets/21177904/ee121945-4cf7-4afd-abd2-c01e382fe1ca)

### New
![image](https://github.com/dodona-edu/dodona/assets/21177904/f39ccb7f-1570-4b76-8045-ab167ee3589b)

## Firefox
### Old
![image](https://github.com/dodona-edu/dodona/assets/21177904/3de474d0-d7b5-4cfe-86cc-2a130912033b)

### New
![image](https://github.com/dodona-edu/dodona/assets/21177904/32616871-a2cd-47bc-8e9f-289864b1e619)

Closes #4943
