### PR TITLE
Show machine annotations on the last line if index out of range

### DIFF
--- a/app/assets/javascripts/state/MachineAnnotations.ts
+++ b/app/assets/javascripts/state/MachineAnnotations.ts
@@ -3,6 +3,7 @@ import { State } from "state/state_system/State";
 import { stateProperty } from "state/state_system/StateProperty";
 import { StateMap } from "state/state_system/StateMap";
 import { createStateFromInterface } from "state/state_system/CreateStateFromInterface";
+import { submissionState } from "state/Submissions";
 
 export interface MachineAnnotationData {
     type: AnnotationType;
@@ -30,7 +31,13 @@ class MachineAnnotationState extends State {
         for (const data of annotations) {
             const annotation = new MachineAnnotation(data);
             const markedLength = annotation.rows ?? 1;
-            const line = annotation.row ? annotation.row + markedLength : 1;
+            let line = annotation.row ? annotation.row + markedLength : 1;
+
+            // show annotation on the last line if it is out of range
+            if (line > submissionState.codeByLine.length) {
+                line = submissionState.codeByLine.length;
+            }
+
             if (this.byLine.has(line)) {
                 this.byLine.get(line)?.push(annotation);
             } else {


### PR DESCRIPTION
This pull request fixes https://github.com/dodona-edu/dodona/issues/5010

This might also be described as a Haskell judge bug (which returned an annotation which spans non existing lines). But I think it is positive that we are a bit flexible towards judge output.

Closes #5010 
