### PR TITLE
Adjust Dutch translation for concept alert

### DIFF
--- a/config/locales/views/activities/nl.yml
+++ b/config/locales/views/activities/nl.yml
@@ -101,8 +101,8 @@ nl:
       preloaded_info: We hebben jouw laatste oplossing ingeladen in de editor.
       preloaded_clear: Maak de editor leeg.
       preloaded_restore: Zet de voorbeeldcode terug.
-      alert_draft_html: Deze oefening is nog een <a href="https://docs.dodona.be/nl/faq/activities/#wat-is-een-conceptactiviteit" target="_blank">concept</a>. Ze is niet zichtbaar voor studenten.
-      alert_draft_edit: Deze oefening publiceren.
+      alert_draft_html: Deze activiteit is nog een <a href="https://docs.dodona.be/nl/faq/activities/#wat-is-een-conceptactiviteit" target="_blank">concept</a>. Ze is niet zichtbaar voor studenten.
+      alert_draft_edit: Deze activiteit publiceren.
     series_activities_add_table:
       course_added_to_usable: "Deze oefening toevoegen zal deze cursus toegang geven tot alle privé oefeningen in de repository van deze oefening. Ben je zeker?"
     edit:


### PR DESCRIPTION
This pull request adjusts to the English translation for concept alerts.

Before:
![image](https://github.com/dodona-edu/dodona/assets/56451049/6643b240-0403-4bee-a06b-f96a5f86e36e)

![image](https://github.com/dodona-edu/dodona/assets/56451049/2b3cffc8-8b58-4c53-9beb-cdca4004ec78)

After:
![image](https://github.com/dodona-edu/dodona/assets/56451049/2c483769-72b8-4b11-8a7d-3e2798127dd1)
