### PR TITLE
Fix redirect to series show from overview page of hidden series

### DIFF
--- a/app/controllers/series_controller.rb
+++ b/app/controllers/series_controller.rb
@@ -71,7 +71,9 @@ class SeriesController < ApplicationController
   def overview
     @title = "#{@series.course.name} #{@series.name}"
     @course = @series.course
-    @crumbs = [[@course.name, course_path(@course)], [@series.name, course_path(@series.course, anchor: @series.anchor)], [I18n.t('crumbs.overview'), '#']]
+    # redirect to series detail page if a token is provided, as the course page wont contain the hidden series even with a valid token
+    series_link = params[:token].present? ? series_path(@series, token: params[:token]) : course_path(@series.course, anchor: @series.anchor)
+    @crumbs = [[@course.name, course_path(@course)], [@series.name, series_link], [I18n.t('crumbs.overview'), '#']]
     @user = User.find(params[:user_id]) if params[:user_id] && current_user&.course_admin?(@course)
   end
 

--- a/app/controllers/series_controller.rb
+++ b/app/controllers/series_controller.rb
@@ -71,7 +71,7 @@ class SeriesController < ApplicationController
   def overview
     @title = "#{@series.course.name} #{@series.name}"
     @course = @series.course
-    # If a token is provided, this is a hidden series that isn't shown on the course page. 
+    # If a token is provided, this is a hidden series that isn't shown on the course page.
     # Therefore, link to the series page instead of the course page from the breadcrumbs.
     series_link = params[:token].present? ? series_path(@series, token: params[:token]) : course_path(@series.course, anchor: @series.anchor)
     @crumbs = [[@course.name, course_path(@course)], [@series.name, series_link], [I18n.t('crumbs.overview'), '#']]

--- a/app/controllers/series_controller.rb
+++ b/app/controllers/series_controller.rb
@@ -71,7 +71,8 @@ class SeriesController < ApplicationController
   def overview
     @title = "#{@series.course.name} #{@series.name}"
     @course = @series.course
-    # redirect to series detail page if a token is provided, as the course page wont contain the hidden series even with a valid token
+    # If a token is provided, this is a hidden series that isn't shown on the course page. 
+    # Therefore, link to the series page instead of the course page from the breadcrumbs.
     series_link = params[:token].present? ? series_path(@series, token: params[:token]) : course_path(@series.course, anchor: @series.anchor)
     @crumbs = [[@course.name, course_path(@course)], [@series.name, series_link], [I18n.t('crumbs.overview'), '#']]
     @user = User.find(params[:user_id]) if params[:user_id] && current_user&.course_admin?(@course)


### PR DESCRIPTION
This pull request provides a redirect to the hidden series with a valid token from the overview page of a hidden series.

Closes #5255
