### PR TITLE
Fix occassional failure of javascript tests

### DIFF
--- a/app/assets/javascripts/utilities.ts
+++ b/app/assets/javascripts/utilities.ts
@@ -126,7 +126,7 @@ function tooltip(target: Element | null, message: string, disappearAfter = 3000)
 
 function fetch(url: URL | RequestInfo, options: RequestInit = {}): Promise<Response> {
     const headers = options.headers || {};
-    headers["x-csrf-token"] = headers["x-csrf-token"] || (document.querySelector("meta[name=\"csrf-token\"]") as HTMLMetaElement).content;
+    headers["x-csrf-token"] = headers["x-csrf-token"] || (document.querySelector("meta[name=\"csrf-token\"]") as HTMLMetaElement)?.content;
     headers["x-requested-with"] = headers["x-requested-with"] || "XMLHttpRequest";
     options["headers"] = headers;
     return window.fetch(url, options);


### PR DESCRIPTION
This pull request fixes the occasional failure of javascript tests.

One test tends to fail on `document.querySelector("meta[name=\"csrf-token\"]")` being undefined. This probably depends on whether or not another test sets this value. 

I do not think the code should fail on absence of this variable, so I fixed that instead of also setting the variable within the specific test.

For future reference, the test error log: (The second failure is caused by the first error)
```
FAIL test/javascript/code_listing.test.ts (92.957 s)
  ● empty form should close on click outside

    TypeError: Cannot read properties of null (reading 'content')

      127 | function fetch(url: URL | RequestInfo, options: RequestInit = {}): Promise<Response> {
      128 |     const headers = options.headers || {};
    > 129 |     headers["x-csrf-token"] = headers["x-csrf-token"] || (document.querySelector("meta[name=\"csrf-token\"]") as HTMLMetaElement).content;
          |                                                                                                                                  ^
      130 |     headers["x-requested-with"] = headers["x-requested-with"] || "XMLHttpRequest";
      131 |     options["headers"] = headers;
      132 |     return window.fetch(url, options);

      at fetch (app/assets/javascripts/utilities.ts:129:130)
      at EventTarget.<anonymous> (app/assets/javascripts/state/SavedAnnotations.ts:38:37)
      at app/assets/javascripts/state/SavedAnnotations.ts:3095:40
      at Object.<anonymous>.__awaiter (app/assets/javascripts/state/SavedAnnotations.ts:3044:10)
      at EventTarget.fetchList (app/assets/javascripts/state/SavedAnnotations.ts:3195:12)
      at app/assets/javascripts/state/SavedAnnotations.ts:72:22
      at Timeout.task [as _onTimeout] (node_modules/jsdom/lib/jsdom/browser/Window.js:516:19)

  ● form should not close when it has content

    expect(received).toBe(expected) // Object.is equality

    Expected: 1
    Received: 0

      387 |     const annotationButton: HTMLButtonElement = document.querySelector(".annotation-button .btn");
      388 |     await userEvent.click(annotationButton);
    > 389 |     expect(document.querySelectorAll("d-annotation-form").length).toBe(1);
          |                                                                   ^
      390 |     await userEvent.click(document.body);
      391 |     expect(document.querySelectorAll("d-annotation-form").length).toBe(0);
      392 | });

      at test/javascript/code_listing.test.ts:389:67
      at fulfilled (test/javascript/code_listing.test.ts:5:58)
```