### PR TITLE
Require at least one correct submission and a valid config before publishing

### DIFF
--- a/app/assets/stylesheets/models/activities.css.scss
+++ b/app/assets/stylesheets/models/activities.css.scss
@@ -203,3 +203,23 @@ center img {
     background-color: var(--d-code-bg);
   }
 }
+
+.draft-notice {
+  .form-check-input[disabled] ~ .form-check-label, .form-check-input:disabled ~ .form-check-label {
+    opacity: 1;
+  }
+
+  .form-check-input:disabled {
+    opacity: 1;
+  }
+
+  .form-check-input:checked {
+    background-color: var(--d-warning);
+    border-color: var(--d-warning);
+  }
+
+  .form-check-input {
+    background-color: transparent;
+    border-color: var(--d-warning);
+  }
+}

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -57,7 +57,7 @@ class Activity < ApplicationRecord
   has_many :labels, through: :activity_labels
 
   validates :path, uniqueness: { scope: :repository_id, case_sensitive: false }, allow_nil: true
-  validate :require_valid_submission_before_publish, on: :update
+  validate :require_correct_submission_before_publish, on: :update
 
   token_generator :repository_token, length: 64
   token_generator :access_token
@@ -512,18 +512,18 @@ class Activity < ApplicationRecord
     hash
   end
 
-  def valid_submission?
+  def correct_submission?
     return true if content_page?
 
     submissions.any?(&:accepted?)
   end
 
-  def require_valid_submission_before_publish
+  def require_correct_submission_before_publish
     return if draft?
     return unless draft_was
-    return if valid_submission?
+    return if correct_submission?
 
-    errors.add(:base, I18n.t('activerecord.errors.models.activity.no_valid_submission'))
+    errors.add(:base, I18n.t('activerecord.errors.models.activity.no_correct_submission'))
     self.draft = true
   end
 end

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -523,7 +523,7 @@ class Activity < ApplicationRecord
     return unless draft_was
     return if valid_submission?
 
-    errors.add(:draft, I18n.t('activerecord.errors.models.activity.no_valid_submission'))
+    errors.add(:base, I18n.t('activerecord.errors.models.activity.no_valid_submission'))
     self.draft = true
   end
 end

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -57,7 +57,7 @@ class Activity < ApplicationRecord
   has_many :labels, through: :activity_labels
 
   validates :path, uniqueness: { scope: :repository_id, case_sensitive: false }, allow_nil: true
-  validate :require_valid_submission_before_publish
+  validate :require_valid_submission_before_publish, on: :update
 
   token_generator :repository_token, length: 64
   token_generator :access_token

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -518,12 +518,20 @@ class Activity < ApplicationRecord
     submissions.any?(&:accepted?)
   end
 
+  def valid_config?
+    config
+    true
+  rescue ConfigParseError
+    false
+  end
+
   def require_correct_submission_before_publish
     return if draft?
     return unless draft_was
-    return if correct_submission?
 
-    errors.add(:base, I18n.t('activerecord.errors.models.activity.no_correct_submission'))
-    self.draft = true
+    errors.add(:base, I18n.t('activerecord.errors.models.activity.no_correct_submission')) unless correct_submission?
+    errors.add(:base, I18n.t('activerecord.errors.models.activity.not_valid')) if not_valid?
+    errors.add(:base, I18n.t('activerecord.errors.models.activity.invalid_config')) unless valid_config?
+    self.draft = true if errors.any?
   end
 end

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -443,6 +443,19 @@ class Activity < ApplicationRecord
     end
   end
 
+  def correct_submission?
+    return true if content_page?
+
+    submissions.any?(&:accepted?)
+  end
+
+  def valid_config?
+    config
+    true
+  rescue ConfigParseError
+    false
+  end
+
   private
 
   def activity_status_for(user, series = nil)
@@ -510,19 +523,6 @@ class Activity < ApplicationRecord
 
     hash['labels'] = hash['labels'].uniq if hash.key? 'labels'
     hash
-  end
-
-  def correct_submission?
-    return true if content_page?
-
-    submissions.any?(&:accepted?)
-  end
-
-  def valid_config?
-    config
-    true
-  rescue ConfigParseError
-    false
   end
 
   def require_correct_submission_before_publish

--- a/app/views/activities/_draft_notice.html.erb
+++ b/app/views/activities/_draft_notice.html.erb
@@ -1,13 +1,36 @@
 <% if @activity.draft? %>
-  <div class="alert alert-warning">
+  <div class="alert alert-warning draft-notice">
     <i class="mdi mdi-file-document-edit-outline"></i>
