### PR TITLE
Remove "actions" for labels for users who can't do actions on labels

### DIFF
--- a/app/views/labels/_labels_table.html.erb
+++ b/app/views/labels/_labels_table.html.erb
@@ -1,15 +1,22 @@
 <div class="table-scroll-wrapper">
   <table class="table table-index table-resource">
     <colgroup>
-      <col class="col-8"/>
-      <col class="col-3"/>
-      <col class="col-1"/>
+      <% if policy(Label).edit? %>
+        <col class="col-8"/>
+        <col class="col-3"/>
+        <col class="col-1"/>
+      <% else %>
+        <col class="col-10"/>
+        <col class="col-3"/>
+      <% end %>
     </colgroup>
     <thead>
     <tr>
       <th><%= t "labels.index.name" %></th>
       <th><%= t "labels.index.exercises" %></th>
-      <th><%= t "labels.index.actions" %></th>
+      <% if policy(Label).edit? %>
+        <th><%= t "labels.index.actions" %></th>
+      <% end %>
     </tr>
     </thead>
     <tbody>

--- a/app/views/labels/_labels_table.html.erb
+++ b/app/views/labels/_labels_table.html.erb
@@ -7,7 +7,7 @@
         <col class="col-1"/>
       <% else %>
         <col class="col-10"/>
-        <col class="col-3"/>
+        <col class="col-2"/>
       <% end %>
     </colgroup>
     <thead>

--- a/app/views/labels/_labels_table.html.erb
+++ b/app/views/labels/_labels_table.html.erb
@@ -1,7 +1,7 @@
 <div class="table-scroll-wrapper">
   <table class="table table-index table-resource">
     <colgroup>
-      <% if policy(Label).edit? %>
+      <% if policy(Label).edit? or policy(Label).destroy? %>
         <col class="col-6"/>
         <col class="col-3"/>
         <col class="col-3"/>
@@ -14,8 +14,8 @@
     <tr>
       <th><%= t "labels.index.name" %></th>
       <th class="text-end"><%= t "labels.index.exercises" %></th>
-      <% if policy(Label).edit? %>
-        <th class="text-end"><%= t "labels.index.actions" %></th>
+      <% if policy(Label).edit? or policy(Label).destroy? %>
+        <th class="text-end"></th>
       <% end %>
     </tr>
     </thead>
@@ -23,19 +23,21 @@
     <% labels.each do |label| %>
       <tr>
         <td><%= link_to label.name, label_path(label) %></td>
-        <td class="text-end"><%= link_to label.activities.count, activities_path({"labels[]" => label.name}) %></td>
-        <td class="text-end">
-          <% if policy(Label).edit? %>
-            <%= link_to edit_label_path(label), class: "btn btn-icon" do %>
-              <i class="mdi mdi-pencil"></i>
+        <td class="text-end"><%= link_to label.activities.count, activities_path({ "labels[]" => label.name }) %></td>
+        <% if policy(Label).edit? or policy(Label).destroy? %>
+          <td class="text-end">
+            <% if policy(Label).edit? %>
+              <%= link_to edit_label_path(label), class: "btn btn-icon" do %>
+                <i class="mdi mdi-pencil"></i>
+              <% end %>
             <% end %>
-          <% end %>
-          <% if policy(Label).destroy? %>
-            <%= link_to label, method: :delete, data: {confirm: t("general.are_you_sure")}, class: "btn btn-icon btn-icon-filled d-btn-danger" do %>
-              <i class="mdi mdi-delete"></i>
+            <% if policy(Label).destroy? %>
+              <%= link_to label, method: :delete, data: { confirm: t("general.are_you_sure") }, class: "btn btn-icon btn-icon-filled d-btn-danger" do %>
+                <i class="mdi mdi-delete"></i>
+              <% end %>
             <% end %>
-          <% end %>
-        </td>
+          </td>
+        <% end %>
       </tr>
     <% end %>
     </tbody>

--- a/app/views/labels/_labels_table.html.erb
+++ b/app/views/labels/_labels_table.html.erb
@@ -2,9 +2,9 @@
   <table class="table table-index table-resource">
     <colgroup>
       <% if policy(Label).edit? %>
-        <col class="col-8"/>
+        <col class="col-6"/>
         <col class="col-3"/>
-        <col class="col-1"/>
+        <col class="col-3"/>
       <% else %>
         <col class="col-10"/>
         <col class="col-2"/>
@@ -13,9 +13,9 @@
     <thead>
     <tr>
       <th><%= t "labels.index.name" %></th>
-      <th><%= t "labels.index.exercises" %></th>
+      <th class="text-end"><%= t "labels.index.exercises" %></th>
       <% if policy(Label).edit? %>
-        <th><%= t "labels.index.actions" %></th>
+        <th class="text-end"><%= t "labels.index.actions" %></th>
       <% end %>
     </tr>
     </thead>
@@ -23,8 +23,8 @@
     <% labels.each do |label| %>
       <tr>
         <td><%= link_to label.name, label_path(label) %></td>
-        <td><%= link_to label.activities.count, activities_path({"labels[]" => label.name}) %></td>
-        <td>
+        <td class="text-end"><%= link_to label.activities.count, activities_path({"labels[]" => label.name}) %></td>
+        <td class="text-end">
           <% if policy(Label).edit? %>
             <%= link_to edit_label_path(label), class: "btn btn-icon" do %>
               <i class="mdi mdi-pencil"></i>


### PR DESCRIPTION
This pull request removes the actions-column entirely for users who don't have the right to perform actions on labels.

## For students
### Pc normal window
Before:
![image](https://github.com/dodona-edu/dodona/assets/93756910/30d9bfbd-c7de-4661-bd84-92ac24ad66d9)
After:
![image](https://github.com/dodona-edu/dodona/assets/93756910/2f7b5c03-589b-496d-8c92-355599159f03)

### Small window 
(simulated by making window as small as possible and zooming in to 130%)
| Before: | After: |
| ----------- | --------- |
![image](https://github.com/dodona-edu/dodona/assets/93756910/83170edd-c84c-4edb-94e7-5ba98ab0e296) |![image](https://github.com/dodona-edu/dodona/assets/93756910/ff8c4a76-5355-4e30-8acd-e058979590be)


## For admins (Zeus)
### Pc normal window
Before:
![image](https://github.com/dodona-edu/dodona/assets/93756910/99b53f4f-91a7-4818-8e31-bb886adeb894)
After:
![image](https://github.com/dodona-edu/dodona/assets/93756910/5a46c778-c1a5-4b0f-bc8b-96959eb475da)


### Small window
(simulated by making window as small as possible and zooming in to 130%)
| Before: | After: |
| ----------- | -------- |
![image](https://github.com/dodona-edu/dodona/assets/93756910/b6a52084-a6fb-4a4c-b16e-20e12cfd7c02) | ![image](https://github.com/dodona-edu/dodona/assets/93756910/611ff9f3-0f8c-48e7-8820-c452e48c7cf3)
