### PR TITLE
Fix input field layout for annotation form

### DIFF
--- a/app/assets/javascripts/components/annotations/annotation_form.ts
+++ b/app/assets/javascripts/components/annotations/annotation_form.ts
@@ -280,7 +280,7 @@ export class AnnotationForm extends watchMixin(ShadowlessLitElement) {
                     ` : ""}
                 </div>
                 <div class="row mb-1">
-                    <div class="col-lg-7 col-xxl-8 align-items-center d-inline-flex">
+                    <div class="col-xxl-8 align-items-center d-inline-flex">
                         ${ this.canSaveAnnotation && this._savedAnnotationId == "" ? html`
                             <div class="field form-group mb-0">
                                 <div class="form-check save-annotation-check">
@@ -312,7 +312,7 @@ export class AnnotationForm extends watchMixin(ShadowlessLitElement) {
                             </div>
                         ` : ""}
                     </div>
-                    <div class="col-lg-5 col-xxl-4 mt-2 mt-lg-0" style="text-align: right">
+                    <div class="col-xxl-4 mt-2 mt-xxl-0" style="text-align: right">
                         <button class="btn btn-text"
                                 type="button"
                                 @click="${() => this.handleCancel()}"


### PR DESCRIPTION
This pull request improves the layout positioning of the annotation title input field.

The jump from this layout:
![image](https://github.com/dodona-edu/dodona/assets/21177904/79fa258b-608d-4ff2-acd3-4620d4763cf7)
To this layout:
![image](https://github.com/dodona-edu/dodona/assets/21177904/486581f7-6955-47cf-8533-cb1ca0f8ca06)
Is now made sooner.

This is required because there is less width available on evaluation feedback pages.



Closes #5153
