### PR TITLE
Translate exercise names in search results

### DIFF
--- a/app/assets/javascripts/state/SavedAnnotations.ts
+++ b/app/assets/javascripts/state/SavedAnnotations.ts
@@ -34,6 +34,10 @@ class SavedAnnotationState extends State {
     @stateProperty private paginationByURL = new StateMap<string, Pagination>();
     @stateProperty private byId = new StateMap<number, SavedAnnotation>();
 
+    private get url(): string {
+        return `/${I18n.locale}${URL}`;
+    }
+
     private async fetchList(url: string): Promise<Array<SavedAnnotation>> {
         const response = await fetch(url);
         this.listByURL.set(url, await response.json());
@@ -42,14 +46,14 @@ class SavedAnnotationState extends State {
     }
 
     private async fetch(id: number): Promise<SavedAnnotation> {
-        const url = `${URL}/${id}.json`;
+        const url = `${this.url}/${id}.json`;
         const response = await fetch(url);
         this.byId.set(id, await response.json());
         return this.byId.get(id);
     }
 
     async create(data: { from: number, saved_annotation: { title: string, annotation_text: string } }): Promise<number> {
-        const url = `${URL}.json`;
+        const url = `${this.url}.json`;
         const response = await fetch(url, {
             method: "post",
             body: JSON.stringify(data),
@@ -66,7 +70,7 @@ class SavedAnnotationState extends State {
     }
 
     getList(params?: Map<string, string>, arrayParams?: Map<string, string[]>): Array<SavedAnnotation> | undefined {
-        const url = addParametersToUrl(`${URL}.json`, params, arrayParams);
+        const url = addParametersToUrl(`${this.url}.json`, params, arrayParams);
         delayerByURL.get(url)(() => {
             if (!this.listByURL.has(url)) {
                 this.fetchList(url);
@@ -76,7 +80,7 @@ class SavedAnnotationState extends State {
     }
 
     getPagination(params?: Map<string, string>, arrayParams?: Map<string, string[]>): Pagination {
-        const url = addParametersToUrl(`${URL}.json`, params, arrayParams);
+        const url = addParametersToUrl(`${this.url}.json`, params, arrayParams);
         delayerByURL.get(url)(() => {
             if (!this.paginationByURL.has(url)) {
                 this.fetchList(url);

--- a/test/system/saved_annotation_test.rb
+++ b/test/system/saved_annotation_test.rb
@@ -110,4 +110,38 @@ class SavedAnnotationsTest < ApplicationSystemTestCase
     end
     sign_out @staff
   end
+
+  test 'searching saved annotations shows activity names in correct language' do
+    sign_in @staff
+    exercise = create :exercise, name_en: 'Fools', name_nl: 'Bars'
+    create :saved_annotation, user: @staff, exercise: exercise, course: @course, title: 'Tetris', annotation_text: 'text'
+    create :saved_annotation, user: @staff, exercise: exercise, course: @course, title: 'TEST', annotation_text: 'text'
+    visit(saved_annotations_path)
+
+    assert_text 'Tetris'
+    assert_text exercise.name_en
+    assert_no_text exercise.name_nl
+
+    find('input.search-filter').fill_in with: 'TEST'
+
+    # wait for the search to complete
+    assert_no_text 'Tetris'
+
+    assert_text exercise.name_en
+    assert_no_text exercise.name_nl
+
+    visit(saved_annotations_path('nl'))
+
+    assert_text 'Tetris'
+    assert_text exercise.name_nl
+    assert_no_text exercise.name_en
+
+    find('input.search-filter').fill_in with: 'TEST'
+
+    # wait for the search to complete
+    assert_no_text 'Tetris'
+
+    assert_text exercise.name_nl
+    assert_no_text exercise.name_en
+  end
 end


### PR DESCRIPTION
This pull request fixes exercise names appearing in the wrong language when searching through saved annotations.

- [x] Tests were added

Closes #5254
