### PR TITLE
Add safety net for unresponsive docker containers

### DIFF
--- a/app/runners/submission_runner.rb
+++ b/app/runners/submission_runner.rb
@@ -186,6 +186,9 @@ class SubmissionRunner
         timeout = true if timeout.nil?
       end
     end
+    # errors raised in the thread should also be raised in the main thread
+    # This ensures they are reported and handled correctly
+    timer.abort_on_exception = true
 
     begin
       outlines, errlines = container.tap(&:start).attach(

--- a/app/runners/submission_runner.rb
+++ b/app/runners/submission_runner.rb
@@ -175,6 +175,7 @@ class SubmissionRunner
           # The docker container might be in a bad state
           # We just ignore this and try again later
           # The timeout will clean up the container if this lasts too long
+          Rails.logger.warn "Failed to get stats from docker container #{container.id} for submission #{@submission.id}"
         end
 
         # Gathering stats still takes a long time, so if we spent enough time on

--- a/config/initializers/delayed_job_config.rb
+++ b/config/initializers/delayed_job_config.rb
@@ -62,11 +62,3 @@ Rails.application.configure do
     end
   end
 end
-
-module NotifyOnFailedJob
-  def handle_failed_job(job, error)
-    super
-    ExceptionNotifier.notify_exception(error, data: { worker: `hostname`, queue: job.queue, payload: job.payload_object, last_error: job.last_error })
-  end
-end
-Delayed::Worker.prepend NotifyOnFailedJob

--- a/config/initializers/delayed_job_config.rb
+++ b/config/initializers/delayed_job_config.rb
@@ -62,3 +62,11 @@ Rails.application.configure do
     end
   end
 end
+
+module NotifyOnFailedJob
+  def handle_failed_job(job, error)
+    super
+    ExceptionNotifier.notify_exception(error, data: { worker: `hostname`, queue: job.queue, payload: job.payload_object, last_error: job.last_error })
+  end
+end
+Delayed::Worker.prepend NotifyOnFailedJob


### PR DESCRIPTION
This pull request adds a rescue block around checking the docker stats.

I am not 100% this is the root cause of the current issue, but it does seem likely.

Checking for stats has the potential to cause an error (eg a timeout if the container is non responsive). This results in rails crashing and never stopping the container.

I tried to be specific in the errors I catch to avoid ignoring other causes.


I also fixed the propagation of errors from within the timer thread. We already have a task that notifies us when errors occur in the submission runner, but this was not triggered by errors occurring within the thread.
See https://stackoverflow.com/a/9095369
