### PR TITLE
Tweak the wording of the "select submission" during evaluations

### DIFF
--- a/app/views/feedbacks/show.html.erb
+++ b/app/views/feedbacks/show.html.erb
@@ -37,13 +37,13 @@
                 <% end %>
                 <% if @feedback.later_attempts + @feedback.previous_attempts > 0 %>
                   <%= link_to edit_feedback_path(@feedback) do %>
-                    <%= t("feedbacks.edit.short_title") %>
+                    <%= t("feedbacks.edit.select_another_submission") %>
                   <% end %>
                 <% end %>
               <% elsif @feedback.total_attempts > 0 %>
                 <%= t('.submission.total_attempts_html', count: @feedback.total_attempts) %>
                 <%= link_to edit_feedback_path(@feedback) do %>
-                  <%= t("feedbacks.edit.short_title") %>
+                  <%= t("feedbacks.edit.select_a_submission") %>
                 <% end %>
               <% end %>
               </p>

--- a/config/locales/views/feedbacks/en.yml
+++ b/config/locales/views/feedbacks/en.yml
@@ -54,6 +54,8 @@ en:
     edit:
       title: "Change submission of %{user} for %{exercise}"
       short_title: "Select another submission."
+      select_a_submission: "Do select a submission."
+      select_another_submission: "Select another submission."
     submissions_table:
       update-submission: "Change to this submission"
       confirm: "Are you sure? All comments on the previous submission will be deleted."

--- a/config/locales/views/feedbacks/nl.yml
+++ b/config/locales/views/feedbacks/nl.yml
@@ -54,6 +54,8 @@ nl:
     edit:
       title: "Oplossing van %{user} voor %{exercise} veranderen"
       short_title: "Selecteer een andere ingediende oplossing."
+      select_a_submission: "Selecteer toch een ingediende oplossing."
+      select_another_submission: "Selecteer een andere ingediende oplossing."
     submissions_table:
       update-submission: "Veranderen naar deze oplossing"
       confirm: "Ben je zeker? Alle opmerkingen op de vorige oplossing zullen verwijderd worden."


### PR DESCRIPTION
This pull request slightly tweaks the wording that is used to select another submission while evaluating. A different message is now used when no submission was selected in the first place.

Closes #4315. The other problem mentioned in that issue was already fixed in a previous PR.
