### PR TITLE
Add tips that nudge users to better use of Dodona

### DIFF
--- a/app/assets/javascripts/series.ts
+++ b/app/assets/javascripts/series.ts
@@ -111,6 +111,7 @@ function initSeriesEdit(): void {
         new Toast(i18n.t("js.activity-added-success"));
         row.querySelector("a.remove-activity").addEventListener("click", removeActivity);
         row.classList.remove("pending");
+        updateActivityCountCallout();
     }
 
     function addingActivityFailed(row: HTMLTableRowElement, addButton: HTMLButtonElement): void {
@@ -128,6 +129,7 @@ function initSeriesEdit(): void {
         row.classList.remove("pending");
         setTimeout( () => {
             row.remove();
+            updateActivityCountCallout();
         }, 500);
         new Toast(i18n.t("js.activity-removed-success"));
         const addButton = document.querySelector(`a.add-activity[data-activity_id="${(row.querySelector("a.remove-activity") as HTMLElement).dataset.activity_id}"`);
@@ -140,6 +142,12 @@ function initSeriesEdit(): void {
         row.classList.remove("pending");
         removeButton.classList.remove("hidden");
         new Toast(i18n.t("js.activity-removed-failed"));
+    }
+
+    function updateActivityCountCallout(): void {
+        const count = document.querySelector(".series-activity-list tbody").children.length;
+        document.getElementById("to-few-activities-info").classList.toggle("d-none", count >= 3);
+        document.getElementById("to-many-activities-info").classList.toggle("d-none", count <= 10);
     }
 
     init();

--- a/app/models/judge.rb
+++ b/app/models/judge.rb
@@ -11,6 +11,7 @@
 #  renderer     :string(255)      not null
 #  remote       :string(255)
 #  clone_status :integer          default("queued"), not null
+#  deprecated   :boolean          default(FALSE), not null
 #
 
 class Judge < ApplicationRecord

--- a/app/policies/judge_policy.rb
+++ b/app/policies/judge_policy.rb
@@ -35,7 +35,7 @@ class JudgePolicy < ApplicationPolicy
 
   def permitted_attributes
     if user&.zeus?
-      %i[name image renderer remote]
+      %i[name image renderer remote deprecated]
     else
       []
     end

--- a/app/views/activities/show.html.erb
+++ b/app/views/activities/show.html.erb
@@ -25,6 +25,15 @@ end %>
 
 <%= render partial: 'draft_notice' %>
 
+<% if @activity.draft? && @activity.exercise? && @activity.judge.deprecated? %>
+  <div class="callout callout-info">
+    <h4><%= t '.tips.title' %></h4>
+    <p>
+      <%= t '.tips.deprecated_judge_html', judge: @activity.judge.name %>
+    </p>
+  </div>
+<% end %>
+
 <div class="row">
   <% if @activity.exercise? %>
     <div class="col-md-1 p-0">

--- a/app/views/activities/show.html.erb
+++ b/app/views/activities/show.html.erb
@@ -27,7 +27,10 @@ end %>
 
 <% if @activity.draft? && @activity.exercise? && @activity.judge.deprecated? %>
   <div class="callout callout-info">
-    <h4><%= t '.tips.title' %></h4>
+    <h4>
+      <i class="mdi mdi-lightbulb-outline"></i>
+      <%= t '.tips.title' %>
+    </h4>
     <p>
       <%= t '.tips.deprecated_judge_html', judge: @activity.judge.name %>
     </p>

--- a/app/views/judges/_form.html.erb
+++ b/app/views/judges/_form.html.erb
@@ -39,4 +39,12 @@
     <div class="col-sm-6"><%= f.select :renderer, FeedbackTableRenderer.renderers.map {|r| r.to_s}, {}, {class: "form-select"} %></div>
     <span class="help-block offset-sm-3 col-sm-6"><%= t ".renderer_help" %></span>
   </div>
+  <div class="field form-group row">
+    <%= f.label :deprecated, :class => "col-sm-3 col-form-label" %>
+    <div class="col-sm-6 mt-2">
+      <div class="form-check">
+        <%= f.check_box :deprecated, class: "form-check-input " %>
+      </div>
+    </div>
+  </div>
 <% end %>

--- a/app/views/series/edit.html.erb
+++ b/app/views/series/edit.html.erb
@@ -55,7 +55,10 @@
             <p class="h3-info-text"><%= t ".manage_activities_info" %></p>
             <% if @series.activities.count < 3 || @series.activities.count > 10 %>
               <div class="callout callout-info">
-                <h4><%= t '.tips.title' %></h4>
+                <h4>
+                  <i class="mdi mdi-lightbulb-outline"></i>
+                  <%= t '.tips.title' %>
+                </h4>
                 <p>
                   <%= t '.tips.ideal_activity_count' %>
                   <%= @series.activities.count < 3 ? t('.tips.increase_activities') : t('.tips.decrease_activities')%>

--- a/app/views/series/edit.html.erb
+++ b/app/views/series/edit.html.erb
@@ -53,6 +53,15 @@
               </div>
             </div>
             <p class="h3-info-text"><%= t ".manage_activities_info" %></p>
+            <% if @series.activities.count < 3 || @series.activities.count > 10 %>
+              <div class="callout callout-info">
+                <h4><%= t '.tips.title' %></h4>
+                <p>
+                  <%= t '.tips.ideal_activity_count' %>
+                  <%= @series.activities.count < 3 ? t('.tips.increase_activities') : t('.tips.decrease_activities')%>
+                </p>
+              </div>
+            <% end %>
             <h4><%= t ".activities_in_series" %></h4>
             <p class="h4-info-text"><%= t ".activities_in_series_info" %></p>
             <div class="series-activity-list">

--- a/app/views/series/edit.html.erb
+++ b/app/views/series/edit.html.erb
@@ -53,18 +53,26 @@
               </div>
             </div>
             <p class="h3-info-text"><%= t ".manage_activities_info" %></p>
-            <% if @series.activities.count < 3 || @series.activities.count > 10 %>
-              <div class="callout callout-info">
-                <h4>
-                  <i class="mdi mdi-lightbulb-outline"></i>
-                  <%= t '.tips.title' %>
-                </h4>
-                <p>
-                  <%= t '.tips.ideal_activity_count' %>
-                  <%= @series.activities.count < 3 ? t('.tips.increase_activities') : t('.tips.decrease_activities')%>
-                </p>
-              </div>
-            <% end %>
+            <div class="callout callout-info <%= @series.activities.count < 3 ? "" : "d-none" %>" id="to-few-activities-info">
+              <h4>
+                <i class="mdi mdi-lightbulb-outline"></i>
+                <%= t '.tips.title' %>
+              </h4>
+              <p>
+                <%= t '.tips.ideal_activity_count' %>
+                <%= t('.tips.increase_activities')%>
+              </p>
+            </div>
+            <div class="callout callout-info <%= @series.activities.count > 10 ? "" : "d-none" %>" id="to-many-activities-info">
+              <h4>
+                <i class="mdi mdi-lightbulb-outline"></i>
+                <%= t '.tips.title' %>
+              </h4>
+              <p>
+                <%= t '.tips.ideal_activity_count' %>
+                <%= t('.tips.decrease_activities')%>
+              </p>
+            </div>
             <h4><%= t ".activities_in_series" %></h4>
             <p class="h4-info-text"><%= t ".activities_in_series_info" %></p>
             <div class="series-activity-list">

--- a/app/views/submissions/_description.html.erb
+++ b/app/views/submissions/_description.html.erb
@@ -80,7 +80,10 @@
 
 <% if submission.exercise.draft? && submission.internal_error? %>
   <div class="callout callout-info">
-    <h4><%= t 'submissions.show.tips.title' %></h4>
+    <h4>
+      <i class="mdi mdi-lightbulb-outline"></i>
+      <%= t 'submissions.show.tips.title' %>
+    </h4>
     <p>
       <%= t 'submissions.show.tips.internal_error_html' %>
     </p>

--- a/app/views/submissions/_description.html.erb
+++ b/app/views/submissions/_description.html.erb
@@ -78,6 +78,15 @@
   </div>
 </div>
 
+<% if submission.exercise.draft? && submission.internal_error? %>
+  <div class="callout callout-info">
+    <h4><%= t 'submissions.show.tips.title' %></h4>
+    <p>
+      <%= t 'submissions.show.tips.internal_error_html' %>
+    </p>
+  </div>
+<% end %>
+
 <% unless submission.queued? or submission.running? %>
   <%= submission.judge.renderer.new(submission, current_user).parse %>
 <% end %>

--- a/config/locales/models/en.yml
+++ b/config/locales/models/en.yml
@@ -88,6 +88,7 @@ en:
         image: Docker image
         path: Path
         renderer: Rendering class
+        deprecated: Deprecated
       repository:
         name: Name
         remote: Clone URL

--- a/config/locales/models/nl.yml
+++ b/config/locales/models/nl.yml
@@ -89,6 +89,7 @@ nl:
         image: Docker image
         path: Padnaam
         renderer: Renderklasse
+        deprecated: Deprecated
       repository:
         name: Naam
         remote: Clone URL

--- a/config/locales/views/activities/en.yml
+++ b/config/locales/views/activities/en.yml
@@ -110,6 +110,9 @@ en:
         valid_config: "The exercise must have a valid configuration file."
         is_valid: "The exercise must have a name and a description."
         correct_submission: "You must submit at least one correct solution."
+      tips:
+        title: Tip
+        deprecated_judge_html: "You are using the legacy %{judge} judge. For new exercises, we recommend switching to the TESTed for a better experience. See <a href='https://docs.dodona.be/nl/guides/exercises/testsuites/' target='_blank'>our documentation</a> for how to make the switch."
     series_activities_add_table:
       course_added_to_usable: "Adding this exercise will allow this course to use all of the private exercises in this exercise's repository. Are you sure?"
     edit:

--- a/config/locales/views/activities/en.yml
+++ b/config/locales/views/activities/en.yml
@@ -112,7 +112,7 @@ en:
         correct_submission: "You must submit at least one correct solution."
       tips:
         title: Tip
-        deprecated_judge_html: "You are using the legacy %{judge} judge. For new exercises, we recommend switching to the TESTed for a better experience. See <a href='https://docs.dodona.be/nl/guides/exercises/testsuites/' target='_blank'>our documentation</a> for how to make the switch."
+        deprecated_judge_html: "You are using the legacy %{judge} judge. For new exercises, we recommend switching to the TESTed judge for a better experience. See <a href='https://docs.dodona.be/nl/guides/exercises/testsuites/' target='_blank'>our documentation</a> for how to make the switch."
     series_activities_add_table:
       course_added_to_usable: "Adding this exercise will allow this course to use all of the private exercises in this exercise's repository. Are you sure?"
     edit:

--- a/config/locales/views/activities/nl.yml
+++ b/config/locales/views/activities/nl.yml
@@ -110,6 +110,9 @@ nl:
         valid_config: "De oefening moet een geldig configuratiebestand hebben."
         is_valid: "De oefening moet een naam en een beschrijving hebben."
         correct_submission: "Je moet minstens één correcte oplossing indienen."
+      tips:
+        title: Tip
+        deprecated_judge_html: "Je gebruikt de verouderde %{judge} judge. Voor nieuwe oefeningen raden we aan om over te schakelen naar de TESTed judge voor een betere ervaring. Zie <a href='https://docs.dodona.be/nl/guides/exercises/testsuites/' target='_blank'>onze documentatie</a> voor hoe je de overstap maakt."
     series_activities_add_table:
       course_added_to_usable: "Deze oefening toevoegen zal deze cursus toegang geven tot alle privé oefeningen in de repository van deze oefening. Ben je zeker?"
     edit:

--- a/config/locales/views/series/en.yml
+++ b/config/locales/views/series/en.yml
@@ -49,6 +49,11 @@ en:
       confidential: Confidential information
       access-link: Secret link
       access-help: If the visibility of the series is set to hidden, students will get access to it when using this secret link.
+      tips:
+        title: Tip
+        ideal_activity_count: "Dodona works best if series contain between 3 and 10 exercises."
+        increase_activities: "Consider adding more exercises below."
+        decrease_activities: "Adding more can affect loading times."
     delete:
       title: Delete series
       confirm: Please confirm you want to delete this series.

--- a/config/locales/views/series/nl.yml
+++ b/config/locales/views/series/nl.yml
@@ -49,6 +49,11 @@ nl:
       confidential: Geheime links en tokens
       access-link: Geheime link
       access-help: Als de zichtbaarheid van de reeks op verborgen staat ingesteld, dan krijgen studenten met deze geheime link toegang.
+      tips:
+        title: Tip
+        ideal_activity_count: "Dodona werkt het best als reeksen 3 tot 10 oefeningen bevatten."
+        increase_activities: "Overweeg om meer oefeningen toe te voegen."
+        decrease_activities: "Het toevoegen van meer oefeningen kan de laadtijden beïnvloeden."
     delete:
       title: Reeks verwijderen
       confirm: Ben je zeker dat je deze reeks wilt verwijderen?

--- a/config/locales/views/submissions/en.yml
+++ b/config/locales/views/submissions/en.yml
@@ -75,3 +75,6 @@ en:
       cut_off_message:
         one: Your output has been cut off as it is much longer than expected. You produced %{generated} characters while only one character was expected.
         other: Your output has been cut off as it is much longer than expected. You produced %{generated} characters while only %{count} characters were expected.
+      tips:
+        title: Tip
+        internal_error_html: "Facing an internal error? This usually indicates a problem with your exercise or test configuration. Check <a href='https://docs.dodona.be/en/guides/exercises/' target='_blank'>our documentation</a> for guidance or <a href='/en/contact' target='_blank'>reach out to us</a> for assistance."

--- a/config/locales/views/submissions/nl.yml
+++ b/config/locales/views/submissions/nl.yml
@@ -75,3 +75,6 @@ nl:
       cut_off_message:
         one: De uitvoer van je programma is ingekort aangezien je veel meer uitvoer had dan het verwachte resultaat. Je genereerde %{generated} karakters terwijl er slechts één karakter verwacht werd.
         other: De uitvoer van je programma is ingekort aangezien je veel meer uitvoer had dan het verwachte resultaat. Je genereerde %{generated} karakters terwijl er slechts %{count} karakters verwacht werden.
+      tips:
+        title: Tip
+        internal_error_html: "Ervaar je een interne fout? Dit duidt meestal op een probleem met je oefening of testconfiguratie. Bekijk <a href='https://docs.dodona.be/nl/guides/exercises/' target='_blank'>onze documentatie</a> voor hulp of <a href='/nl/contact' target='_blank'>neem contact met ons op</a> voor assistentie."

--- a/db/migrate/20240226090515_add_deprecated_to_judges.rb
+++ b/db/migrate/20240226090515_add_deprecated_to_judges.rb
@@ -1,0 +1,5 @@
+class AddDeprecatedToJudges < ActiveRecord::Migration[7.1]
+  def change
+    add_column :judges, :deprecated, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_11_07_160330) do
+ActiveRecord::Schema[7.1].define(version: 2024_02_26_090515) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -333,6 +333,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_11_07_160330) do
     t.string "renderer", null: false
     t.string "remote"
     t.integer "clone_status", default: 1, null: false
