### PR TITLE
Fix repo processing crash when labels contained an integer

### DIFF
--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -500,7 +500,7 @@ class Activity < ApplicationRecord
   def lowercase_labels(hash)
     return unless hash
 
-    hash['labels'] = hash['labels'].map(&:downcase).uniq if hash.key? 'labels'
+    hash['labels'] = hash['labels'].map(&:to_s).map(&:downcase).uniq if hash.key? 'labels'
     hash
   end
 


### PR DESCRIPTION
This pull request fixes an issue that crashed exercise repository processing when the labels contained an integer. All elements in labels are now first converted to a string before downcasing.

The error we received was

```
A NoMethodError occurred in repositories#reprocess:

  undefined method `downcase' for 1339:Integer

    hash['labels'] = hash['labels'].map(&:downcase).uniq if hash.key? 'labels'
                                   ^^^^
  app/models/activity.rb:503:in `map'
```

This issue was encountered by @bmoelans.
