### PR TITLE
Create card with a link to our documentation to help teachers get started

### DIFF
--- a/app/assets/stylesheets/bootstrap_css_variable_overrides.css.scss
+++ b/app/assets/stylesheets/bootstrap_css_variable_overrides.css.scss
@@ -38,10 +38,11 @@
   --bs-danger-rgb: var(--d-danger-rgb);
   --bs-light: $neutral-90;
   --bs-dark: $neutral-25;
+  --bs-secondary-text-emphasis: var(--d-on-secondary-container);
+  --bs-secondary-bg-subtle: var(--d-secondary-container);
 
   // not overwritten
   // --bs-primary-text-emphasis: #052c65;
-  // --bs-secondary-text-emphasis: #2b2f32;
   // --bs-success-text-emphasis: #0a3622;
   // --bs-info-text-emphasis: #055160;
   // --bs-warning-text-emphasis: #664d03;

--- a/app/views/pages/_teacher_intro_card.html.erb
+++ b/app/views/pages/_teacher_intro_card.html.erb
@@ -1,15 +1,13 @@
-<div class="card">
-  <div class="card-supporting-text">
-    <h2 class="card-title-text mb-3">
-      <%= t ".title" %>
-    </h2>
-    <% if current_user.student? %>
-      <p>
-        <%= t ".rights_request_html" %>
-      </p>
-    <% end %>
+<div class="alert alert-secondary">
+  <h2 class="card-title-text mb-3">
+    <%= t ".title" %>
+  </h2>
+  <% if current_user.student? %>
     <p>
-      <%= t ".documentation_html" %>
+      <%= t ".rights_request_html" %>
     </p>
-  </div>
+  <% end %>
+  <p>
+    <%= t ".documentation_html" %>
+  </p>
 </div>

--- a/app/views/pages/_teacher_intro_card.html.erb
+++ b/app/views/pages/_teacher_intro_card.html.erb
@@ -1,0 +1,15 @@
+<div class="card">
+  <div class="card-supporting-text">
+    <h2 class="card-title-text mb-3">
+      <%= t ".title" %>
+    </h2>
+    <% if current_user.student? %>
+      <p>
+        <%= t ".rights_request_html" %>
+      </p>
+    <% end %>
+    <p>
+      <%= t ".documentation_html" %>
+    </p>
+  </div>
+</div>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -38,6 +38,9 @@
   <div class="col-12 col-md-6 col-lg-4">
     <div class="row">
       <div class="col-12">
+        <% if current_user.administrating_courses.empty? && (current_user.staff? || current_user.institution&.users&.count == 1) %>
+          <%= render partial: 'teacher_intro_card' %>
+        <% end %>
         <%= render "user_card" %>
         <% if current_user.pending_courses.any? %>
           <%= render "pending_courses_card" %>

--- a/config/locales/views/pages/en.yml
+++ b/config/locales/views/pages/en.yml
@@ -158,3 +158,8 @@ en:
       supported_by: Supported by
       supported_p1_html: "Dodona is run by a small team of researchers at <a href='https://www.ugent.be/en' target='_blank'>Ghent University</a>. The platform is open source and all code is available on <a href='https://github.com/dodona-edu/dodona' target='_blank'>GitHub</a>. The hosting is provided by Ghent University. In addition, Dodona is supported by educational innovation projects from Ghent University and the Faculty of Sciences. <a href='https://www.elixir-belgium.org/' target='_blank'>ELIXIR Belgium</a> also provides some funding."
       support_button: Make a donation
+    teacher_intro_card:
+      title: Create your own course
+      rights_request_html: "<a href='/en/rights_requests/new/'>Request teacher rights</a> to be able to create your own courses."
+      documentation_html: "In <a href='https://docs.dodona.be/nl/guides/teachers/getting-started/' target='_blank'>our documentation</a> you can find more information about how to get started with Dodona as a teacher in."
+

