### PR TITLE
Fix line of code not shown on invalid judge output

### DIFF
--- a/app/assets/javascripts/components/annotations/line_of_code.ts
+++ b/app/assets/javascripts/components/annotations/line_of_code.ts
@@ -107,7 +107,7 @@ export class LineOfCode extends ShadowlessLitElement {
     mergeRanges(ranges: { start: number, length: number, index: number }[]): { start: number, length: number, indexes: number[] }[] {
         const annotationsByPosition: number[][] = new Array(this.codeLength).fill(null).map(() => []);
         for (const range of ranges) {
-            for (let i = range.start; i < range.start + range.length; i++) {
+            for (let i = range.start; i < range.start + range.length && i < this.codeLength; i++) {
                 annotationsByPosition[i].push(range.index);
             }
         }


### PR DESCRIPTION
This pull request fixes a line of code not being shown when the judge returns out of bounds column indexes.

Eg of submission with the issue: https://dodona.be/nl/submissions/16080236/#code
Here the second line is hidden.
![image](https://github.com/dodona-edu/dodona/assets/21177904/14d1b961-4726-422a-a63a-55b0a6332ecf)


The issue is not reproducible as the judge has already been fixed, but from the error message I discovered the issue.

Although this was caused by the judge returning to many columns, we should deal with such case more gracefully. With the new fix, a column number out of bounds will be treated as marking the whole line.
