### PR TITLE
Fix system test chromedriver version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -114,8 +114,6 @@ jobs:
         cache: yarn
     - name: Setup chromium-chromedriver
       uses: nanasess/setup-chromedriver@master
-      with:
-        chromedriver-version: '115.0.5790.102'
     - name: Install JS dependencies
       run: |
         yarn install


### PR DESCRIPTION
This pull request fixes failing system test because of the wrong chromedriver version.

It reverts https://github.com/dodona-edu/dodona/pull/4866 which resolved an version mismatch, which should not exist anymore.
