### PR TITLE
Revert "Add uniqueness validation to repository remote url"

### DIFF
--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -23,7 +23,7 @@ class Repository < ApplicationRecord
   MEDIA_DIR = 'media'.freeze
 
   validates :name, presence: true, uniqueness: { case_sensitive: false }
-  validates :remote, presence: true, uniqueness: { case_sensitive: false }
+  validates :remote, presence: true
 
   validate :repo_is_accessible, on: :create
 

--- a/db/migrate/20231107160330_add_unique_to_repository_remote.rb
+++ b/db/migrate/20231107160330_add_unique_to_repository_remote.rb
@@ -1,5 +1,0 @@
-class AddUniqueToRepositoryRemote < ActiveRecord::Migration[7.1]
-  def change
-    add_index :repositories, :remote, unique: true
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_11_07_160330) do
+ActiveRecord::Schema[7.1].define(version: 2023_10_26_075353) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -396,7 +396,6 @@ ActiveRecord::Schema[7.1].define(version: 2023_11_07_160330) do
     t.index ["judge_id"], name: "index_repositories_on_judge_id"
     t.index ["name"], name: "index_repositories_on_name", unique: true
     t.index ["path"], name: "index_repositories_on_path", unique: true
-    t.index ["remote"], name: "index_repositories_on_remote", unique: true
   end
 
   create_table "repository_admins", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -276,9 +276,6 @@ if Rails.env.development?
   puts activity_repo.errors.full_messages unless activity_repo.valid?
   activity_repo.process_activities
 
-  # remote must be unique for the repository, and we want to clone it again
-  activity_repo.update!(remote: '-')
-
   big_activity_repo = Repository.create name: 'A lot of python activities', remote: 'git@github.com:dodona-edu/example-exercises.git', judge: python_judge, allowed_courses: courses
   Delayed::Worker.delay_jobs = true
   Dir.glob("#{big_activity_repo.full_path}/*")

--- a/test/controllers/repositories_controller_test.rb
+++ b/test/controllers/repositories_controller_test.rb
@@ -200,8 +200,6 @@ class RepositoryGitControllerTest < ActionDispatch::IntegrationTest
     @remote.update_json('echo/config.json', 'make echo private') do |config|
       config.update 'access' => 'private'
     end
-
-    @second_remote = local_remote('exercises/lasagna')
   end
 
   def find_echo
@@ -224,16 +222,16 @@ class RepositoryGitControllerTest < ActionDispatch::IntegrationTest
     user = users(:staff)
     judge = create :judge, :git_stubbed
     sign_in user
-    post repositories_path, params: { repository: { name: 'test', remote: @second_remote.path, judge_id: judge.id } }
+    post repositories_path, params: { repository: { name: 'test', remote: @remote.path, judge_id: judge.id } }
   end
 
   test 'should email during repository creation' do
     user = users(:staff)
     judge = create :judge, :git_stubbed
     sign_in user
-    @second_remote.update_file('exercises/extra/echo/config.json', 'break config') { '(╯°□°)╯︵ ┻━┻' }
+    @remote.update_file('echo/config.json', 'break config') { '(╯°□°)╯︵ ┻━┻' }
     assert_difference 'ActionMailer::Base.deliveries.size', +1 do
-      post repositories_path, params: { repository: { name: 'test', remote: @second_remote.path, judge_id: judge.id } }
+      post repositories_path, params: { repository: { name: 'test', remote: @remote.path, judge_id: judge.id } }
     end
   end
 


### PR DESCRIPTION
Reverts dodona-edu/dodona#5118

I will revert this for now because:
- it is broken on naos as some non unique values still exist
- it will still be broken on production as well as the non unique values noticed on naos are different from those fixed on production. These need to be verified and fixed in production first
- deploying the backup to naos is also broken, which should be fixed bfore this can be fixed properly
- Reverting this allows more important fixes to be roaaled out first (Ufora bug seems more urgent than this)