### PR TITLE
Set the color for active FABs

### DIFF
--- a/app/assets/stylesheets/components/btn.css.scss
+++ b/app/assets/stylesheets/components/btn.css.scss
@@ -195,6 +195,10 @@
   --d-btn-color: var(--d-secondary-container);
   --d-on-btn-color: var(--d-on-secondary-container);
 
+  // boostrap applies these variables, but they aren't set.
+  --bs-btn-active-bg: var(--d-btn-color);
+  --bs-btn-active-color: var(--d-on-btn-color);
+
   background: var(--d-btn-color);
   color: var(--d-on-btn-color);
 


### PR DESCRIPTION
This pull request fixes an issue there the bg color FABs wasn't set while clicking the button.

Bootstrap did apply styles in this case, but the variables that were applied weren't set. Apparently, they are only set for `btn-primary` and other colored variants and not for the native btn.

Closes #5053 
