### PR TITLE
Use correct language for exercise names in exports

### DIFF
--- a/app/helpers/export_helper.rb
+++ b/app/helpers/export_helper.rb
@@ -22,6 +22,7 @@ module ExportHelper
       @list = kwargs[:list]
       @users = kwargs[:users]
       @for_user = kwargs[:for_user]
+      I18n.locale = @for_user&.lang # set locale to use correct exercise names
       case @item
       when Series
         @list = @item.exercises if all?


### PR DESCRIPTION
This pull request fixes a bug where Dutch exercises names were always used in exports.

During the creation of an export, the exercise name was fetched using `name`. This function uses the current locale to determine which language to use. Because exports are created async, the current locale wasn't set correctly.

This fix explicitly sets the locale when creating an export, based on the user that requested the export.

Closes #4780 
