### PR TITLE
Add export of course users

### DIFF
--- a/app/assets/javascripts/components/search/search_actions.ts
+++ b/app/assets/javascripts/components/search/search_actions.ts
@@ -95,8 +95,14 @@ export class SearchActions extends DodonaElement {
     }
 
     async performAction(action: SearchAction): Promise<boolean> {
-        if (!action.action && !action.js) {
+        if (!action.action && !action.js && !action.url) {
             return true;
+        }
+
+        if (action.url) {
+            const url: string = searchQueryState.addParametersToUrl(action.url);
+            window.open(url);
+            return false;
         }
 
         if (!action.action) {
@@ -147,7 +153,6 @@ export class SearchActions extends DodonaElement {
                     ${this.getSearchActions().map(action => html`
                         <li>
                             <a class="action dropdown-item"
-                               href='${action.url ? action.url : "#"}'
                                data-type="${action.type}"
                                @click=${() => this.performAction(action)}
                             >

--- a/app/controllers/course_members_controller.rb
+++ b/app/controllers/course_members_controller.rb
@@ -33,11 +33,22 @@ class CourseMembersController < ApplicationController
     @course_memberships = apply_scopes(@course.course_memberships.order_by_status_in_course_and_name('ASC'))
                           .includes(:course_labels, user: [:institution])
                           .where(status: statuses)
-                          .paginate(page: parse_pagination_param(params[:page]))
 
     @title = I18n.t('courses.index.users')
     @crumbs = [[@course.name, course_path(@course)], [I18n.t('courses.index.users'), '#']]
     @course_labels = CourseLabel.where(course: @course)
+
+    respond_to do |format|
+      format.html do
+        @course_memberships = @course_memberships.paginate(page: parse_pagination_param(params[:page]))
+      end
+      format.js do
+        @course_memberships = @course_memberships.paginate(page: parse_pagination_param(params[:page]))
+      end
+      format.csv do
+        headers['Content-Disposition'] = "attachment; filename=\"#{@course.name} - #{I18n.t('courses.index.users')}.csv\""
+      end
+    end
   end
 
   def show

--- a/app/controllers/course_members_controller.rb
+++ b/app/controllers/course_members_controller.rb
@@ -81,15 +81,6 @@ class CourseMembersController < ApplicationController
     end
   end
 
-  def download_labels_csv
-    csv = @course.labels_csv
-    send_data csv[:data],
-              type: 'application/csv',
-              filename: csv[:filename],
-              disposition: 'attachment',
-              x_sendfile: true
-  end
-
   def upload_labels_csv
     return render json: { message: I18n.t('course_members.upload_labels_csv.no_file') }, status: :unprocessable_entity if params[:file] == 'undefined'
 

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -393,22 +393,6 @@ class Course < ApplicationRecord
     }
   end
 
-  def labels_csv
-    sorted_course_memberships = course_memberships
-                                .where.not(status: %i[unsubscribed pending])
-                                .includes(:user)
-                                .order(status: :asc)
-                                .order(Arel.sql('users.permission ASC'))
-                                .order(Arel.sql('users.last_name ASC'), Arel.sql('users.first_name ASC'))
-    data = CSV.generate(force_quotes: true) do |csv|
-      csv << %w[id username last_name first_name email labels]
-      sorted_course_memberships.each do |cm|
-        csv << [cm.user.id, cm.user.username, cm.user.last_name, cm.user.first_name, cm.user.email, cm.course_labels.map(&:name).join(';')]
-      end
-    end
-    { filename: "#{name}-users-labels.csv", data: data }
-  end
-
   def self.format_year(year)
     year.sub(/ ?- ?/, '–')
   end

--- a/app/views/annotations/question_index.html.erb
+++ b/app/views/annotations/question_index.html.erb
@@ -23,7 +23,7 @@
       <div class="card-supporting-text" id="question-container">
         <% actions = [] %>
         <% if current_user&.a_course_admin? %>
-          <% actions << { text: t('questions.index.watch'), search: { refresh: true }, click: 'window.dodona.toggleIndexReload()' } %>
+          <% actions << { text: t('questions.index.watch'), search: { refresh: true } } %>
           <% actions << { text: t('questions.index.everything'), search: { everything: true } } if @unfiltered %>
         <% end %>
         <%= render partial: 'layouts/searchbar', locals: { actions: actions, refresh_element: "#question-container", courses: @courses, question_states: Question.question_states.keys } %>

--- a/app/views/course_members/index.csv.erb
+++ b/app/views/course_members/index.csv.erb
@@ -1,13 +1,13 @@
 <%= CSV.generate_line %w[id username last_name first_name email correct_exercises attempted_exercises labels], row_sep: nil %>
 <% @course_memberships.each do |cm| %>
-  <%= CSV.generate_line([
-    cm.user.id,
-    cm.user.username,
-    cm.user.last_name,
-    cm.user.first_name,
-    cm.user.email,
-    cm.user.correct_exercises(course: @course),
-    cm.user.attempted_exercises(course: @course),
-    cm.course_labels.map(&:name).join(';')
- ], row_sep: nil).html_safe  %>
+<%= CSV.generate_line([
+  cm.user.id,
+  cm.user.username,
+  cm.user.last_name,
+  cm.user.first_name,
+  cm.user.email,
+  cm.user.correct_exercises(course: @course),
+  cm.user.attempted_exercises(course: @course),
+  cm.course_labels.map(&:name).join(';')
+], row_sep: nil).html_safe  %>
 <% end %>

--- a/app/views/course_members/index.csv.erb
+++ b/app/views/course_members/index.csv.erb
@@ -1,0 +1,4 @@
+<%= CSV.generate_line %w[id username last_name first_name email labels], row_sep: nil %>
+<% @course_memberships.each do |cm| %>
+  <%= CSV.generate_line([cm.user.id, cm.user.username, cm.user.last_name, cm.user.first_name, cm.user.email, cm.course_labels.map(&:name).join(';')], row_sep: nil).html_safe  %>
+<% end %>

--- a/app/views/course_members/index.csv.erb
+++ b/app/views/course_members/index.csv.erb
@@ -1,4 +1,13 @@
-<%= CSV.generate_line %w[id username last_name first_name email labels], row_sep: nil %>
+<%= CSV.generate_line %w[id username last_name first_name email correct_exercises attempted_exercises labels], row_sep: nil %>
 <% @course_memberships.each do |cm| %>
-  <%= CSV.generate_line([cm.user.id, cm.user.username, cm.user.last_name, cm.user.first_name, cm.user.email, cm.course_labels.map(&:name).join(';')], row_sep: nil).html_safe  %>
+  <%= CSV.generate_line([
+    cm.user.id,
+    cm.user.username,
+    cm.user.last_name,
+    cm.user.first_name,
+    cm.user.email,
+    cm.user.correct_exercises(course: @course),
+    cm.user.attempted_exercises(course: @course),
+    cm.course_labels.map(&:name).join(';')
+ ], row_sep: nil).html_safe  %>
 <% end %>

--- a/app/views/course_members/index.html.erb
+++ b/app/views/course_members/index.html.erb
@@ -82,6 +82,11 @@
                                text: t(".edit_all_labels"),
                                js: 'bootstrap.Modal.getOrCreateInstance(document.querySelector("#labelsUploadModal")).show()',
                                type: 'enrolled'
+                           },
+                           {
+                               icon: 'cloud-download',
+                               text: t(".download_user_csv"),
+                               url: course_members_path(@course, format: :csv),
                            }
                        ],
                        course_labels: @course_labels,

--- a/app/views/course_members/index.html.erb
+++ b/app/views/course_members/index.html.erb
@@ -35,7 +35,7 @@
                         <%= t ".first_download_labels" %>
                       </p>
                       <p>
-                        <a class="btn btn-outline" href="<%= download_labels_csv_course_members_path(@course) %>"><%= t ".download" %>
+                        <a class="btn btn-outline" href="<%= course_members_path(@course, format: :csv) %>"><%= t ".download" %>
                         </a>
                       </p>
                     </li>

--- a/app/views/submissions/index.html.erb
+++ b/app/views/submissions/index.html.erb
@@ -39,7 +39,7 @@
           <%
              actions << {icon: 'replay', text: t(".reevaluate_submissions"), confirm: t(".confirm_reevaluate_submissions"), action: mass_rejudge_submissions_path(user_id: @user&.id, activity_id: @activity&.id, course_id: @course&.id, series_id: @series&.id, judge_id: @judge&.id)} if policy(Submission).mass_rejudge?
              actions << {icon: 'done', text: t('.most_recent'), search: {most_recent_per_user: true}} if @activity
-             actions << {icon: 'file-eye', text: t('.watch_submissions'), search: {refresh: true}, click: 'window.dodona.toggleIndexReload()'}
+             actions << {icon: 'file-eye', text: t('.watch_submissions'), search: {refresh: true}}
           %>
         <% end %>
         <%= render partial: 'layouts/searchbar', locals: {actions: actions, course_labels: @course_labels, statuses: Submission.statuses.keys, refresh_element: "#refresh_element"} %>

--- a/config/locales/views/course_members/en.yml
+++ b/config/locales/views/course_members/en.yml
@@ -25,6 +25,7 @@ en:
       close: "Close"
       upload: "Upload changes"
       edit_all_labels: "Edit all labels"
+      download_user_csv: "Download user list"
       first_download_labels: "Download a list of all users and their labels as a CSV file."
       then_edit: "Open the file you just downloaded and edit the labels. Only changes to the labels column will be used. Note that the labels are in one field, separated by semicolons."
       finally_upload: "When you are happy with your changes, select the modified file below."

--- a/config/locales/views/course_members/nl.yml
+++ b/config/locales/views/course_members/nl.yml
@@ -25,6 +25,7 @@ nl:
       close: "Sluiten"
       upload: "Aanpassingen uploaden"
       edit_all_labels: "Alle labels bewerken"
+      download_user_csv: "Gebruikerslijst downloaden"
       first_download_labels: "Download een lijst van alle gebruikers en hun labels als een CSV bestand."
       then_edit: "Open het tekstbestand dat je net gedownload hebt, en pas de labels aan. Enkel wijzigingen aan de labels kolom zullen doorgevoerd worden. Merk op dat de labels in één veld zitten, gescheiden met puntkomma's."
       finally_upload: "Als je tevreden bent met je aanpassingen, selecteer hieronder dan het aangepaste bestand."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -98,7 +98,6 @@ Rails.application.routes.draw do
       resources :submissions, only: [:index]
       resources :activity_read_states, only: [:index]
       resources :members, only: %i[index show edit update], controller: :course_members do
-        get 'download_labels_csv', on: :collection
         post 'upload_labels_csv', on: :collection
       end
       member do

--- a/test/javascript/components/search/search_actions.test.ts
+++ b/test/javascript/components/search/search_actions.test.ts
@@ -58,7 +58,16 @@ describe("SearchActions", () => {
     });
 
     test("clicking a link action should navigate to the url", async () => {
-        expect(screen.getByText("link-test").closest("a").href).toBe("https://test.dodona.be/");
+        jest.spyOn(window, "open").mockImplementation(() => window);
+        await userEvent.click(screen.queryByText("link-test"));
+        expect(window.open).toHaveBeenCalledWith("https://test.dodona.be");
+    });
+
+    test("clicking a link action should add query params to the url", async () => {
+        jest.spyOn(window, "open").mockImplementation(() => window);
+        searchQueryState.queryParams.set("foo", "bar");
+        await userEvent.click(screen.queryByText("link-test"));
+        expect(window.open).toHaveBeenCalledWith("https://test.dodona.be/?foo=bar");
     });
 
     test("clicking a confirm action should show a confirmation dialog", async () => {


### PR DESCRIPTION
This pull request adds an export of all users in a course. 
![image](https://github.com/dodona-edu/dodona/assets/21177904/b62d725a-7783-4d90-9a38-7196840f02eb)

The csv is a different content type for the index api endpoint.
This means that all filters and sort features of the index page can also be applied.

The export now also includes the student progress in the course.
![image](https://github.com/dodona-edu/dodona/assets/21177904/e2bd6d3b-a125-46f0-9dec-d6c3d6e375f1)

This export also replaces the old specific export labels csv, in the edit all labels flow.

Closes #3617