-    <%= t "activities.show.alert_draft_html" %>
+    <%= t "activities.show.alert_draft.text_html" %>
     <% if policy(@activity).edit? %>
       <% edit_path = @series.present? ?
                        course_series_activity_path(@series&.course, @series, @activity, {activity: {draft: false}}) :
                        activity_path(@activity, {activity: {draft: false}})
       %>
-      <%= link_to t("activities.show.alert_draft_edit"), edit_path, method: :put %>
+
+      <% if @activity.ok? && @activity.correct_submission? && @activity.valid_config?  %>
+        <%= link_to t("activities.show.alert_draft.edit"), edit_path, method: :put %>
+      <% else %>
+        <div style="margin-left: 5px; margin-top: 8px;">
+          <%= t("activities.show.alert_draft.before_publish") %>
+          <div style="margin-left: 16px;margin-top: 8px;">
+            <div class="form-check">
+              <input type="checkbox" id="valid-config" class="form-check-input" disabled <%= "checked" if @activity.valid_config? %>>
+              <label class="form-check-label" for="valid-config"><%= t('activities.show.alert_draft.valid_config') %></label>
+            </div>
+            <div class="form-check">
+              <input type="checkbox" id="is-valid" class="form-check-input" disabled <%= "checked" if @activity.ok? %>>
+              <label class="form-check-label" for="is-valid"><%= t('activities.show.alert_draft.is_valid') %></label>
+            </div>
+            <% if @activity.exercise? %>
+              <div class="form-check">
+                <input type="checkbox" id="correct-submission" class="form-check-input" disabled <%= "checked" if @activity.correct_submission? %>>
+                <label class="form-check-label" for="correct-submission"><%= t('activities.show.alert_draft.correct_submission') %></label>
+              </div>
+            <% end %>
+          </div>
+        </div>
+      <% end %>
 
     <% end %>
   </div>

--- a/app/views/activities/_draft_notice.html.erb
+++ b/app/views/activities/_draft_notice.html.erb
@@ -11,7 +11,7 @@
       <% if @activity.ok? && @activity.correct_submission? && @activity.valid_config?  %>
         <%= link_to t("activities.show.alert_draft.edit"), edit_path, method: :put %>
       <% else %>
-        <div style="margin-left: 5px; margin-top: 8px;">
+        <div style="margin-left: 30px; margin-top: 8px;">
           <%= t("activities.show.alert_draft.before_publish") %>
           <div style="margin-left: 16px;margin-top: 8px;">
             <div class="form-check">

--- a/config/locales/models/en.yml
+++ b/config/locales/models/en.yml
@@ -3,7 +3,7 @@ en:
     errors:
       models:
         activity:
-          no_valid_submission: "At least one correct submission is required, before the activity can be published."
+          no_valid_submission: "At least one correct submission is required, before the exercise can be published."
         course_membership:
           at_least_one_admin: The course should always have at least one course administrator.
         api_token:

--- a/config/locales/models/en.yml
+++ b/config/locales/models/en.yml
@@ -3,7 +3,7 @@ en:
     errors:
       models:
         activity:
-          no_valid_submission: "At least one correct submission is required, before the exercise can be published."
+          no_correct_submission: "At least one correct submission is required, before the exercise can be published."
         course_membership:
           at_least_one_admin: The course should always have at least one course administrator.
         api_token:

--- a/config/locales/models/en.yml
+++ b/config/locales/models/en.yml
@@ -2,6 +2,8 @@ en:
   activerecord:
     errors:
       models:
+        activity:
+          no_valid_submission: "At least one correct submission is required, before the activity can be published."
         course_membership:
           at_least_one_admin: The course should always have at least one course administrator.
         api_token:

--- a/config/locales/models/en.yml
+++ b/config/locales/models/en.yml
@@ -4,6 +4,8 @@ en:
       models:
         activity:
           no_correct_submission: "At least one correct submission is required, before the exercise can be published."
+          not_valid: "The exercise must have a name and a description."
+          invalid_config: "The JSON configuration is invalid."
         course_membership:
           at_least_one_admin: The course should always have at least one course administrator.
         api_token:

--- a/config/locales/models/nl.yml
+++ b/config/locales/models/nl.yml
@@ -2,6 +2,8 @@ nl:
   activerecord:
     errors:
       models:
+        activity:
+          no_valid_submission: "Er moet minstens één geldige oplossing zijn, vooraleer de activiteit kan worden gepubliceerd."
         course_membership:
           at_least_one_admin: Een cursus moet altijd minstens één cursusbeheerder hebben.
         api_token:

