### PR TITLE
Fix dead news link in side nav bar

### DIFF
--- a/app/views/layouts/_drawer.html.erb
+++ b/app/views/layouts/_drawer.html.erb
@@ -215,7 +215,7 @@
           <% end %>
         </li>
         <li>
-          <%= link_to "https://docs.dodona.be/#{I18n.locale}/news/",
+          <%= link_to "https://github.com/orgs/dodona-edu/discussions?discussions_q=category%3AAnnouncements+category%3A%22Release+notes%22",
                                     class: 'drawer-list-item',
                                     title: t('layout.menu.news') do %>
             <i class="mdi mdi-alert-decagram"></i>


### PR DESCRIPTION
This pull request fixes the dead URL to the news page in the side nav bar.
The news page has been moved to GitHub, but the old link was still pointing to docs.dodona.be/locale/news which no longer exists, resulting in a 404.