--- a/config/locales/views/pages/en.yml
+++ b/config/locales/views/pages/en.yml
@@ -161,5 +161,5 @@ en:
     teacher_intro_card:
       title: Create your own course
       rights_request_html: "<a href='/en/rights_requests/new/'>Request teacher rights</a> to be able to create your own courses."
-      documentation_html: "In <a href='https://docs.dodona.be/nl/guides/teachers/getting-started/' target='_blank'>our documentation</a> you can find more information about how to get started with Dodona as a teacher in."
+      documentation_html: "In <a href='https://docs.dodona.be/en/guides/teachers/getting-started/' target='_blank'>our documentation</a> you can find more information about how to get started with Dodona as a teacher in."
 

--- a/config/locales/views/pages/en.yml
+++ b/config/locales/views/pages/en.yml
@@ -161,5 +161,5 @@ en:
     teacher_intro_card:
       title: Start your own course today!
       rights_request_html: "<a href='/en/rights_requests/new/'>Request teacher rights</a> to be able to create your own courses."
-      documentation_html: "In <a href='https://docs.dodona.be/en/guides/teachers/getting-started/' target='_blank'>our documentation</a> you can find more information about how to get started with Dodona as a teacher in."
+      documentation_html: "Get detailed guidance on launching your own courses with Dodona by visiting <a href='https://docs.dodona.be/en/guides/teachers/getting-started/' target='_blank'>our documentation</a>."
 

--- a/config/locales/views/pages/en.yml
+++ b/config/locales/views/pages/en.yml
@@ -159,7 +159,7 @@ en:
       supported_p1_html: "Dodona is run by a small team of researchers at <a href='https://www.ugent.be/en' target='_blank'>Ghent University</a>. The platform is open source and all code is available on <a href='https://github.com/dodona-edu/dodona' target='_blank'>GitHub</a>. The hosting is provided by Ghent University. In addition, Dodona is supported by educational innovation projects from Ghent University and the Faculty of Sciences. <a href='https://www.elixir-belgium.org/' target='_blank'>ELIXIR Belgium</a> also provides some funding."
       support_button: Make a donation
     teacher_intro_card:
-      title: Create your own course
+      title: Start your own course today!
       rights_request_html: "<a href='/en/rights_requests/new/'>Request teacher rights</a> to be able to create your own courses."
       documentation_html: "In <a href='https://docs.dodona.be/en/guides/teachers/getting-started/' target='_blank'>our documentation</a> you can find more information about how to get started with Dodona as a teacher in."
 

--- a/config/locales/views/pages/nl.yml
+++ b/config/locales/views/pages/nl.yml
@@ -159,6 +159,6 @@ nl:
       supported_p1_html: "Dodona wordt ontwikkeld door een klein team onderzoekers aan de <a href='https://www.ugent.be' target='_blank'>Universiteit Gent</a>. Het platform is volledig open source en alle code is beschikbaar op <a href='https://github.com/dodona-edu/dodona' target='_blank'>GitHub</a>. De hosting wordt aangeboden door de Universiteit Gent. Daarnaast ontving Dodona al steun in de vorm van onderwijsinnovatieprojecten van de Universiteit Gent en de Faculteit Wetenschappen. Ook <a href='https://www.elixir-belgium.org/' target='_blank'>ELIXIR Belgium</a> ondersteunde dit project."
       support_button: Doe een gift
     teacher_intro_card:
-      title: Maak je eigen cursus
+      title: Maak je eigen cursus aan!
       rights_request_html: "<a href='/nl/rights_requests/new/'>Vraag lesgeversrechten aan</a> om eigen curussen te kunnen maken."
       documentation_html: "In <a href='https://docs.dodona.be/nl/guides/teachers/getting-started/' target='_blank'>onze documentatie</a> vind je alle informatie over hoe je vlot van start gaat met Dodona als leerkracht."