--- a/config/locales/models/nl.yml
+++ b/config/locales/models/nl.yml
@@ -3,7 +3,7 @@ nl:
     errors:
       models:
         activity:
-          no_valid_submission: "Er moet minstens één geldige oplossing zijn, vooraleer de oefening kan worden gepubliceerd."
+          no_correct_submission: "Er moet minstens één correcte oplossing zijn, vooraleer de oefening kan worden gepubliceerd."
         course_membership:
           at_least_one_admin: Een cursus moet altijd minstens één cursusbeheerder hebben.
         api_token:

--- a/config/locales/models/nl.yml
+++ b/config/locales/models/nl.yml
@@ -4,6 +4,8 @@ nl:
       models:
         activity:
           no_correct_submission: "Er moet minstens één correcte oplossing zijn, vooraleer de oefening kan worden gepubliceerd."
+          not_valid: "De oefening moet een naam en een beschrijving hebben."
+          invalid_config: "De JSON-configuratie is ongeldig."
         course_membership:
           at_least_one_admin: Een cursus moet altijd minstens één cursusbeheerder hebben.
         api_token:

--- a/config/locales/models/nl.yml
+++ b/config/locales/models/nl.yml
@@ -3,7 +3,7 @@ nl:
     errors:
       models:
         activity:
-          no_valid_submission: "Er moet minstens één geldige oplossing zijn, vooraleer de activiteit kan worden gepubliceerd."
+          no_valid_submission: "Er moet minstens één geldige oplossing zijn, vooraleer de oefening kan worden gepubliceerd."
         course_membership:
           at_least_one_admin: Een cursus moet altijd minstens één cursusbeheerder hebben.
         api_token:

--- a/config/locales/views/activities/en.yml
+++ b/config/locales/views/activities/en.yml
@@ -101,8 +101,13 @@ en:
       preloaded_info: "We have preloaded your latest submission into the editor."
       preloaded_clear: Clear editor.
       preloaded_restore: Restore the initial code.
-      alert_draft_html: This activity is a <a href="https://docs.dodona.be/en/faq/activities/#what-is-a-draft-activity" target="_blank">draft</a> and thus not visible for students.
-      alert_draft_edit: Publish activity.
+      alert_draft:
+        text_html: This activity is a <a href="https://docs.dodona.be/en/faq/activities/#what-is-a-draft-activity" target="_blank">draft</a> and thus not visible for students.
+        edit: Publish activity.
+        before_publish: "Before you can publish this activity, the following conditions must be met:"
+        valid_config: "The JSON configuration must be valid."
+        is_valid: "The activity must have a name and a description."
+        correct_submission: "There must be at least one correct submission."
     series_activities_add_table:
       course_added_to_usable: "Adding this exercise will allow this course to use all of the private exercises in this exercise's repository. Are you sure?"
     edit:

--- a/config/locales/views/activities/en.yml
+++ b/config/locales/views/activities/en.yml
@@ -102,12 +102,12 @@ en:
       preloaded_clear: Clear editor.
       preloaded_restore: Restore the initial code.
       alert_draft:
-        text_html: This activity is a <a href="https://docs.dodona.be/en/faq/activities/#what-is-a-draft-activity" target="_blank">draft</a> and thus not visible for students.
+        text_html: This activity is currently a <a href="https://docs.dodona.be/en/faq/activities/#what-is-a-draft-activity" target="_blank">draft</a> and is not yet visible to students.
         edit: Publish activity.
-        before_publish: "Before you can publish this activity, the following conditions must be met:"
-        valid_config: "The JSON configuration must be valid."
+        before_publish: "Before you can publish this activity, please ensure the following criteria are met:"
+        valid_config: "The exercise must have a valid configuration file."
         is_valid: "The activity must have a name and a description."
-        correct_submission: "There must be at least one correct submission."
+        correct_submission: "You must submit at least one correct solution."
     series_activities_add_table:
       course_added_to_usable: "Adding this exercise will allow this course to use all of the private exercises in this exercise's repository. Are you sure?"
     edit:

--- a/config/locales/views/activities/en.yml
+++ b/config/locales/views/activities/en.yml
@@ -106,7 +106,7 @@ en:
         edit: Publish activity.
         before_publish: "Before you can publish this activity, please ensure the following criteria are met:"
         valid_config: "The exercise must have a valid configuration file."
-        is_valid: "The activity must have a name and a description."
+        is_valid: "The exercise must have a name and a description."
         correct_submission: "You must submit at least one correct solution."
     series_activities_add_table:
       course_added_to_usable: "Adding this exercise will allow this course to use all of the private exercises in this exercise's repository. Are you sure?"

