### PR TITLE
Extend allowed attributes (svg)

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -149,7 +149,7 @@ module ApplicationHelper
               %w[svg g style circle line rect path polygon text]
     @attributes ||= Rails::Html::SafeListSanitizer.allowed_attributes.to_a +
                     %w[style target data-bs-toggle data-parent data-tab data-line data-element id] +
-                    %w[viewBox width height version style class transform id x y rx ry x1 y1 x2 y2 d points fill stroke stroke-width cx cy r font-size font-family font-weight font-variant]
+                    %w[viewBox width height version style class transform id x y rx ry x1 y1 x2 y2 d points fill stroke stroke-width stroke-dasharray cx cy r font-size font-family font-weight font-variant textLength writing-mode glyph-orientation-vertical text-orientation]
 
     # Filters allowed tags and attributes
     sanitized = ActionController::Base.helpers.sanitize html,

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -104,7 +104,9 @@ class ApplicationHelperTest < ActiveSupport::TestCase
     dirty_html = <<~HTML
       <svg viewBox="0 0 100 100" width="300" height="100" version="1.1">
         <style>line,circle{stroke-width:3px;stroke:black;stroke-linecap:round}</style>
-        <style>test{stroke-width:3px;stroke:black;stroke-linecap:round}</style>
+        <style>test{stroke-width:3px;stroke:black;stroke-dasharray:1;stroke-linecap:round}</style>
+        <style>text.vertical{writing-mode:tb;glyph-orientation-vertical:0;fill:grey;}</style>
+        <style>text.vertical{writing-mode:vertical-rl;text-orientation:upright;}</style>
         <g id="group1" transform="translate(50,50)">
           <circle cx="0" cy="0" r="40" fill="none"></circle>
           <line class="test" x1="0" y1="0" x2="0" y2="-40"></line>
@@ -113,6 +115,7 @@ class ApplicationHelperTest < ActiveSupport::TestCase
         <polygon points="0,0 100,0 100,100 0,100"></polygon>
         <path d="M0,0 L100,0 L100,100 L0,100 Z"></path>
         <text x="0" y="0" font-size="14px" font-weight="bold" font-variant="normal" font-family="serif">Hello</text>
+        <text x="0" y="0" textLength="10">abcdefgh</text>
       </svg>
     HTML
     clean_html = sanitize dirty_html


### PR DESCRIPTION
This pull request adds additional SVG attributes:

`writing-mode` `glyph-orientation-vertical` `text-orientation` `stroke-dasharray` `textLength `

- [x] Tests were added