### PR TITLE
Fix broken pythia submission if data is not present in group

### DIFF
--- a/app/helpers/renderers/pythia_renderer.rb
+++ b/app/helpers/renderers/pythia_renderer.rb
@@ -7,11 +7,11 @@ class PythiaRenderer < FeedbackTableRenderer
   def show_code_tab
     return true unless @result[:groups]
 
-    @result[:groups].none? { |t| t[:data][:source_annotations] }
+    @result[:groups].none? { |t| t[:data] && t[:data][:source_annotations] }
   end
 
   def tab_content(t, i)
-    if t[:data][:source_annotations]
+    if t[:data] && t[:data][:source_annotations]
       linting(t[:data][:source_annotations], @code)
     else
       super
@@ -19,7 +19,7 @@ class PythiaRenderer < FeedbackTableRenderer
   end
 
   def diff(t)
-    if t[:data][:diff]
+    if t[:data] && t[:data][:diff]
       pythia_diff(t[:data][:diff])
     else
       super
@@ -27,7 +27,7 @@ class PythiaRenderer < FeedbackTableRenderer
   end
 
   def test_accepted(t)
-    if t[:data][:diff]
+    if t[:data] && t[:data][:diff]
       @builder.div(class: 'test-accepted') do
         @builder.span(class: 'output') do
           html = t[:data][:diff].map do |l|
@@ -227,7 +227,7 @@ class PythiaRenderer < FeedbackTableRenderer
   end
 
   def determine_diff_type(test)
-    if test[:data][:diff]
+    if test[:data] && test[:data][:diff]
       test[:data][:diff].each do |diff_line|
         # Not perfect, since there might be html in the diff_line items
         return 'unified' if !diff_line[2].nil? && strip_outer_html(diff_line[2]).length >= 55

--- a/test/controllers/submissions_controller_test.rb
+++ b/test/controllers/submissions_controller_test.rb
@@ -436,4 +436,28 @@ class SubmissionsControllerTest < ActionDispatch::IntegrationTest
     assert_equal least_recent.id, response.parsed_body.first['id']
     assert_equal most_recent.id, response.parsed_body.second['id']
   end
+
+  test 'rendering pythia submission should not crash' do
+    stub_git(Judge.any_instance)
+    judge = create :judge, name: 'pythia', renderer: PythiaRenderer
+    exercise = create :exercise, judge: judge
+    submission = create :submission, :wrong, exercise: exercise
+    submission.result = '{
+      "accepted": false,
+      "status": "wrong",
+      "description": "Onverwachte uitvoer",
+      "annotations": [],
+      "groups": [
+        {
+          "description": "maximum",
+          "badgeCount": 6,
+          "groups": []
+        }
+      ],
+      "messages": []
+    }'
+    get submission_path(submission)
+
+    assert_response :ok
+  end
 end


### PR DESCRIPTION
This pull request fixes a dodona crash when it tries to render this submission: https://dodona.be/nl/submissions/14904216.json

The cause was `data` not being present in the group.

- [x] Tests were added