+    t.boolean "deprecated", default: false, null: false
     t.index ["name"], name: "index_judges_on_name", unique: true
   end
 

--- a/test/factories/judges.rb
+++ b/test/factories/judges.rb
@@ -11,6 +11,7 @@
 #  renderer     :string(255)      not null
 #  remote       :string(255)
 #  clone_status :integer          default("queued"), not null
+#  deprecated   :boolean          default(FALSE), not null
 #
 
 require "#{File.dirname(__FILE__)}/../testhelpers/stub_helper.rb"

--- a/test/fixtures/judges.yml
+++ b/test/fixtures/judges.yml
@@ -11,6 +11,7 @@
 #  renderer     :string(255)      not null
 #  remote       :string(255)
 #  clone_status :integer          default("queued"), not null
+#  deprecated   :boolean          default(FALSE), not null
 #
 
 python_judge:

--- a/test/models/judge_test.rb
+++ b/test/models/judge_test.rb
@@ -11,6 +11,7 @@
 #  renderer     :string(255)      not null
 #  remote       :string(255)
 #  clone_status :integer          default("queued"), not null
+#  deprecated   :boolean          default(FALSE), not null
 #
 
 require 'test_helper'


### PR DESCRIPTION
This pull request introduces user tips in Dodona. These tips are meant to nudge users in the right direction, so they can make use of Dodona in the most optimal way.

![image](https://github.com/dodona-edu/dodona/assets/21177904/ef2c2950-f581-44ae-aaee-28a89f785dbb)
For the above notice I had to introduce a database column that tracks if a judge is deprecated
![image](https://github.com/dodona-edu/dodona/assets/21177904/3f662a2f-71a7-4dec-9255-6aa3d1c5a184)

![image](https://github.com/dodona-edu/dodona/assets/21177904/57c4bd7d-fe27-4707-b2e0-b867d914df66)
![image](https://github.com/dodona-edu/dodona/assets/21177904/53fa47fe-b588-4cf2-a537-d444ea55f87c)
These notices are dynamically added or removed when changing the number of exercises.

![image](https://github.com/dodona-edu/dodona/assets/21177904/56f478d3-3c6b-4251-aa92-af2b1587b344)



Closes #5335
