### PR TITLE
Blur class progress in anonymous mode

### DIFF
--- a/app/assets/stylesheets/components.css.scss
+++ b/app/assets/stylesheets/components.css.scss
@@ -127,10 +127,10 @@ blockquote {
   color: var(--d-on-surface-muted);
 }
 
-.blur {
+.blur:not(:hover) {
   filter: blur(5px);
 
-  &:hover {
-    filter: none;
+  .progress-chart line {
+    stroke: var(--d-divider);
   }
 }

--- a/app/views/activities/_series_activities_table.html.erb
+++ b/app/views/activities/_series_activities_table.html.erb
@@ -69,7 +69,7 @@
         </td>
 
         <% if @course.blank? || policy(local_assigns[:series]).show_progress? %>
-          <td class="d-none d-sm-table-cell">
+          <td class="d-none d-sm-table-cell <%= 'blur' if (local_assigns[:series].hidden? || local_assigns[:series].closed?) && Current.demo_mode %>">
             <% if activity.exercise? %>
               <% if @course %>
                 <%= render partial: 'application/progress_chart',

--- a/app/views/activities/_series_activities_table.html.erb
+++ b/app/views/activities/_series_activities_table.html.erb
@@ -69,7 +69,7 @@
         </td>
 
         <% if @course.blank? || policy(local_assigns[:series]).show_progress? %>
-          <td class="d-none d-sm-table-cell <%= 'blur' if (local_assigns[:series].hidden? || local_assigns[:series].closed?) && Current.demo_mode %>">
+          <td class="d-none d-sm-table-cell <%= 'blur' if (!local_assigns[:series].progress_enabled || local_assigns[:series].hidden? || local_assigns[:series].closed?) && Current.demo_mode %>">
             <% if activity.exercise? %>
               <% if @course %>
                 <%= render partial: 'application/progress_chart',


### PR DESCRIPTION
This pull request adds a blur in anonymous mode to the class progress of hidden/closed series and series where the progress is hidden for students.

Simply blurring wasn't enough (the bar length was still visible), so I also set the color of the different pieces to neutral color.

I simplified the css by using `:not` which is supported by our supported browsers: https://caniuse.com/css-not-sel-list

![image](https://github.com/dodona-edu/dodona/assets/481872/4a372ee5-c254-4f4c-9dfd-74f436558aa1)

Closes #5117.
