### PR TITLE
Don't show saved annotations from other users to zeus

### DIFF
--- a/app/policies/saved_annotation_policy.rb
+++ b/app/policies/saved_annotation_policy.rb
@@ -1,9 +1,7 @@
 class SavedAnnotationPolicy < ApplicationPolicy
   class Scope < ApplicationPolicy::Scope
     def resolve
-      if user&.zeus?
-        scope.all
-      elsif user&.a_course_admin?
+      if user&.zeus? || user&.a_course_admin?
         scope.where(user_id: user.id)
       else
         scope.none

--- a/test/controllers/saved_annotation_controller_test.rb
+++ b/test/controllers/saved_annotation_controller_test.rb
@@ -31,4 +31,22 @@ class SavedAnnotationControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
   end
+
+  test 'zeus should not have access to saved annotations of other users' do
+    sign_in users(:staff)
+    get saved_annotations_url, params: { format: :json }
+
+    assert_response :success
+    assert_equal 1, response.parsed_body.length
+
+    sign_in users(:zeus)
+    get saved_annotations_url, params: { format: :json }
+
+    assert_response :success
+    assert_equal 0, response.parsed_body.length
+
+    get saved_annotation_url(@instance), params: { format: :json }
+
+    assert_response :forbidden
+  end
 end


### PR DESCRIPTION
This pull request removes saved annotations from the results zeus users receive.
This gives zeus users the intended user experience. In case of detecting bugs in this feature they should use impersonate.

- [x] Tests were added

Closes #5166
