### PR TITLE
Make copy course button more prominent for featured courses

### DIFF
--- a/app/helpers/courses_helper.rb
+++ b/app/helpers/courses_helper.rb
@@ -5,6 +5,7 @@ module CoursesHelper
 
     secret = args[:secret]
     membership = args[:membership]
+    css_class = args[:class] || 'btn btn-filled'
 
     if membership.nil? || membership.unsubscribed?
       if course.open_for_user?(current_user) || current_user.nil?
@@ -13,13 +14,13 @@ module CoursesHelper
                   subscribe_course_path(@course, secret: secret),
                   title: t('courses.registration.registration-tooltip'),
                   method: :post,
-                  class: 'btn btn-filled'
+                  class: css_class
         else
           link_to t('courses.show.subscribe'),
                   subscribe_course_path(@course, secret: secret),
                   title: t('courses.registration.registration-tooltip'),
                   method: :post,
-                  class: 'btn btn-filled'
+                  class: css_class
         end
       else
         tag.p t("courses.show.registration-#{@course.registration}-info", institution: @course.institution&.name)

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -64,7 +64,7 @@
         <div class="card-actions card-border">
           <% if current_user&.member_of? @course %>
             <%= button_to t('.unsubscribe'), unsubscribe_course_path(@course), class: 'btn btn-text', data: {confirm: t('general.are_you_sure')} %>
-          <% elsif @course.featured? and policy(@course).copy?%>
+          <% elsif @course.featured? and policy(@course).copy? %>
             <%= registration_action_for course: @course, membership: @current_membership, secret: (@course.secret if @course.secret_required?(current_user)), class: 'btn btn-text' %>
           <% end %>
           <% if policy(@course).copy? or policy(@course).scoresheet? or policy(@course).download_submissions? %>

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -27,12 +27,12 @@
 
       <% if @course.description.present? or current_user&.member_of?(@course).! %>
         <div class="card-supporting-text card-border row course-description">
-          <div class="col-sm-<%= current_user&.member_of?(@course).! ? '6' : '12' %> col-12">
+          <div class="col-sm-<%= (@course.featured? && policy(@course).copy?) || current_user&.member_of?(@course).! ? '6' : '12' %> col-12">
             <%= cache @course do %>
               <%= markdown(@course.description) %>
             <% end %>
           </div>
-          <% if @course.featured? and policy(@course).copy?%>
+          <% if @course.featured? && policy(@course).copy?%>
             <div class="col-sm-6 col-12">
               <div class="callout callout-info">
                 <p><%= t(".copy_info_html") %></p>

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -53,10 +53,15 @@
 
       <% if current_user&.member_of? @course or policy(@course).copy? or policy(@course).scoresheet? %>
         <div class="card-actions card-border">
+          <% if @course.featured? and policy(@course).copy? %>
+            <%= link_to new_course_url(copy_options: {base_id: @course.id}), class: "btn btn-filled with-icon" do %>
+              <i class="mdi mdi-content-copy mdi-18"></i> <%= t(".copy") %>
+            <% end %>
+          <% end %>
           <% if current_user&.member_of? @course %>
             <%= button_to t('.unsubscribe'), unsubscribe_course_path(@course), class: 'btn btn-text', data: {confirm: t('general.are_you_sure')} %>
           <% end %>
-          <% if policy(@course).copy? or policy(@course).scoresheet? or policy(@course).download_submissions? %>
+          <% if (!@course.featured? and policy(@course).copy?) or policy(@course).scoresheet? or policy(@course).download_submissions? %>
             <a class="btn btn-icon dropdown-toggle hidden-print" data-bs-toggle="dropdown">
               <i class="mdi mdi-dots-vertical"></i>
             </a>

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -65,7 +65,7 @@
           <% if current_user&.member_of? @course %>
             <%= button_to t('.unsubscribe'), unsubscribe_course_path(@course), class: 'btn btn-text', data: {confirm: t('general.are_you_sure')} %>
           <% elsif @course.featured? and policy(@course).copy?%>
-            <%= registration_action_for course: @course, membership: @current_membership, secret: (@course.secret if @course.secret_required?(current_user)) %>
+            <%= registration_action_for course: @course, membership: @current_membership, secret: (@course.secret if @course.secret_required?(current_user)), class: 'btn btn-text' %>
           <% end %>
           <% if policy(@course).copy? or policy(@course).scoresheet? or policy(@course).download_submissions? %>
             <a class="btn btn-icon dropdown-toggle hidden-print" data-bs-toggle="dropdown">

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -32,7 +32,7 @@
               <%= markdown(@course.description) %>
             <% end %>
           </div>
-          <% if @course.featured? && policy(@course).copy?%>
+          <% if @course.featured? && policy(@course).copy? %>
             <div class="col-sm-6 col-12">
               <div class="callout callout-info">
                 <p><%= t(".copy_info_html") %></p>

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -32,7 +32,16 @@
               <%= markdown(@course.description) %>
             <% end %>
           </div>
-          <% if current_user&.member_of?(@course).! %>
+          <% if @course.featured? and policy(@course).copy?%>
+            <div class="col-sm-6 col-12">
+              <div class="callout callout-info">
+                <p><%= t(".copy_info_html") %></p>
+                <%= link_to new_course_url(copy_options: {base_id: @course.id}), class: "btn btn-filled with-icon" do %>
+                  <i class="mdi mdi-content-copy mdi-18"></i> <%= t(".copy") %>
+                <% end %>
+              </div>
+            </div>
+          <% elsif current_user&.member_of?(@course).! %>
             <%= render partial: 'not_a_member_card' %>
             <% if @lti_launch %>
               <%= render partial: 'not_a_member_dialog' %>
