### PR TITLE
Allow submitting the annotation form using Ctrl-Enter as well

### DIFF
--- a/app/assets/javascripts/components/annotations/annotation_form.ts
+++ b/app/assets/javascripts/components/annotations/annotation_form.ts
@@ -188,8 +188,8 @@ export class AnnotationForm extends watchMixin(ShadowlessLitElement) {
     }
 
     handleKeyDown(e: KeyboardEvent): boolean {
-        if (e.code === "Enter" && e.shiftKey) {
-            // Send using Shift-Enter.
+        if (e.code === "Enter" && (e.shiftKey || e.ctrlKey)) {
+            // Send using Shift-Enter or Ctrl-Enter.
             e.preventDefault();
             this.handleSubmit();
             return false;


### PR DESCRIPTION
As discussed during lunch, adding this as an undocumented feature to help people who have this shortcut as muscle memory (which includes yours truly).