### PR TITLE
Add extra validation when editing all labels by CSV

### DIFF
--- a/app/controllers/course_members_controller.rb
+++ b/app/controllers/course_members_controller.rb
@@ -83,6 +83,11 @@ class CourseMembersController < ApplicationController
     return render json: { message: I18n.t('course_members.upload_labels_csv.no_file') }, status: :unprocessable_entity if params[:file] == 'undefined'
 
     begin
+      headers = CSV.foreach(params[:file].path).first
+      %w[id labels].each do |column|
+        return render json: { message: I18n.t('course_members.upload_labels_csv.missing_column', column: column) }, status: :unprocessable_entity unless headers&.include?(column)
+      end
+
       CSV.foreach(params[:file].path, headers: true) do |row|
         row = row.to_hash
         cm = CourseMembership.find_by(user_id: row['id'], course: @course)

--- a/config/locales/views/course_members/en.yml
+++ b/config/locales/views/course_members/en.yml
@@ -33,3 +33,4 @@ en:
     upload_labels_csv:
       no_file: "Please upload a file."
       malformed: Something went wrong while reading the file. Check that the file you uploaded is in the correct format.
+      missing_column: "We couldn't find the column \"%{column}\". Check that the file you uploaded is in the correct format."

--- a/config/locales/views/course_members/nl.yml
+++ b/config/locales/views/course_members/nl.yml
@@ -33,4 +33,5 @@ nl:
     upload_labels_csv:
       no_file: "Gelieve een bestand op te laden."
       malformed: Er ging iets mis bij het inlezen van het bestand. Controleer of het aangepaste bestand aan de voorwaarden voldoet.
+      missing_column: "We konden de kolom \"%{column}\" niet vinden. Controleer of het aangepaste bestand aan de voorwaarden voldoet."
 


### PR DESCRIPTION
This pull request adds an extra validation when uploading user labels.

This way we give a proper error for valid CSV files that do not contain the correct columns.
![image](https://github.com/dodona-edu/dodona/assets/21177904/dc059d3b-75db-44f7-bc25-dd151b92a138)


Closes #5367