--- a/config/locales/views/activities/nl.yml
+++ b/config/locales/views/activities/nl.yml
@@ -102,12 +102,12 @@ nl:
       preloaded_clear: Maak de editor leeg.
       preloaded_restore: Zet de voorbeeldcode terug.
       alert_draft:
-        text_html: Deze oefening is nog een <a href="https://docs.dodona.be/nl/faq/activities/#wat-is-een-conceptactiviteit" target="_blank">concept</a>. Ze is niet zichtbaar voor studenten.
+        text_html: Deze oefening is momenteel een <a href="https://docs.dodona.be/nl/faq/activities/#wat-is-een-conceptactiviteit" target="_blank">concept</a> en nog niet zichtbaar voor studenten.
         edit: Deze oefening publiceren.
         before_publish: "Vooraleer je deze oefening kan publiceren, moet aan de volgende voorwaarden voldaan zijn:"
-        valid_config: "De JSON-configuratie moet geldig zijn."
+        valid_config: "De oefening moet een geldig configuratiebestand hebben."
         is_valid: "De oefening moet een naam en een beschrijving hebben."
-        correct_submission: "Er moet minstens één correcte oplossing zijn."
+        correct_submission: "Je moet minstens één correcte oplossing indienen."
     series_activities_add_table:
       course_added_to_usable: "Deze oefening toevoegen zal deze cursus toegang geven tot alle privé oefeningen in de repository van deze oefening. Ben je zeker?"
     edit:

--- a/config/locales/views/activities/nl.yml
+++ b/config/locales/views/activities/nl.yml
@@ -101,8 +101,13 @@ nl:
       preloaded_info: We hebben jouw laatste oplossing ingeladen in de editor.
       preloaded_clear: Maak de editor leeg.
       preloaded_restore: Zet de voorbeeldcode terug.
-      alert_draft_html: Deze oefening is nog een <a href="https://docs.dodona.be/nl/faq/activities/#wat-is-een-conceptactiviteit" target="_blank">concept</a>. Ze is niet zichtbaar voor studenten.
-      alert_draft_edit: Deze oefening publiceren.
+      alert_draft:
+        text_html: Deze oefening is nog een <a href="https://docs.dodona.be/nl/faq/activities/#wat-is-een-conceptactiviteit" target="_blank">concept</a>. Ze is niet zichtbaar voor studenten.
+        edit: Deze oefening publiceren.
+        before_publish: "Vooraleer je deze oefening kan publiceren, moet aan de volgende voorwaarden voldaan zijn:"
+        valid_config: "De JSON-configuratie moet geldig zijn."
+        is_valid: "De oefening moet een naam en een beschrijving hebben."
+        correct_submission: "Er moet minstens één correcte oplossing zijn."
     series_activities_add_table:
       course_added_to_usable: "Deze oefening toevoegen zal deze cursus toegang geven tot alle privé oefeningen in de repository van deze oefening. Ben je zeker?"
     edit:

--- a/test/controllers/activities_controller_test.rb
+++ b/test/controllers/activities_controller_test.rb
@@ -802,6 +802,7 @@ class ActivitiesPermissionControllerTest < ActionDispatch::IntegrationTest
     repo = create :repository, :git_stubbed
     repo.admins << user
     exercise = create :exercise, repository: repo, draft: true
+    create :correct_submission, exercise: exercise
 
     put activity_url(exercise), params: { activity: { draft: false } }
 

--- a/test/models/activity_test.rb
+++ b/test/models/activity_test.rb
@@ -304,4 +304,20 @@ class ActivityTest < ActiveSupport::TestCase
     assert_empty Activity.repository_scope(scope: :my_institution, user: nil)
     assert_empty Activity.repository_scope(scope: :my_institution, user: create(:user, institution_id: nil))
   end
+
+  test 'should have at least one valid submission before publishing' do
+    activity = create :exercise, draft: true
+    activity.update(draft: false)
+
+    assert_not_empty activity.errors
+    assert_predicate activity.reload, :draft?
+
+    # reset errors
+    activity = Activity.find(activity.id)
+    create :correct_submission, exercise: activity
+    activity.update(draft: false)
+
+    assert_empty activity.errors
+    assert_not activity.reload.draft?
+  end
 end


### PR DESCRIPTION
This pull request adds a validation to activities that checks if an activity has at least one correct submission and a valid config before publishing.

This info is displayed to the user in the notice.

![image](https://github.com/dodona-edu/dodona/assets/21177904/2c54e42a-483d-4206-ac2a-149c606f5bd7)

- [x] Tests were added

Closes  #5084
