### PR TITLE
Fix sorting for most recent submission per user

### DIFF
--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -188,8 +188,14 @@ class SubmissionsController < ApplicationController
 
     @course_membership = CourseMembership.find_by(user: @user, course: @course) if @user.present? && @course.present?
 
+    return unless params[:most_recent_per_user]
+
     # this cannot use has_scope, because we need the scopes in this method
     # to be applied before this one
-    @submissions = @submissions.most_recent_per_user if params[:most_recent_per_user]
+    @submissions = @submissions.most_recent_per_user
+    # reapplies the order_by scope if present in the params
+    # this is needed because the previous line creates a group by query, which breaks the order_by scope
+    @submissions = Submission.where(id: @submissions.pluck(:id)) # otherwise the group_by breaks order_by scopes that use joins
+    @submissions = apply_scopes(@submissions, { order_by: params[:order_by] }) if params[:order_by].present?
   end
 end

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -193,9 +193,12 @@ class SubmissionsController < ApplicationController
     # this cannot use has_scope, because we need the scopes in this method
     # to be applied before this one
     @submissions = @submissions.most_recent_per_user
+
+    return if params[:order_by].blank?
+
     # reapplies the order_by scope if present in the params
     # this is needed because the previous line creates a group by query, which breaks the order_by scope
     @submissions = Submission.where(id: @submissions.pluck(:id)) # otherwise the group_by breaks order_by scopes that use joins
-    @submissions = apply_scopes(@submissions, { order_by: params[:order_by] }) if params[:order_by].present?
+    @submissions = apply_scopes(@submissions, { order_by: params[:order_by] })
   end
 end

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -194,11 +194,14 @@ class SubmissionsController < ApplicationController
     # to be applied before this one
     @submissions = @submissions.most_recent_per_user
 
-    return if params[:order_by].blank?
-
-    # reapplies the order_by scope if present in the params
-    # this is needed because the previous line creates a group by query, which breaks the order_by scope
-    @submissions = Submission.where(id: @submissions.pluck(:id)) # otherwise the group_by breaks order_by scopes that use joins
-    @submissions = apply_scopes(@submissions, { order_by: params[:order_by] })
+    if params[:order_by].present?
+      # reapplies the order_by scope if present in the params
+      # this is needed because the previous line creates a group by query, which breaks the order_by scope
+      @submissions = Submission.where(id: @submissions) # otherwise the group_by breaks order_by scopes that use joins
+      @submissions = apply_scopes(@submissions, { order_by: params[:order_by] })
+    else
+      # reapply the default order scope, as most_recent_per_user breaks it
+      @submissions = @submissions.reorder(id: :desc)
+    end
   end
 end


### PR DESCRIPTION
This pull request fixes broken sorting on submission listings when only viewing the most recent submission per user.

This was caused because the scope contains a `group by` call which doesn't always work as expected together with joins or order by statements.

- [x] Tests were added

