### PR TITLE
Improve webpack build time

### DIFF
--- a/config/webpack/webpack.config.js
+++ b/config/webpack/webpack.config.js
@@ -22,7 +22,15 @@ const config = {
                     return modulePath.endsWith('.ts') && !modulePath.endsWith('test.ts');
                 },
                 exclude: /node_modules/,
-                use: ["babel-loader", "ts-loader"],
+                use: [
+                    "babel-loader",
+                    {
+                        loader: 'ts-loader',
+                        options: {
+                            transpileOnly: true,
+                        },
+                    }
+                ],
             },
         ],
     },
@@ -62,7 +70,7 @@ if (process.env.NODE_ENV === "development") {
     config.devtool = "inline-source-map";
 }
 
-// disable terser minimization when running tests
+// disable terser minimization when running
 if (process.env.RAILS_ENV === "test") {
     config.optimization.minimize = false;
 }

--- a/config/webpack/webpack.config.js
+++ b/config/webpack/webpack.config.js
@@ -62,6 +62,11 @@ if (process.env.NODE_ENV === "development") {
     config.devtool = "inline-source-map";
 }
 
+// disable terser minimization when running tests
+if (process.env.RAILS_ENV === "test") {
+    config.optimization.minimize = false;
+}
+
 // Test, Staging and Production use default config
 
 module.exports = config;


### PR DESCRIPTION
This pull request tweaks the webpack config to improve the build time. This will speed up the github actions.

There are 2 changes:
- Don't minimize the code (using terser) when building for tests
- Don't typecheck when building the code, this is checked in the linting action

Build times on my macbook:
| Version | Time in s |
|--------|--------:|
| Original version | 34.06 |
| Don't minimize while testing | 16.56 |
| Don't typecheck | 12.29 | 