### PR TITLE
Make ctrl-f more usable on submissions

### DIFF
--- a/app/assets/javascripts/components/annotations/line_of_code.ts
+++ b/app/assets/javascripts/components/annotations/line_of_code.ts
@@ -156,12 +156,14 @@ export class LineOfCode extends ShadowlessLitElement {
 
         for (const range of this.ranges) {
             const substring = this.code.substring(range.start, range.start + range.length);
+            // replace every non-whitespace character with a non-breaking space
+            const nonSearchableSubstring = substring.replace(/\S/g, "\u00a0");
             if (!range.annotations.length) {
-                backgroundLayer.push(substring);
-                tooltipLayer.push(substring);
+                backgroundLayer.push(nonSearchableSubstring);
+                tooltipLayer.push(nonSearchableSubstring);
             } else {
-                backgroundLayer.push(html`<d-annotation-marker .annotations=${range.annotations}>${substring}</d-annotation-marker>`);
-                tooltipLayer.push(html`<d-annotation-tooltip .annotations=${range.annotations}>${substring}</d-annotation-tooltip>`);
+                backgroundLayer.push(html`<d-annotation-marker .annotations=${range.annotations}>${nonSearchableSubstring}</d-annotation-marker>`);
+                tooltipLayer.push(html`<d-annotation-tooltip .annotations=${range.annotations}>${nonSearchableSubstring}</d-annotation-tooltip>`);
             }
         }
 


### PR DESCRIPTION
This pull request improves browser search (ctrl-f) features on submission pages.

The issue was that search matched each code element three times as it is repeated in each layer.
This issue was reported by Steven, who made the case for the search feature when trying to understand a students code while grading.

A side effect: copying code will only copy spaces while our custom hack isn't working. This will happen more often with https://github.com/dodona-edu/dodona/pull/5157 so accepting this pr will require changes there.

I do not see any other options for fixing this aside of reverting the whole three layered approach for annotations.
But I am open for suggestions.

