### PR TITLE
Always print judge output when encountering a ResultConstructorError

### DIFF
--- a/app/runners/submission_runner.rb
+++ b/app/runners/submission_runner.rb
@@ -256,6 +256,7 @@ class SubmissionRunner
       else
         messages = [build_message(e.title, 'staff', 'plain')]
         messages << build_message(e.description, 'staff') unless e.description.nil?
+        messages << build_message(stdout.force_encoding('utf-8'), 'staff', 'plain')
         build_error 'internal error', 'internal error', messages
       end
     end


### PR DESCRIPTION
This came in handy when trying to investigate a judge issue, and would be nice when encountering these issues in production as well.
