### PR TITLE
Add year to course name in saved annotations filter

### DIFF
--- a/app/views/layouts/_searchbar.html.erb
+++ b/app/views/layouts/_searchbar.html.erb
@@ -161,7 +161,7 @@
                 return course.id.toString();
             },
             multi: false,
-            data: <%= raw local_assigns.fetch(:courses, []).map{|course| {id: course.id, name: course.name}}.to_json %>,
+            data: <%= raw local_assigns.fetch(:courses, []).map{|course| {id: course.id, name: "#{course.name} (#{course.year})"}}.to_json %>,
             color: function () {
                 return "orange";
             }

--- a/app/views/layouts/_searchbar.html.erb
+++ b/app/views/layouts/_searchbar.html.erb
@@ -161,7 +161,7 @@
                 return course.id.toString();
             },
             multi: false,
-            data: <%= raw local_assigns.fetch(:courses, []).map{|course| {id: course.id, name: "#{course.name} (#{course.year})"}}.to_json %>,
+            data: <%= raw local_assigns.fetch(:courses, []).map{|course| {id: course.id, name: "#{course.name} (#{course.formatted_year})"}}.to_json %>,
             color: function () {
                 return "orange";
             }


### PR DESCRIPTION
This pull request add the year of a course to the filter by course field.
![image](https://github.com/dodona-edu/dodona/assets/21177904/128ebb23-ac8c-4e63-83c7-a77585f3aab9)

Closes #5062
