### PR TITLE
Fix score table overflow

### DIFF
--- a/app/assets/stylesheets/models/score_items.css.scss
+++ b/app/assets/stylesheets/models/score_items.css.scss
@@ -6,7 +6,7 @@
 
 .score-items-table {
   td.description {
-    width: 400px;
+    max-width: 150px;
 
     p {
       margin: 0;


### PR DESCRIPTION
This pull request improves the overflow issues with the score table by limiting the description width. Although a max-width is set, the description column will still take up more space if it is available (which is what we want).

Note that this does not fully fix the problem on very narrow screens where even 150px is too much. 

Before:

![image](https://github.com/dodona-edu/dodona/assets/481872/692c8a4a-eb9f-4403-8b50-b99a2d37707f)

After:

![image](https://github.com/dodona-edu/dodona/assets/481872/9d529da0-1d76-48f3-be2b-bee60b6a87ce)

This problem was mentioned in (unrelated) issue #4355 .
