### PR TITLE
Extend allowed tags and attributes (svg)

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -146,10 +146,10 @@ module ApplicationHelper
   def sanitize(html)
     @tags ||= Rails::Html::SafeListSanitizer.allowed_tags.to_a +
               %w[table thead tbody tr td th colgroup col style summary details] +
-              %w[svg g style circle line rect path polygon text]
+              %w[svg g style circle line rect path polygon text defs use]
     @attributes ||= Rails::Html::SafeListSanitizer.allowed_attributes.to_a +
                     %w[style target data-bs-toggle data-parent data-tab data-line data-element id] +
-                    %w[viewBox width height version style class transform id x y rx ry x1 y1 x2 y2 d points fill stroke stroke-width stroke-dasharray cx cy r font-size font-family font-weight font-variant textLength writing-mode glyph-orientation-vertical text-orientation]
+                    %w[viewBox width height version style class transform id x y rx ry x1 y1 x2 y2 d points fill stroke stroke-width stroke-dasharray cx cy r font-size font-family font-weight font-variant textLength writing-mode glyph-orientation-vertical text-orientation color]
 
     # Filters allowed tags and attributes
     sanitized = ActionController::Base.helpers.sanitize html,

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -107,6 +107,13 @@ class ApplicationHelperTest < ActiveSupport::TestCase
         <style>test{stroke-width:3px;stroke:black;stroke-dasharray:1;stroke-linecap:round}</style>
         <style>text.vertical{writing-mode:tb;glyph-orientation-vertical:0;fill:grey;}</style>
         <style>text.vertical{writing-mode:vertical-rl;text-orientation:upright;}</style>
+        <defs>
+          <g id="diamond">
+            <polygon points="0,-1 -0.5773,0 0.5773,0 0,-1"></polygon>
+            <polygon points="0,1 -0.5773,0 0.5773,0 0,1" fill="currentColor"></polygon>
+            <polygon class="border" points="0,1 -0.5773,0 0,-1 0.5773,0 0,1" fill="none"></polygon>
+          </g>
+        </defs>
         <g id="group1" transform="translate(50,50)">
           <circle cx="0" cy="0" r="40" fill="none"></circle>
           <line class="test" x1="0" y1="0" x2="0" y2="-40"></line>
@@ -116,6 +123,7 @@ class ApplicationHelperTest < ActiveSupport::TestCase
         <path d="M0,0 L100,0 L100,100 L0,100 Z"></path>
         <text x="0" y="0" font-size="14px" font-weight="bold" font-variant="normal" font-family="serif">Hello</text>
         <text x="0" y="0" textLength="10">abcdefgh</text>
+        <use xlink:href="#diamond" x="0.5" y="0.866" fill="blue" color="cyan" transform="rotate(90,0.5,0.866)"></use>
       </svg>
     HTML
     clean_html = sanitize dirty_html


### PR DESCRIPTION
This pull request adds additional SVG tags:
`<defs>` `<use>`

And attributes:
`color`

- [x] Tests were added
- [ ] Documentation update can be found at dodona-edu/dodona-edu.github.io#