### PR TITLE
Avoid git race conditions by allowing only one worker

### DIFF
--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -12,7 +12,8 @@ server 'tityos.ugent.be',   user: 'dodona', port: '4840', roles: %w[app worker]
 
 set :delayed_job_pools_per_server,
     'dodona' => {
-      'default,git,statistics,exports,cleaning' => 2
+      'default,statistics,exports,cleaning' => 2,
+      'git' => 1,
     },
     'sisyphus' => {
       'submissions,low_priority_submissions,high_priority_submissions' => 6


### PR DESCRIPTION
This pull request fixes race conditions when multiple repository reprocess jobs are running simultaneously.

Closes #5023 as it replaces it
