### PR TITLE
Add basic styling for details html element

### DIFF
--- a/app/assets/stylesheets/components.css.scss
+++ b/app/assets/stylesheets/components.css.scss
@@ -27,6 +27,7 @@
 @import "components/courselabel-edit.css.scss";
 @import "components/action-card.css.scss";
 @import "components/progress_bar.css.scss";
+@import "components/details.css.scss";
 
 .flex-spacer {
   flex-grow: 1;

--- a/app/assets/stylesheets/components/details.css.scss
+++ b/app/assets/stylesheets/components/details.css.scss
@@ -2,6 +2,7 @@ details {
   border: 1px solid var(--d-divider);
   border-radius: var(--d-border-radius-base);
   padding: 12px;
+  margin-bottom: .875rem;
 
   summary {
     font-size: 16px;

--- a/app/assets/stylesheets/components/details.css.scss
+++ b/app/assets/stylesheets/components/details.css.scss
@@ -1,0 +1,15 @@
+details {
+  border: 1px solid var(--d-divider);
+  border-radius: var(--d-border-radius-base);
+  padding: 12px;
+
+  summary {
+    font-size: 16px;
+  }
+}
+
+details[open] {
+  summary {
+    margin-bottom: 8px;
+  }
+}


### PR DESCRIPTION
This pull request adds basic styling for the details html element

![image](https://github.com/dodona-edu/dodona/assets/21177904/e9e3a555-54ec-4b99-831f-15e80559cae3)
![image](https://github.com/dodona-edu/dodona/assets/21177904/0c9c66e1-1a20-41bb-8fb6-68c18236985a)

- [x] Documentation update can be found at dodona-edu/dodona-edu.github.io#383

Closes #5237