@@ -53,15 +62,12 @@
 
       <% if current_user&.member_of? @course or policy(@course).copy? or policy(@course).scoresheet? %>
         <div class="card-actions card-border">
-          <% if @course.featured? and policy(@course).copy? %>
-            <%= link_to new_course_url(copy_options: {base_id: @course.id}), class: "btn btn-filled with-icon" do %>
-              <i class="mdi mdi-content-copy mdi-18"></i> <%= t(".copy") %>
-            <% end %>
-          <% end %>
           <% if current_user&.member_of? @course %>
             <%= button_to t('.unsubscribe'), unsubscribe_course_path(@course), class: 'btn btn-text', data: {confirm: t('general.are_you_sure')} %>
+          <% elsif @course.featured? and policy(@course).copy?%>
+            <%= registration_action_for course: @course, membership: @current_membership, secret: (@course.secret if @course.secret_required?(current_user)) %>
           <% end %>
-          <% if (!@course.featured? and policy(@course).copy?) or policy(@course).scoresheet? or policy(@course).download_submissions? %>
+          <% if policy(@course).copy? or policy(@course).scoresheet? or policy(@course).download_submissions? %>
             <a class="btn btn-icon dropdown-toggle hidden-print" data-bs-toggle="dropdown">
               <i class="mdi mdi-dots-vertical"></i>
             </a>

--- a/config/locales/views/courses/en.yml
+++ b/config/locales/views/courses/en.yml
@@ -128,7 +128,7 @@ en:
         one: 1 pending user is rejected.
         other: "%{count} pending users are rejected."
       copy: "Copy this course"
-      copy_info_html: "Make a copy of this course to start using it with your own students. Have a look at our <a href=\"https://docs.dodona.be/en/guides/teachers/course-management/\">documentation</a> to learn how to manage your own course."
+      copy_info_html: "Ready to bring this course to your students? Use the copy button to get started. Dive into <a href=\"https://docs.dodona.be/en/guides/teachers/course-management/\">our documentation</a> to discover how to customize and manage your course effortlessly."
       manage_series: "Manage series"
       download_deadlines: "Add course to calendar"
       download_deadlines_tooltip: "Add this link to your calendar application to show the course deadlines in your calendar"

--- a/config/locales/views/courses/en.yml
+++ b/config/locales/views/courses/en.yml
@@ -128,6 +128,7 @@ en:
         one: 1 pending user is rejected.
         other: "%{count} pending users are rejected."
       copy: "Copy this course"
+      copy_info_html: "Make a copy of this course to start using it with your own students. Have a look at our <a href=\"https://docs.dodona.be/en/guides/teachers/course-management/\">documentation</a> to learn how to manage your own course."
       manage_series: "Manage series"
       download_deadlines: "Add course to calendar"
       download_deadlines_tooltip: "Add this link to your calendar application to show the course deadlines in your calendar"

--- a/config/locales/views/courses/nl.yml
+++ b/config/locales/views/courses/nl.yml
@@ -137,7 +137,7 @@ nl:
         one: 1 gebruiker op de wachtlijst is afgewezen.
         other: "%{count} gebruikers op de wachtlijst zijn afgewezen."
       copy: "Deze cursus kopiëren"
-      copy_info_html: "Wil je met je eigen studenten aan de slag met deze cursus? Maak dan je eigen kopie. In onze <a href=\"https://docs.dodona.be/nl/guides/teachers/course-management/\">documentatie</a> vind je meer informatie over het beheren van je eigen cursus."
+      copy_info_html: "Wil je met aan de slag met deze cursus met jouw studenten? Maak dan je eigen kopie. Ontdek in <a href=\"https://docs.dodona.be/nl/guides/teachers/course-management/\">onze documentatie</a> hoe je jouw cursus moeiteloos kunt beheren."
       manage_series: "Reeksen beheren"
       download_deadlines: "Cursus toevoegen aan agenda"
       download_deadlines_tooltip: "Voeg deze link toe aan je agenda-applicatie om de deadlines van deze cursus in je kalender te zien"

--- a/config/locales/views/courses/nl.yml
+++ b/config/locales/views/courses/nl.yml
@@ -137,6 +137,7 @@ nl:
         one: 1 gebruiker op de wachtlijst is afgewezen.
         other: "%{count} gebruikers op de wachtlijst zijn afgewezen."
       copy: "Deze cursus kopiëren"
+      copy_info_html: "Wil je met je eigen studenten aan de slag met deze cursus? Maak dan je eigen kopie. In onze <a href=\"https://docs.dodona.be/nl/guides/teachers/course-management/\">documentatie</a> vind je meer informatie over het beheren van je eigen cursus."
       manage_series: "Reeksen beheren"
       download_deadlines: "Cursus toevoegen aan agenda"
       download_deadlines_tooltip: "Voeg deze link toe aan je agenda-applicatie om de deadlines van deze cursus in je kalender te zien"


### PR DESCRIPTION
This pull request makes the copy course button more prominent for featured courses.

Featured courses are mainly used as templates for teachers. It thus makes sense to make copying such a course the primary highlighted action for teachers.

![image](https://github.com/dodona-edu/dodona/assets/21177904/32017d65-1062-4913-a3e9-b3ae8ec0acc0)

The copy course card replaces the subscribe card for teachers. The subscribe button is moved to same location as the unsubscribe location.

This allowed me to make use of this space in the card to add some extra information for new teachers and redirect them to [our documentation](https://docs.dodona.be/nl/guides/teachers/course-management/).

