### PR TITLE
Stop previous papyros execution on new debug run

### DIFF
--- a/app/assets/javascripts/tutor.ts
+++ b/app/assets/javascripts/tutor.ts
@@ -49,7 +49,7 @@ export function initTutor(submissionCode: string): void {
     async function loadTutor(exerciseId: string, studentCode: string, statements: string, stdin: string, inlineFiles: Record<string, string>, hrefFiles: Record<string, string>): Promise<void> {
         const papyros = await initPapyros(ProgrammingLanguage.Python);
 
-        if (papyros.codeRunner.getState() != RunState.Ready && papyros.codeRunner.getState() != RunState.Loading) {
+        if (papyros.codeRunner.getState() !== RunState.Ready && papyros.codeRunner.getState() !== RunState.Loading) {
             // stop the code runner if it is running
             await papyros.codeRunner.stop();
 

--- a/app/assets/javascripts/tutor.ts
+++ b/app/assets/javascripts/tutor.ts
@@ -54,7 +54,7 @@ export function initTutor(submissionCode: string): void {
             await papyros.codeRunner.stop();
 
             // wait to make sure the code runner is stopped
-            while (papyros.codeRunner.getState() == RunState.Stopping) {
+            while (papyros.codeRunner.getState() === RunState.Stopping) {
                 await new Promise(resolve => setTimeout(resolve, 100));
             }
         }

--- a/app/assets/javascripts/tutor.ts
+++ b/app/assets/javascripts/tutor.ts
@@ -1,5 +1,5 @@
 import { initPapyros, OFFCANVAS_ID } from "coding_scratchpad";
-import { InputMode, ProgrammingLanguage } from "@dodona/papyros";
+import { InputMode, ProgrammingLanguage, RunState } from "@dodona/papyros";
 import { BatchInputHandler } from "@dodona/papyros/dist/input/BatchInputHandler";
 import { Offcanvas } from "bootstrap";
 import { RunMode } from "@dodona/papyros/dist/Backend";
@@ -48,6 +48,16 @@ export function initTutor(submissionCode: string): void {
 
     async function loadTutor(exerciseId: string, studentCode: string, statements: string, stdin: string, inlineFiles: Record<string, string>, hrefFiles: Record<string, string>): Promise<void> {
         const papyros = await initPapyros(ProgrammingLanguage.Python);
+
+        if (papyros.codeRunner.getState() != RunState.Ready && papyros.codeRunner.getState() != RunState.Loading) {
+            // stop the code runner if it is running
+            await papyros.codeRunner.stop();
+
+            // wait to make sure the code runner is stopped
+            while (papyros.codeRunner.getState() == RunState.Stopping) {
+                await new Promise(resolve => setTimeout(resolve, 100));
+            }
+        }
 
         papyros.setCode(studentCode);
         papyros.codeRunner.inputManager.setInputMode(InputMode.Batch);


### PR DESCRIPTION
This pull request fixes  #5361 

I will refactor this in papyros so we only need `await papyros.codeRunner.stop();` on the dodona side. But decided to already push this now to fix the bug.

Closes #5361 
