### PR TITLE
Add debug state to papyros editor

### DIFF
--- a/app/assets/javascripts/coding_scratchpad.ts
+++ b/app/assets/javascripts/coding_scratchpad.ts
@@ -1,10 +1,9 @@
-import { BackendManager, CodeEditor, InputMode, Papyros, ProgrammingLanguage } from "@dodona/papyros";
+import { CodeEditor, InputMode, Papyros, ProgrammingLanguage } from "@dodona/papyros";
 import { themeState } from "state/Theme";
 import { EditorView } from "@codemirror/view";
 import { rougeStyle, setCode } from "editor";
 import { syntaxHighlighting } from "@codemirror/language";
 import { i18n } from "i18n/i18n";
-import { BackendEventType } from "@dodona/papyros/dist/BackendEvent";
 import { Tab } from "bootstrap";
 
 /** Identifiers used in HTML for relevant elements */

--- a/app/assets/javascripts/coding_scratchpad.ts
+++ b/app/assets/javascripts/coding_scratchpad.ts
@@ -96,25 +96,16 @@ export async function initPapyros(programmingLanguage: ProgrammingLanguage): Pro
             fallback: true
         })]);
 
-        // Hide Trace tab when a new run is started
-        BackendManager.subscribe(BackendEventType.Start, () => {
+        papyros.codeRunner.addEventListener("debug-mode", (event: CustomEvent<boolean>) => {
+            const debugMode = event.detail;
             const traceTab = document.getElementById(TRACE_TAB_ID);
-            if (traceTab) {
-                traceTab.classList.add("hidden");
-                const descriptionTab = document.getElementById(DESCRIPTION_TAB_ID);
-                if (descriptionTab) {
-                    const tabTrigger = new Tab(descriptionTab.querySelector("a"));
-                    tabTrigger.show();
-                }
-            }
-        });
-
-        // Show Trace tab when a new frame is added
-        BackendManager.subscribe(BackendEventType.Frame, () => {
-            const traceTab = document.getElementById(TRACE_TAB_ID);
-            if (traceTab) {
-                traceTab.classList.remove("hidden");
+            traceTab.classList.toggle("hidden", !debugMode);
+            if (debugMode) {
                 const tabTrigger = new Tab(traceTab.querySelector("a"));
+                tabTrigger.show();
+            } else {
+                const descriptionTab = document.getElementById(DESCRIPTION_TAB_ID);
+                const tabTrigger = new Tab(descriptionTab.querySelector("a"));
                 tabTrigger.show();
             }
         });

--- a/app/assets/javascripts/tutor.ts
+++ b/app/assets/javascripts/tutor.ts
@@ -49,15 +49,7 @@ export function initTutor(submissionCode: string): void {
     async function loadTutor(exerciseId: string, studentCode: string, statements: string, stdin: string, inlineFiles: Record<string, string>, hrefFiles: Record<string, string>): Promise<void> {
         const papyros = await initPapyros(ProgrammingLanguage.Python);
 
-        if (papyros.codeRunner.getState() !== RunState.Ready && papyros.codeRunner.getState() !== RunState.Loading) {
-            // stop the code runner if it is running
-            await papyros.codeRunner.stop();
-
-            // wait to make sure the code runner is stopped
-            while (papyros.codeRunner.getState() === RunState.Stopping) {
-                await new Promise(resolve => setTimeout(resolve, 100));
-            }
-        }
+        await papyros.codeRunner.reset();
 
         papyros.setCode(studentCode);
         papyros.codeRunner.inputManager.setInputMode(InputMode.Batch);

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@codemirror/language-data": "^6.4.1",
     "@codemirror/state": "^6.3.3",
     "@codemirror/view": "^6.24.0",
-    "@dodona/papyros": "2.3.1",
+    "@dodona/papyros": "2.3.2",
     "@lezer/common": "^1.2.1",
     "@lezer/highlight": "^1.2.0",
     "@lezer/lr": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@codemirror/language-data": "^6.4.1",
     "@codemirror/state": "^6.3.3",
     "@codemirror/view": "^6.24.0",
-    "@dodona/papyros": "2.3.0-beta.1",
+    "@dodona/papyros": "2.3.0-beta.4",
     "@lezer/common": "^1.2.1",
     "@lezer/highlight": "^1.2.0",
     "@lezer/lr": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@codemirror/language-data": "^6.4.1",
     "@codemirror/state": "^6.3.3",
     "@codemirror/view": "^6.24.0",
-    "@dodona/papyros": "2.3.0-beta.5",
+    "@dodona/papyros": "2.3.1",
     "@lezer/common": "^1.2.1",
     "@lezer/highlight": "^1.2.0",
     "@lezer/lr": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@codemirror/language-data": "^6.4.1",
     "@codemirror/state": "^6.3.3",
     "@codemirror/view": "^6.24.0",
-    "@dodona/papyros": "2.2.0",
+    "@dodona/papyros": "2.3.0-beta.1",
     "@lezer/common": "^1.2.1",
     "@lezer/highlight": "^1.2.0",
     "@lezer/lr": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@codemirror/language-data": "^6.4.1",
     "@codemirror/state": "^6.3.3",
     "@codemirror/view": "^6.24.0",
-    "@dodona/papyros": "2.3.0-beta.4",
+    "@dodona/papyros": "2.3.0-beta.5",
     "@lezer/common": "^1.2.1",
     "@lezer/highlight": "^1.2.0",
     "@lezer/lr": "^1.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1327,10 +1327,10 @@
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz#1d572bfbbe14b7704e0ba0f39b74815b84870d70"
   integrity sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==
 
-"@dodona/papyros@2.3.0-beta.5":
-  version "2.3.0-beta.5"
-  resolved "https://registry.yarnpkg.com/@dodona/papyros/-/papyros-2.3.0-beta.5.tgz#61b6401a1983e6cf41992327fc3381cec8a529db"
-  integrity sha512-3qedP+GpV23nU1c63mApsNqCPwjK7p5YwNRMZRjVNF0CV/39+tWrRNGXSqF4Fgq6qWGCR8dhWBanuo0dKZUvEA==
+"@dodona/papyros@2.3.1":
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/@dodona/papyros/-/papyros-2.3.1.tgz#9e6968350abaa66b49f9eee00206c86c8c7cacca"
+  integrity sha512-xY+5WrKG4yTWoAw0/QS9wTKXLeMGPifF271xSC/rjrUbmj1h3thbqAK5jkWdlvkM1qJ/Md/k7bwfkl9L0A7+sA==
   dependencies:
     "@codemirror/autocomplete" "^6.11.1"
     "@codemirror/commands" "^6.3.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1327,10 +1327,10 @@
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz#1d572bfbbe14b7704e0ba0f39b74815b84870d70"
   integrity sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==
 
-"@dodona/papyros@2.3.1":
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/@dodona/papyros/-/papyros-2.3.1.tgz#9e6968350abaa66b49f9eee00206c86c8c7cacca"
-  integrity sha512-xY+5WrKG4yTWoAw0/QS9wTKXLeMGPifF271xSC/rjrUbmj1h3thbqAK5jkWdlvkM1qJ/Md/k7bwfkl9L0A7+sA==
+"@dodona/papyros@2.3.2":
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/@dodona/papyros/-/papyros-2.3.2.tgz#4572f1a7a70a4c0b731bc5d0d116e364e198af34"
+  integrity sha512-rCQYQxggtlWEPkj8srGYlJFX+dKH4JTJAEUeU4N+35bN3VfATdscLaqHd/kLRoM6fUsbl9IZRWsn7GIRSjI4OQ==
   dependencies:
     "@codemirror/autocomplete" "^6.11.1"
     "@codemirror/commands" "^6.3.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1327,10 +1327,10 @@
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz#1d572bfbbe14b7704e0ba0f39b74815b84870d70"
   integrity sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==
 
-"@dodona/papyros@2.3.0-beta.1":
-  version "2.3.0-beta.1"
-  resolved "https://registry.yarnpkg.com/@dodona/papyros/-/papyros-2.3.0-beta.1.tgz#51471176405a4cdd1c27bde3a3d0c6eac441615d"
-  integrity sha512-ek2oS9Xu3QG8cNFOlBrwZ4i2b5yLpGJajq57AptYD7UDjwK1FWeJNH4vLcI5NNlRwIdBj9AqE78ZLH/f9U/J7Q==
+"@dodona/papyros@2.3.0-beta.4":
+  version "2.3.0-beta.4"
+  resolved "https://registry.yarnpkg.com/@dodona/papyros/-/papyros-2.3.0-beta.4.tgz#bc7fcc332719066c02c3b3d0b2bcfa43d1cf3e71"
+  integrity sha512-4qYlY9othouu9Ti/k62RpqTRW0S6H3v4KpyL4zLf/CmzOTtwMPertamoy9BNT7ZiS7ouFdS0Zk6JMxEWqhAixg==
   dependencies:
     "@codemirror/autocomplete" "^6.11.1"
     "@codemirror/commands" "^6.3.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1327,10 +1327,10 @@
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz#1d572bfbbe14b7704e0ba0f39b74815b84870d70"
   integrity sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==
 
-"@dodona/papyros@2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@dodona/papyros/-/papyros-2.2.0.tgz#eb80c8d9263c7e8cefbf55661b884736f02bf892"
-  integrity sha512-DGXKWegvOMWEGhxNoYVwNkWwF3Y+odWc8is6qiLlETKCh78rvw5fUlb0mGhWRw7VPZANxAOqXa4O9royJnp5YQ==
+"@dodona/papyros@2.3.0-beta.1":
+  version "2.3.0-beta.1"
+  resolved "https://registry.yarnpkg.com/@dodona/papyros/-/papyros-2.3.0-beta.1.tgz#51471176405a4cdd1c27bde3a3d0c6eac441615d"
+  integrity sha512-ek2oS9Xu3QG8cNFOlBrwZ4i2b5yLpGJajq57AptYD7UDjwK1FWeJNH4vLcI5NNlRwIdBj9AqE78ZLH/f9U/J7Q==
   dependencies:
     "@codemirror/autocomplete" "^6.11.1"
     "@codemirror/commands" "^6.3.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1327,10 +1327,10 @@
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz#1d572bfbbe14b7704e0ba0f39b74815b84870d70"
   integrity sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==
 
-"@dodona/papyros@2.3.0-beta.4":
-  version "2.3.0-beta.4"
-  resolved "https://registry.yarnpkg.com/@dodona/papyros/-/papyros-2.3.0-beta.4.tgz#bc7fcc332719066c02c3b3d0b2bcfa43d1cf3e71"
-  integrity sha512-4qYlY9othouu9Ti/k62RpqTRW0S6H3v4KpyL4zLf/CmzOTtwMPertamoy9BNT7ZiS7ouFdS0Zk6JMxEWqhAixg==
+"@dodona/papyros@2.3.0-beta.5":
+  version "2.3.0-beta.5"
+  resolved "https://registry.yarnpkg.com/@dodona/papyros/-/papyros-2.3.0-beta.5.tgz#61b6401a1983e6cf41992327fc3381cec8a529db"
+  integrity sha512-3qedP+GpV23nU1c63mApsNqCPwjK7p5YwNRMZRjVNF0CV/39+tWrRNGXSqF4Fgq6qWGCR8dhWBanuo0dKZUvEA==
   dependencies:
     "@codemirror/autocomplete" "^6.11.1"
     "@codemirror/commands" "^6.3.1"
@@ -1349,7 +1349,7 @@
     comsync "^0.0.9"
     escape-html "^1.0.3"
     file-loader "^6.2.0"
-    i18n-js "4.4.0"
+    i18n-js "4.4.3"
     pyodide "^0.22.0"
     pyodide-worker-runner "1.3.2"
     sync-message "^0.0.12"
@@ -4858,10 +4858,10 @@ human-signals@^1.1.1:
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-1.1.1.tgz#c5b1cd14f50aeae09ab6c59fe63ba3395fe4dfa3"
   integrity sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==
 
-i18n-js@4.4.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/i18n-js/-/i18n-js-4.4.0.tgz#fddb46ea7dec8fbdb20176a7d89f0b2dba5035d5"
-  integrity sha512-nAOY1z+lPX4dCEUbl9Uw7JtrJFRDjQm7XLk5Lf8iQYFOwZ0yA//jzp42r+OwOt7SazUkYr55R6Dt9ziQGUlxFQ==
+i18n-js@4.4.3:
+  version "4.4.3"
+  resolved "https://registry.yarnpkg.com/i18n-js/-/i18n-js-4.4.3.tgz#09744ddd377261f614502cc5622ce6981026ea4a"
+  integrity sha512-QIIyvJ+wOKdigL4BlgwiFFrpoXeGdlC8EYgori64YSWm1mnhNYYjIfRu5wETFrmiNP2fyD6xIjVG8dlzaiQr/A==
   dependencies:
     bignumber.js "*"
     lodash "*"


### PR DESCRIPTION
This pull request adds a debug state to the papyros editor.

related papyros pr: https://github.com/dodona-edu/papyros/pull/629

> When a debug run is started, the editor becomes readonly.
All visualization of generated output, input used and active line is now based on the shown frame instead of the current phase of execution.
While the debug mode is active, the buttons to start a new execution are replaced by an end debug mode button.
![Peek 2024-02-16 10-30](https://github.com/dodona-edu/papyros/assets/21177904/6dcf196d-6069-4d72-956c-eb290a2af51d)

