### PR TITLE
Don't send emails for slow requests and internal errors

### DIFF
--- a/app/exceptions/internal_error_exception.rb
+++ b/app/exceptions/internal_error_exception.rb
@@ -1,0 +1,2 @@
+class InternalErrorException < Exception
+end

--- a/app/exceptions/internal_error_exception.rb
+++ b/app/exceptions/internal_error_exception.rb
@@ -1,2 +1,2 @@
-class InternalErrorException < Exception
+class InternalErrorException < StandardError
 end

--- a/app/exceptions/slow_request_exception.rb
+++ b/app/exceptions/slow_request_exception.rb
@@ -1,2 +1,2 @@
-class SlowRequestException < Exception
+class SlowRequestException < StandardError
 end

--- a/app/exceptions/slow_request_exception.rb
+++ b/app/exceptions/slow_request_exception.rb
@@ -1,0 +1,2 @@
+class SlowRequestException < Exception
+end

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -523,7 +523,7 @@ class Submission < ApplicationRecord
 
     ExceptionNotifier.notify_exception(
       InternalErrorException.new("Submission(#{id}) status was changed to internal error"),
-      env: self,
+      env: self, # this is a hack to get callbacks to run, see https://github.com/smartinez87/exception_notification/issues/518
       data: {
         host: `hostname`,
         judge: judge.name,

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -523,6 +523,7 @@ class Submission < ApplicationRecord
 
     ExceptionNotifier.notify_exception(
       InternalErrorException.new("Submission(#{id}) status was changed to internal error"),
+      env: self,
       data: {
         host: `hostname`,
         judge: judge.name,

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -522,7 +522,7 @@ class Submission < ApplicationRecord
     return unless status_changed? && send(:'internal error?')
 
     ExceptionNotifier.notify_exception(
-      Exception.new("Submission(#{id}) status was changed to internal error"),
+      InternalErrorException.new("Submission(#{id}) status was changed to internal error"),
       data: {
         host: `hostname`,
         judge: judge.name,

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -124,6 +124,12 @@ Rails.application.configure do
   # Exception notifications
   config.middleware.use ExceptionNotification::Rack,
                         ignore_if: ->(env, _exception) { env['HTTP_HOST'] == 'localhost:3000' || env['HTTP_HOST'] == 'dodona.localhost:3000' },
+                        ignore_notifier_if: {
+                          email: lambda { |env, exception|
+                            exception.is_a?(InternalErrorException) ||
+                              exception.is_a?(SlowRequestException)
+                          }
+                        },
                         email: {
                           email_prefix: '[Dodona-dev] ',
                           sender_address: %("Dodona" <dodona@ugent.be>),

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -135,6 +135,12 @@ Rails.application.configure do
                             env['action_controller.instance'].action_name == 'create_contact' &&
                             exception.is_a?(ActionController::InvalidAuthenticityToken)
                         },
+                        ignore_notifier_if: {
+                          email: lambda { |env, exception|
+                            exception.is_a?(InternalErrorException) ||
+                              exception.is_a?(SlowRequestException)
+                          }
+                        },
                         email: {
                             email_prefix: '[Dodona] ',
                             sender_address: %("Dodona" <dodona@ugent.be>),

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -85,6 +85,12 @@ Rails.application.configure do
 
   config.middleware.use ExceptionNotification::Rack,
                         ignore_if: ->(env, _exception) {env['HTTP_HOST'] == 'localhost:3000'},
+                        ignore_notifier_if: {
+                          email: lambda { |env, exception|
+                            exception.is_a?(InternalErrorException) ||
+                              exception.is_a?(SlowRequestException)
+                          }
+                        },
                         email: {
                             email_prefix: '[Dodona-dev] ',
                             sender_address: %("Dodona" <dodona@ugent.be>),

--- a/config/initializers/exception_notification.rb
+++ b/config/initializers/exception_notification.rb
@@ -10,7 +10,7 @@ ActiveSupport::Notifications.subscribe 'process_action.action_controller' do |_n
 
   headers = payload.delete :headers
   ExceptionNotifier.notify_exception(
-    Exception.new("A request took #{finish - start} seconds"),
+    SlowRequestException.new("A request took #{finish - start} seconds"),
     env: headers.env,
     data: payload
   )


### PR DESCRIPTION
This pull request stops emails being sent for internal errors and slow requests. Slack messages should still be generated.


Closes #5130