### PR TITLE
Fix assets not available in production

### DIFF
--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -22,4 +22,13 @@ namespace :deploy do
       end
     end
   end
+  before :publishing, :asset_stuff do
+    on roles :web do
+      within release_path do
+        with rails_env: fetch(:rails_env) do
+          execute :rake, 'assets:nodigest'
+        end
+      end
+    end
+  end
 end

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -64,6 +64,9 @@ Rails.application.configure do
   # Compress JavaScripts and CSS.
   config.assets.js_compressor = :terser
 
+  # Do not fallback to assets pipeline if a precompiled asset is missed.
+  config.assets.compile = false
+
   # Asset digests allow you to set far-future HTTP expiration dates on all assets,
   # yet still be able to expire them through the digest params.
   config.assets.digest = true

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -13,4 +13,4 @@ Rails.application.config.assets.paths << Rails.root.join('node_modules')
 # folder are already added.
 # Rails.application.config.assets.precompile += %w( admin.js admin.css )
 
-Rails.application.config.assets.nodigest = []
+Rails.application.config.assets.nodigest = ['*.nodigest.js']

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -13,4 +13,4 @@ Rails.application.config.assets.paths << Rails.root.join('node_modules')
 # folder are already added.
 # Rails.application.config.assets.precompile += %w( admin.js admin.css )
 
-Rails.application.config.assets.nodigest = ['*.nodigest.js']
+Rails.application.config.assets.nodigest = ['*.nodigest.js', '*.load_by_url']

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -13,4 +13,7 @@ Rails.application.config.assets.paths << Rails.root.join('node_modules')
 # folder are already added.
 # Rails.application.config.assets.precompile += %w( admin.js admin.css )
 
+# These files are fetched from within other js assets
+# so they do not support rails sprockets renaming them
+# We need to provide them as assets without digest
 Rails.application.config.assets.nodigest = ['*.nodigest.js', '*.load_by_url']

--- a/config/webpack/webpack.config.js
+++ b/config/webpack/webpack.config.js
@@ -42,7 +42,7 @@ const config = {
         filename: "[name].js",
         sourceMapFilename: "[name].js.map",
         path: path.resolve(__dirname, "..", "..", "app/assets/builds"),
-        chunkFilename: "[name].[chunkhash].js",
+        chunkFilename: "[name].[chunkhash].nodigest.js",
     },
     resolve: {
         modules: ["node_modules", "app/assets/javascripts"],

--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -3,9 +3,11 @@ namespace :assets do
   task nodigest: :environment do
     assets_path = File.join(Rails.root, 'public', Rails.configuration.assets.prefix)
     Rails.configuration.assets.nodigest.each do |asset|
-      source = File.join('app/assets/builds', asset)
-      dest = File.join(assets_path, asset)
-      FileUtils.copy_file(source, dest)
+      Dir.glob(File.join('app/assets/builds', asset)).each do |source_path|
+        file_name = File.basename(source_path)
+        dest_path = File.join(assets_path, file_name)
+        FileUtils.copy_file(source_path, dest_path)
+      end
     end
   end
 end

--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -3,7 +3,7 @@ namespace :assets do
   task nodigest: :environment do
     assets_path = File.join(Rails.root, 'public', Rails.configuration.assets.prefix)
     Rails.configuration.assets.nodigest.each do |asset|
-      source = File.join('app/assets/javascripts', asset)
+      source = File.join('app/assets/builds', asset)
       dest = File.join(assets_path, asset)
       FileUtils.copy_file(source, dest)
     end


### PR DESCRIPTION
This pull request fixes the fetching of undigested files. 

Since https://github.com/rails/sprockets-rails/issues/49#issuecomment-20535134 rails does not support this by default and requires a custom task or gem. We already had such a task, which I updated.

Step 1 was to reproduce the bug on naos.
The relevant setting was  `config.assets.compile = false`
It is not an option to set this to true in production: https://stackoverflow.com/questions/8821864/config-assets-compile-true-in-rails-production-why-not

Step 2 was to fix the precompilation step for these files.
To fix this on naos I executed the `assets:nodigest` on naos.
I updated this task, which was unused, to support glob variables and be rooted in the builds directory.

It is important to keep in mind that these files are not managed by sprockets, so we need to add the hash for cache bumping ourselves.
For this reason I updated the naming scheme in webpack and only copied the files that certainly received a hash by webpack.

- [x] tested on naos
