### PR TITLE
Fix SubmissionRunner ignoring errors while removing temporary directory with judge results

### DIFF
--- a/app/runners/submission_runner.rb
+++ b/app/runners/submission_runner.rb
@@ -275,7 +275,7 @@ class SubmissionRunner
     start_final = Time.zone.now
 
     # remove path on file system used as temporary working directory for processing the submission
-    FileUtils.remove_entry_secure(@mountsrc, verbose: true)
+    FileUtils.remove_entry_secure(@mountsrc)
     @mountsrc = nil
     end_final = Time.zone.now
     @time_messages << build_message(format('<strong>Finalize:</strong> %<time>.2f seconds', time: (end_final - start_final)), 'zeus', 'html')


### PR DESCRIPTION
This pull request  removes the non-existing argument `verbose: true` from the `FileUtils.remove_entry_secure` method, as it causes this method to silently ignore errors.

The method [FileUtils#remove_entry_secure](https://docs.ruby-lang.org/en/3.1/FileUtils.html#method-c-remove_entry_secure) has the following signature:

```ruby
def remove_entry_secure(path, force = false)
```

The `verbose: true` argument is actually translated to a hash, causing the parameter `force` to be truthy. Any errors thrown while removing the unwanted files, are ignored because of the last line of the method:

```ruby
  raise unless force
``` 

This was hiding errors in Dolos because of this bug (see the first two commits in: https://github.com/dodona-edu/dolos/pull/1413).
