### PR TITLE
Enable indents with tab in codemirror

### DIFF
--- a/app/assets/javascripts/editor.ts
+++ b/app/assets/javascripts/editor.ts
@@ -1,5 +1,5 @@
 import { closeBrackets, closeBracketsKeymap, autocompletion } from "@codemirror/autocomplete";
-import { defaultKeymap, history, historyKeymap } from "@codemirror/commands";
+import { defaultKeymap, history, historyKeymap, indentWithTab } from "@codemirror/commands";
 import {
     bracketMatching,
     foldGutter,
@@ -132,6 +132,7 @@ const editorSetup = (() => [
         ...defaultKeymap,
         ...historyKeymap,
         ...foldKeymap,
+        indentWithTab
     ]),
     syntaxHighlighting(rougeStyle, {
         fallback: true


### PR DESCRIPTION
This pull request enables indenting with tab in the codemirror editor. This was disabled [by default](https://codemirror.net/examples/tab/) for accessibility reasons, but since we enabled this in ACE, it makes sense to also enable it here.

Closes #5097 
