### PR TITLE
Allow adding scores in submission export

### DIFF
--- a/app/controllers/exports_controller.rb
+++ b/app/controllers/exports_controller.rb
@@ -15,6 +15,7 @@ class ExportsController < ApplicationController
     @series = Series.find(params[:id])
     authorize @series, :export?
     authorize @user, :export? if @user
+    @has_scores = @user ? @series.evaluation&.users&.include?(@user) : @series.evaluation.present?
     @crumbs = [[@series.course.name, course_path(@series.course)], [@series.name, breadcrumb_series_path(@series, current_user)], [I18n.t('exports.download_submissions.title'), '#']]
     @data = { item: @series,
               users: ([@user] if @user),
@@ -30,6 +31,7 @@ class ExportsController < ApplicationController
     @course = Course.find(params[:id])
     authorize @course, :export?
     authorize @user, :export? if @user
+    @has_scores = @course.series.any? { |s| @user ? s.evaluation&.users&.include?(@user) : s.evaluation.present? }
     @crumbs = [[@course.name, course_path(@course)], [I18n.t('exports.download_submissions.title'), '#']]
     @data = { item: @course,
               users: ([@user] if @user),
@@ -42,6 +44,7 @@ class ExportsController < ApplicationController
   def new_user_export
     @user = User.find(params[:id])
     authorize @user, :export?
+    @has_scores = @user.courses.any? { |c| c.series.any? { |s| s.evaluation&.users&.include?(@user) } }
     @crumbs = [[@user.full_name, user_path(@user)], [I18n.t('exports.download_submissions.title'), '#']]
     @data = { item: @user,
               list: @user.courses,

--- a/app/helpers/export_helper.rb
+++ b/app/helpers/export_helper.rb
@@ -219,17 +219,21 @@ module ExportHelper
     def write_scores(zio)
       case @item
       when Series
-        if @item.evaluation.present?
-          zio.put_next_entry('scores.csv')
-          zio.write @item.evaluation.grades_csv
-        end
+        evaluations = [@item.evaluation].compact
       when Course
         evaluations = @list.map(&:evaluation).compact
-        return if evaluations.empty?
+      when User
+        evaluations = @list.flat_map(&:series).map(&:evaluation).compact
+      end
 
-        evaluations.each do |evaluation|
+      return if evaluations.empty?
+
+      evaluations.each do |evaluation|
+        csv = evaluation.grades_csv(@users)
+
+        if csv.present?
           zio.put_next_entry("scores/#{series_fn(evaluation.series)}.csv")
-          zio.write evaluation.grades_csv
+          zio.write csv
         end
       end
     end

--- a/app/models/evaluation.rb
+++ b/app/models/evaluation.rb
@@ -114,7 +114,11 @@ class Evaluation < ApplicationRecord
     end
   end
 
-  def grades_csv
+  def grades_csv(for_users = nil)
+    csv_users = users
+    csv_users = csv_users.where(id: for_users) if for_users.present?
+    return if csv_users.empty?
+
     sheet = evaluation_sheet
     users_labels = series.course.course_memberships
                          .includes(:course_labels, :user)
@@ -124,7 +128,7 @@ class Evaluation < ApplicationRecord
       headers = ['id', 'username', 'last_name', 'first_name', 'full_name', 'email', 'labels', 'Total Score', 'Total Max']
       headers += sheet[:evaluation_exercises].flat_map { |e| ["#{e.exercise.name} Score", "#{e.exercise.name} Max"] }
       csv << headers
-      users.order(last_name: :asc, first_name: :asc).each do |user|
+      csv_users.order(last_name: :asc, first_name: :asc).each do |user|
         feedback_l = sheet[:feedbacks][user.id]
         total_score = sheet[:totals][user.id]
         total_max = sheet[:evaluation_exercises].map(&:maximum_score).compact.sum

--- a/app/views/exports/download_submissions.html.erb
+++ b/app/views/exports/download_submissions.html.erb
@@ -57,7 +57,7 @@
               <%= form_with class: "form-horizontal", id: "download_submissions" do |form| %>
                 <input type="hidden" id="all_submissions" name="all" value="false">
                 <%= render partial: 'option', locals: { name: 'with_info', explanation: t('.with_info_label'), details: t('.with_info_label_help') } %>
-                <% if @series&.evaluation.present? || @course&.series&.map(&:evaluation)&.any? %>
+                <% if @has_scores %>
                   <%= render partial: 'option', locals: { name: 'with_scores', explanation: t('.with_scores'), details: t('.with_scores_help') } %>
                 <% end %>
                 <div class="form-group">

--- a/app/views/exports/download_submissions.html.erb
+++ b/app/views/exports/download_submissions.html.erb
@@ -57,6 +57,9 @@
               <%= form_with class: "form-horizontal", id: "download_submissions" do |form| %>
                 <input type="hidden" id="all_submissions" name="all" value="false">
                 <%= render partial: 'option', locals: { name: 'with_info', explanation: t('.with_info_label'), details: t('.with_info_label_help') } %>
+                <% if @series&.evaluation.present? || @course&.series&.map(&:evaluation)&.any? %>
+                  <%= render partial: 'option', locals: { name: 'with_scores', explanation: t('.with_scores'), details: t('.with_scores_help') } %>
+                <% end %>
                 <div class="form-group">
                   <strong class="col-sm-6 offset-sm-3"><%= t '.only_last_submission_label' %></strong>
                 </div>

--- a/config/locales/views/exports/en.yml
+++ b/config/locales/views/exports/en.yml
@@ -46,3 +46,5 @@ en:
       course: Course
       series: Series
       no_series: no-series
+      with_scores: Include the scores
+      with_scores_help: A CSV-file will be added for each evaluated series containing the scores of the students.

--- a/config/locales/views/exports/nl.yml
+++ b/config/locales/views/exports/nl.yml
@@ -46,3 +46,5 @@ nl:
       course: Cursus
       series: Reeks
       no_series: geen-reeks
+      with_scores: Voeg de punten toe
+      with_scores_help: Een CSV-bestand zal toegevoegd worden voor elke geëvalueerde reeks met de punten van de studenten.

--- a/test/controllers/exports_controller_test.rb
+++ b/test/controllers/exports_controller_test.rb
@@ -372,4 +372,13 @@ class ExportsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to exports_path
     assert_zip ActiveStorage::Blob.last.download, with_scores: false, data: @data
   end
+
+  test 'students should only see their own scores' do
+    create :evaluation, series: @series
+    sign_in @students[0]
+    post series_exports_path(@series), params: { with_scores: true, user_id: @students[0].id }
+
+    assert_redirected_to exports_path
+    assert_zip ActiveStorage::Blob.last.download, with_scores: true, data: @data, group_by: 'user', is_student: true
+  end
 end

--- a/test/testhelpers/export_zip_helper.rb
+++ b/test/testhelpers/export_zip_helper.rb
@@ -2,13 +2,17 @@ module SeriesZipHelper
   def assert_zip(zip_data, options = {})
     zipio = StringIO.new(zip_data)
     with_info = options[:with_info]
+    with_scores = options[:with_scores]
     Zip::File.open_buffer(zipio) do |zip|
       has_info = false
+      has_scores = false
       other_entries = 0
       zip.each do |entry|
         if entry.name == 'info.csv'
           has_info = true
           check_csv entry if with_info
+        elsif entry.name == 'scores.csv' || %r{scores/.*\.csv}.match(entry.name)
+          has_scores = true
         else
           check_entry(entry, options)
           other_entries += 1
@@ -19,6 +23,13 @@ module SeriesZipHelper
           assert has_info, 'zip file should contain info.csv but did not'
         else
           assert_not has_info, 'zip file should not contain info.csv but did'
+        end
+      end
+      unless with_scores.nil?
+        if with_scores
+          assert has_scores, 'zip file should contain scores but did not'
+        else
+          assert_not has_scores, 'zip file should not contain scores but did'
         end
       end
       assert_equal options[:solution_count], other_entries, 'unexpected submission count in csv' if options[:solution_count].present?

--- a/test/testhelpers/export_zip_helper.rb
+++ b/test/testhelpers/export_zip_helper.rb
@@ -11,8 +11,9 @@ module SeriesZipHelper
         if entry.name == 'info.csv'
           has_info = true
           check_csv entry if with_info
-        elsif entry.name == 'scores.csv' || %r{scores/.*\.csv}.match(entry.name)
+        elsif %r{scores/.*\.csv}.match(entry.name)
           has_scores = true
+          check_scores_csv entry, options
         else
           check_entry(entry, options)
           other_entries += 1
@@ -43,6 +44,19 @@ module SeriesZipHelper
     %w[filename status submission_id exercise_id name_nl name_en].each do |h|
       assert_includes header, "\"#{h}\"", "info.csv header did not include #{h}"
     end
+  end
+
+  def check_scores_csv(entry, options)
+    csv = entry.get_input_stream.read
+    header = csv.split("\n").first
+
+    ['id', 'username', 'last_name', 'first_name', 'full_name', 'email', 'labels', 'Total Score', 'Total Max'].each do |h|
+      assert_includes header, "\"#{h}\"", "scores.csv header did not include #{h}"
+    end
+
+    return unless options[:is_student]
+
+    assert_equal 2, csv.split("\n").length, "scores.csv should only contain one line for students"
   end
 
   def check_entry(entry, options)


### PR DESCRIPTION
This pull request adds the scores CSV to the submission export when the relevant option is checked

![image](https://github.com/dodona-edu/dodona/assets/21177904/ee6b02ce-bb8f-4f38-b8e6-f6f6a5b96ae2)

I chose the simplest implementation. This means the scores wont respond to filtering in users and activities etc...
We might implement these more advanced features should there ever be any demand.

Students now also get access to the scores export, as they had access to the submission export. For this reason I limited their CSVs to a single row with their own scores.
I see this as added value as this improves the options for the student to extract their information from dodona.

- [x] Tests were added

Closes #2503
