### PR TITLE
Blur potentially sensitive info while in anonymous mode

### DIFF
--- a/app/assets/stylesheets/components.css.scss
+++ b/app/assets/stylesheets/components.css.scss
@@ -126,3 +126,11 @@ blockquote {
   border-left: var(--d-divider) 3px solid;
   color: var(--d-on-surface-muted);
 }
+
+.blur {
+  filter: blur(5px);
+
+  &:hover {
+    filter: none;
+  }
+}

--- a/app/views/activities/_series_activities_table.html.erb
+++ b/app/views/activities/_series_activities_table.html.erb
@@ -52,7 +52,7 @@
         <td>
           <%= "#{index + 1}." if local_assigns[:series]&.activity_numbers_enabled? %>
           <% if activity.accessible?(current_user, @course) %>
-            <%= link_to activity.name, get_activity_path.call(activity) %>
+            <%= link_to activity.name, get_activity_path.call(activity), class: ('blur' if (local_assigns[:series].hidden? || local_assigns[:series].closed?) && Current.demo_mode) %>
           <% else %>
             <%= activity.name %>
             <% if current_user&.course_admin?(@course) && current_user&.repository_admin?(activity.repository) %>

--- a/app/views/pages/_user_card.html.erb
+++ b/app/views/pages/_user_card.html.erb
@@ -25,8 +25,8 @@
             <i class="mdi mdi-chevron-right"></i>
           <% end %>
           <span class='float-start'><%= activity_icon exercise %></span>
-          <%= link_to exercise.name, activity_path(exercise), class: "course-link", title: exercise.name %>
-          <%= link_to exercise.repository.name, repository_path(exercise.repository), class: "small text-muted course-link", title: exercise.repository.name %>
+          <%= link_to exercise.name, activity_path(exercise), class: "course-link #{'blur' if Current.demo_mode }", title: exercise.name %>
+          <%= link_to exercise.repository.name, repository_path(exercise.repository), class: "small text-muted course-link #{'blur' if Current.demo_mode }", title: exercise.repository.name %>
         </p>
       <% end %>
       <% if @draft_exercises.count > 5 %>

--- a/app/views/pages/_user_card.html.erb
+++ b/app/views/pages/_user_card.html.erb
@@ -72,12 +72,12 @@
           <% end %>
           <span class='float-start'><%= submission_status_icon(submission) %></span>
           <% if exercise.accessible?(current_user, submission.course) %>
-            <%= link_to exercise.name, activity_scoped_path(course: submission.course, activity: exercise), class: "course-link", title: exercise.name %>
+            <%= link_to exercise.name, activity_scoped_path(course: submission.course, activity: exercise), class: "course-link #{'blur' if Current.demo_mode }", title: exercise.name %>
           <% else %>
-            <span title="<%= exercise.name %>"><%= exercise.name %></span>
+            <span title="<%= exercise.name %>"  <%='class="blur"' if Current.demo_mode %>><%= exercise.name %></span>
           <% end %>
           <% unless submission.course.nil? %>
-            <%= link_to submission.course.name, course_path(submission.course), class: "small text-muted course-link", title: submission.course.name %>
+            <%= link_to submission.course.name, course_path(submission.course), class: "small text-muted course-link #{'blur' if Current.demo_mode }", title: submission.course.name %>
           <% end %>
         </p>
       <% end %>


### PR DESCRIPTION
This pull request blurs some exercise names while in anonymous mode to prevent sensitive information from leaking. Currently, the blur is applied to:
- recent exercises
- draft exercises
- exercises in hidden series on the course page

The blur is applied by adding a css class that adds a blur using a filter. When you hover over the element, the blur disapprears.

This feature was implemented after @pdawyndt voiced his concern that the name of exam/evaluation exercises might be leaked to students when using Dodona while projecting. The addition of draft exercises on the homepage worsens this concern.

You could argue that "jump back in" and recent exercises in courses should also be blurred, but then the homepage becomes hard to read. I think we now blur the most likely candidates.

Note that we keep struggling with finding an accurate name for demo mode/anonymous mode.

![image](https://github.com/dodona-edu/dodona/assets/481872/1b859672-2fb3-464c-8903-7bd9b47e97e7)
![image](https://github.com/dodona-edu/dodona/assets/481872/157167e8-96ee-4e3b-b3e8-972d7cf57185)

