### PR TITLE
Never remove exercises that are part of an evaluation

### DIFF
--- a/app/jobs/remove_activities_job.rb
+++ b/app/jobs/remove_activities_job.rb
@@ -2,6 +2,7 @@ class RemoveActivitiesJob < ApplicationJob
   # permanently remove activities that match all of the following criteria:
   # - status is 'removed'
   # - updated_at is more than 1 month ago
+  # - not part of an evaluation
   # - one of the following is true:
   #   - draft is true (never published)
   #   - series_memberships is empty and less then 25 submissions and latest submission is more than 1 month ago
@@ -27,6 +28,8 @@ class RemoveActivitiesJob < ApplicationJob
         next if activity.submissions.count >= 25
         next if activity.submissions.present? && activity.submissions.reorder(:created_at).last.created_at > 1.month.ago
       end
+
+      next if EvaluationExercise.exists?(exercise_id: activity.id)
 
       # destroy submissions first explicitly, as they are dependent: :restrict_with_error
       activity.submissions.destroy_all

--- a/test/jobs/remove_activities_job_test.rb
+++ b/test/jobs/remove_activities_job_test.rb
@@ -102,4 +102,13 @@ class RemoveActivitiesJobTest < ActiveJob::TestCase
       RemoveActivitiesJob.perform_now
     end
   end
+
+  test 'should not remove activities that are part of an evaluation' do
+    e = create :exercise, status: :removed, draft: false, updated_at: 2.months.ago
+    create :evaluation_exercise, exercise: e
+
+    assert_no_difference 'Exercise.count' do
+      RemoveActivitiesJob.perform_now
+    end
+  end
 end


### PR DESCRIPTION
This pull request fixes the remove activity job to not consider exercises that are part of an evaluation

- [x] Tests were added
