### PR TITLE
Disable selection of line numbers in submission result

### DIFF
--- a/app/assets/stylesheets/models/submissions.css.scss
+++ b/app/assets/stylesheets/models/submissions.css.scss
@@ -199,6 +199,7 @@
     td.line-nr {
       text-align: right;
       white-space: pre-wrap;
+      user-select: none;
     }
 
     th {

--- a/app/controllers/feedbacks_controller.rb
+++ b/app/controllers/feedbacks_controller.rb
@@ -75,15 +75,7 @@ class FeedbacksController < ApplicationController
       if updated
         format.html { redirect_to evaluation_feedback_path(@feedback.evaluation, @feedback) }
         format.json { render :show, status: :ok, location: @feedback }
-        format.js do
-          @user_labels = @feedback.evaluation
-                                  .series
-                                  .course
-                                  .course_memberships
-                                  .find_by(user_id: @feedback.user)
-                                  .course_labels
-          render :show
-        end
+        format.js { render :show }
       else
         format.json { render json: @feedback.errors, status: :unprocessable_entity }
         format.js { render :show, status: :unprocessable_entity }

--- a/app/controllers/feedbacks_controller.rb
+++ b/app/controllers/feedbacks_controller.rb
@@ -75,7 +75,15 @@ class FeedbacksController < ApplicationController
       if updated
         format.html { redirect_to evaluation_feedback_path(@feedback.evaluation, @feedback) }
         format.json { render :show, status: :ok, location: @feedback }
-        format.js { render :show }
+        format.js do
+          @user_labels = @feedback.evaluation
+                                  .series
+                                  .course
+                                  .course_memberships
+                                  .find_by(user_id: @feedback.user)
+                                  .course_labels
+          render :show
+        end
       else
         format.json { render json: @feedback.errors, status: :unprocessable_entity }
         format.js { render :show, status: :unprocessable_entity }


### PR DESCRIPTION
This pull request disables the selection of line numbers. These numbers are almost never expected in the result.

![image](https://github.com/dodona-edu/dodona/assets/21177904/16583220-506c-4066-b71a-a5a472e4cfde)

The behavior would be improved even more if selection happened column by column. But that would require another html structure, which would remove the vertical alignment of lines that happens in this example:
![image](https://github.com/dodona-edu/dodona/assets/21177904/11f8e13c-e0fb-4bdb-aa58-7225c80f7472)



Closes #5224
