### PR TITLE
Fix submission table overflow

### DIFF
--- a/app/assets/stylesheets/bootstrap_style_overrides.css.scss
+++ b/app/assets/stylesheets/bootstrap_style_overrides.css.scss
@@ -20,7 +20,7 @@ pre {
   font-size: 13px;
   line-height: 1.38461538;
   word-break: break-all;
-  word-wrap: break-word;
+  overflow-wrap: break-word;
   background-color: var(--d-code-bg);
   border: 1px solid var(--d-outline);
   border-radius: var(--d-border-radius-base);

--- a/app/assets/stylesheets/models/submissions.css.scss
+++ b/app/assets/stylesheets/models/submissions.css.scss
@@ -125,7 +125,7 @@
       text-decoration: none;
       padding-left: 5px;
       padding-right: 5px;
-      word-wrap: break-word;
+      overflow-wrap: anywhere;
       word-break: break-all;
       white-space: pre-wrap;
       font-family: var(--d-font-monospace);


### PR DESCRIPTION
This pull request fixes the submission table from overflowing when it contained long lines without spaces. This is done by setting `overflow-wrap` to `anywhere`.

Before:
![image](https://github.com/dodona-edu/dodona/assets/481872/6e26fc10-6ad8-4cd3-9fa5-73ae76e1f668)

After:
![image](https://github.com/dodona-edu/dodona/assets/481872/f6d0df82-ddac-4d63-836c-4f40244c4ffe)


Note: `overflow-wrap` is the official name for the old property called `word-wrap`.

Fixes #4355.