--- a/config/locales/views/pages/nl.yml
+++ b/config/locales/views/pages/nl.yml
@@ -160,5 +160,5 @@ nl:
       support_button: Doe een gift
     teacher_intro_card:
       title: Maak je eigen cursus aan!
-      rights_request_html: "<a href='/nl/rights_requests/new/'>Vraag lesgeversrechten aan</a> om eigen curussen te kunnen maken."
+      rights_request_html: "Wist je dat je je eigen cursussen op Dodona kunt maken? <a href='/nl/rights_requests/new/'>Vraag lesgeversrechten aan</a> om van start te gaan."
       documentation_html: "In <a href='https://docs.dodona.be/nl/guides/teachers/getting-started/' target='_blank'>onze documentatie</a> vind je alle informatie over hoe je vlot van start gaat met Dodona als leerkracht."

--- a/config/locales/views/pages/nl.yml
+++ b/config/locales/views/pages/nl.yml
@@ -158,3 +158,7 @@ nl:
       supported_by: Met de steun van
       supported_p1_html: "Dodona wordt ontwikkeld door een klein team onderzoekers aan de <a href='https://www.ugent.be' target='_blank'>Universiteit Gent</a>. Het platform is volledig open source en alle code is beschikbaar op <a href='https://github.com/dodona-edu/dodona' target='_blank'>GitHub</a>. De hosting wordt aangeboden door de Universiteit Gent. Daarnaast ontving Dodona al steun in de vorm van onderwijsinnovatieprojecten van de Universiteit Gent en de Faculteit Wetenschappen. Ook <a href='https://www.elixir-belgium.org/' target='_blank'>ELIXIR Belgium</a> ondersteunde dit project."
       support_button: Doe een gift
+    teacher_intro_card:
+      title: Maak je eigen cursus
+      rights_request_html: "<a href='/nl/rights_requests/new/'>Vraag lesgeversrechten aan</a> om eigen curussen te kunnen maken."
+      documentation_html: "In <a href='https://docs.dodona.be/nl/guides/teachers/getting-started/' target='_blank'>onze documentatie</a> vind je alle informatie over hoe je vlot van start gaat met Dodona als leerkracht."

--- a/config/locales/views/pages/nl.yml
+++ b/config/locales/views/pages/nl.yml
@@ -161,4 +161,4 @@ nl:
     teacher_intro_card:
       title: Maak je eigen cursus aan!
       rights_request_html: "Wist je dat je je eigen cursussen op Dodona kunt maken? <a href='/nl/rights_requests/new/'>Vraag lesgeversrechten aan</a> om van start te gaan."
-      documentation_html: "In <a href='https://docs.dodona.be/nl/guides/teachers/getting-started/' target='_blank'>onze documentatie</a> vind je alle informatie over hoe je vlot van start gaat met Dodona als leerkracht."
+      documentation_html: "Ontdek hoe je eigen cursus op Dodona kunt starten met hulp van <a href='https://docs.dodona.be/nl/guides/teachers/getting-started/' target='_blank'>onze documentatie</a>."


### PR DESCRIPTION
This pull request adds a card to the homepage that links to our documentation.

![image](https://github.com/dodona-edu/dodona/assets/21177904/629af387-c29c-45bc-a7ae-660751826420)

This card is visible for all teachers who are not admin of any course.

It is also visible for students who are the only members of their institution, as we assume the first users of an institution to most likely be teachers. 

![image](https://github.com/dodona-edu/dodona/assets/21177904/e9079a3b-4c1f-4f7d-92ba-c3f54b1087c9)

As said this card remains as long as the teacher is not administering any courses
![image](https://github.com/dodona-edu/dodona/assets/21177904/e98ec4c5-fec3-4fcb-b1c5-22204ff85ab3)

I'll make use of this occasion to update the linked documentation:
- [x] Documentation update can be found at dodona-edu/dodona-edu.github.io#400

Closes #3433
