### PR TITLE
Remove browser outline styling for focus-within on nav-tabs

### DIFF
--- a/app/assets/stylesheets/base.css.scss
+++ b/app/assets/stylesheets/base.css.scss
@@ -115,7 +115,3 @@ figcaption {
   justify-content: space-between;
   flex-direction: row;
 }
-
-.nav.nav-tabs a:focus-visible {
-  outline: none;
-}

--- a/app/assets/stylesheets/base.css.scss
+++ b/app/assets/stylesheets/base.css.scss
@@ -116,6 +116,6 @@ figcaption {
   flex-direction: row;
 }
 
-a:focus-visible {
+.nav.nav-tabs a:focus-visible {
   outline: none;
 }

--- a/app/assets/stylesheets/base.css.scss
+++ b/app/assets/stylesheets/base.css.scss
@@ -115,3 +115,7 @@ figcaption {
   justify-content: space-between;
   flex-direction: row;
 }
+
+a:focus-visible {
+  outline: none;
+}

--- a/app/assets/stylesheets/bootstrap_style_overrides.css.scss
+++ b/app/assets/stylesheets/bootstrap_style_overrides.css.scss
@@ -242,3 +242,7 @@ blockquote {
   background: var(--d-background);
   color: var(--d-on-surface-muted);
 }
+
+.nav.nav-tabs a:focus-visible {
+  outline: none;
+}


### PR DESCRIPTION
This pull request removes the outline styling applied by some browsers on tab links
focus-within is specifically applied by browsers to improve ux (https://developer.mozilla.org/en-US/docs/Web/CSS/:focus-visible). But it does not seem relevant in our case as we have custom styling to make UX clear for tabs.

Closes #4569
