### PR TITLE
Update API - submissions.json

### DIFF
--- a/app/views/submissions/_submission_basic.json.jbuilder
+++ b/app/views/submissions/_submission_basic.json.jbuilder
@@ -6,5 +6,11 @@ else
   json.user user_url(submission.user.id, format: :json)
 end
 json.has_annotations submission.annotated?
-json.exercise activity_url(submission.exercise, format: :json)
+
+if submission.course.nil?
+  json.exercise activity_url(submission.exercise, format: :json)
+else
+  json.exercise course_activity_path(submission.course, submission.exercise, format: :json)
+end
+
 json.course course_url(submission.course, format: :json) if submission.course

--- a/app/views/submissions/_submission_basic.json.jbuilder
+++ b/app/views/submissions/_submission_basic.json.jbuilder
@@ -10,7 +10,7 @@ json.has_annotations submission.annotated?
 if submission.course.nil?
   json.exercise activity_url(submission.exercise, format: :json)
 else
-  json.exercise course_activity_path(submission.course, submission.exercise, format: :json)
+  json.exercise course_activity_url(submission.course, submission.exercise, format: :json)
 end
 
 json.course course_url(submission.course, format: :json) if submission.course


### PR DESCRIPTION
This pull request aims to fix the discrepancy between the html and json results for user submissions (not tied to single exercise), as mentioned in #5248 .

This updates dodona/app/views/_submission_basic.json.jsonbuilder to include the same logic found in _submission.html.erb (same directory). 

First tests seem to indicate that this is indeed working, but I don't have access to the live production server to test the same case that caused #5248 .

- [ ] Tests were added
- [ ] Documentation update can be found at dodona-edu/dodona-edu.github.io#

Closes #5248  .
