### PR TITLE
Unregister old serviceworkers manualy

### DIFF
--- a/app/assets/javascripts/coding_scratchpad.ts
+++ b/app/assets/javascripts/coding_scratchpad.ts
@@ -28,6 +28,15 @@ function initCodingScratchpad(programmingLanguage: ProgrammingLanguage): void {
         showButton.classList.remove("hidden");
         showButton.addEventListener("click", async function () {
             if (!papyros) { // Only create Papyros once per session, but only when required
+                // Papyros registers a service worker on a specific path
+                // We used to do this on a different path
+                // So we need to unregister old serviceworkers manually as these won't get overwritten
+                navigator.serviceWorker.getRegistrations().then(function (registrations) {
+                    for (const registration of registrations) {
+                        registration.unregister();
+                    }
+                });
+
                 papyros = new Papyros(
                     {
                         programmingLanguage: Papyros.toProgrammingLanguage(programmingLanguage),

--- a/app/assets/javascripts/coding_scratchpad.ts
+++ b/app/assets/javascripts/coding_scratchpad.ts
@@ -33,7 +33,9 @@ function initCodingScratchpad(programmingLanguage: ProgrammingLanguage): void {
                 // So we need to unregister old serviceworkers manually as these won't get overwritten
                 navigator.serviceWorker.getRegistrations().then(function (registrations) {
                     for (const registration of registrations) {
-                        registration.unregister();
+                        if (registration.scope !== document.location.origin + "/") {
+                            registration.unregister();
+                        }
                     }
                 });
 


### PR DESCRIPTION
This pull request fixes the old serviceworkers on scoped paths still existing after the update. This sometimes interferes with the new version (particularly in firefox).


