### PR TITLE
Fix copying selected code without extra newlines

### DIFF
--- a/app/assets/javascripts/code_listing.ts
+++ b/app/assets/javascripts/code_listing.ts
@@ -56,6 +56,8 @@ function initAnnotateButtons(): void {
         }
 
         const selectedCode = submissionState.code.split("\n").slice(selection.row - 1, selection.row + selection.rows - 1);
+        // on the first and last line, selection might only cover part of the line
+        // only copy the selected columns/characters
         selectedCode[0] = selectedCode[0].slice(selection.column);
         selectedCode[selectedCode.length - 1] = selectedCode[selectedCode.length - 1].slice(0, selection.columns);
         event.clipboardData.setData("text/plain", selectedCode.join("\n"));

--- a/app/assets/javascripts/code_listing.ts
+++ b/app/assets/javascripts/code_listing.ts
@@ -48,7 +48,7 @@ function initAnnotateButtons(): void {
     document.addEventListener("dragover", e => e.preventDefault());
     document.addEventListener("drop", e => e.preventDefault());
 
-    // copy only the selected code, this avoids copying the line numbers or extra whitespace form the complex html
+    // copy only the selected code, this avoids copying the line numbers or extra whitespace from the complex html
     document.addEventListener("copy", event => {
         const selection = userAnnotationState.selectedRange;
         if (!selection) {

--- a/app/assets/javascripts/code_listing.ts
+++ b/app/assets/javascripts/code_listing.ts
@@ -47,6 +47,20 @@ function initAnnotateButtons(): void {
     // make the whole document a valid target for dropping the create annotation button
     document.addEventListener("dragover", e => e.preventDefault());
     document.addEventListener("drop", e => e.preventDefault());
+
+    // copy only the selected code, this avoids copying the line numbers or extra whitespace form the complex html
+    document.addEventListener("copy", event => {
+        const selection = userAnnotationState.selectedRange;
+        if (!selection) {
+            return; // if there is no code selection, let the browser handle the copy event
+        }
+
+        const selectedCode = submissionState.code.split("\n").slice(selection.row - 1, selection.row + selection.rows - 1);
+        selectedCode[0] = selectedCode[0].slice(selection.column);
+        selectedCode[selectedCode.length - 1] = selectedCode[selectedCode.length - 1].slice(0, selection.columns);
+        event.clipboardData.setData("text/plain", selectedCode.join("\n"));
+        event.preventDefault();
+    });
 }
 
 function loadUserAnnotations(): void {


### PR DESCRIPTION
This pull request fixes copying parts of submitted code, without extra newlines being present in the result.

Before this pr in firefox a newline was added after every line.
In chrome a newline was added before each annotation

It was rather complex to avoid these newlines being selected in the complex html structure.
Instead we reproduce the selection in the original code and return the relevant subset of that string when the copy event is triggered.
