### PR TITLE
Avoid duplicate series icon when favoring a course

### DIFF
--- a/app/assets/javascripts/favorite_course_buttons.ts
+++ b/app/assets/javascripts/favorite_course_buttons.ts
@@ -1,6 +1,7 @@
 import { Toast } from "./toast";
 import { fetch, getParentByClassName } from "utilities";
 import { i18n } from "i18n/i18n";
+import { SeriesIcon } from "components/series_icon";
 
 function initFavoriteButtons(doc: Document | HTMLElement = document): void {
     function init(): void {
@@ -44,6 +45,11 @@ function initFavoriteButtons(doc: Document | HTMLElement = document): void {
                 cloneFavButton.setAttribute("title", i18n.t("js.unfavorite-course-do"));
                 new bootstrap.Tooltip(cloneFavButton); // is enabled by default
                 cloneFavButton.addEventListener("click", toggleFavorite);
+                // hack to fix double rendering of content of lit element 'd-series-icon'
+                clone.querySelectorAll("d-series-icon").forEach((el: SeriesIcon) => {
+                    el.replaceChildren();
+                    el.requestUpdate();
+                });
             } else {
                 new Toast(i18n.t("js.favorite-course-failed"));
             }


### PR DESCRIPTION
This pull request fixes the duplicate series icon on a favored course.

This bug was caused by a bad interaction between 'cloneNode' and custom elements.
There seem to no way to know your elements is being cloned (https://github.com/WICG/webcomponents/issues/176), thus the only solution seems a hack after the clone happened

Closes #5348
