### PR TITLE
Swap order of status icon in series-activity-table

### DIFF
--- a/app/views/activities/_series_activities_table.html.erb
+++ b/app/views/activities/_series_activities_table.html.erb
@@ -41,7 +41,7 @@
             <%= render partial: 'activities/user_status_icon', locals: {activity: activity, series: local_assigns[:series], user: user} %>
             <% if current_user.repository_admin?(activity.repository) || current_user.course_admin?(@course) %>
               <%= render partial: 'activities/repository_status', locals: {activity: activity, series: local_assigns[:series]} %>
-        <% end %>
+            <% end %>
           <% end %>
         </td>
 

--- a/app/views/activities/_series_activities_table.html.erb
+++ b/app/views/activities/_series_activities_table.html.erb
@@ -38,10 +38,10 @@
       <tr>
         <td class='status-icon'>
           <% if user_signed_in? %>
+            <%= render partial: 'activities/user_status_icon', locals: {activity: activity, series: local_assigns[:series], user: user} %>
             <% if current_user.repository_admin?(activity.repository) || current_user.course_admin?(@course) %>
               <%= render partial: 'activities/repository_status', locals: {activity: activity, series: local_assigns[:series]} %>
-            <% end %>
-            <%= render partial: 'activities/user_status_icon', locals: {activity: activity, series: local_assigns[:series], user: user} %>
+        <% end %>
           <% end %>
         </td>
 


### PR DESCRIPTION
This pull request reverses the order of the activity-status (solved/wrong) and the draft-icon, as mentioned in #5238 

![image](https://github.com/dodona-edu/dodona/assets/93756910/42ab07d8-8186-46a8-96ff-38953cc77390)


I have no idea if there are tests related to this, I tried looking through the tests/ folder, but didn't see anything that I could relate to this change.
- [ ] Tests were added

Closes #5238  .
