### PR TITLE
Don't show series info on activity show if activity not in series

### DIFF
--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -114,6 +114,9 @@ class ActivitiesController < ApplicationController
     raise Pundit::NotAuthorizedError, 'Not allowed' unless @activity.accessible?(current_user, @course)
 
     @series = Series.find_by(id: params[:series_id])
+    # Double check if activity still exists within this series, redirect to course activity if it does not
+    redirect_to helpers.activity_scoped_path(activity: @activity, course: @course) if @series&.activities&.exclude?(@activity)
+
     @not_registered = @course && !current_user&.member_of?(@course)
     flash.now[:alert] = I18n.t('activities.show.not_a_member') if @not_registered
     @current_membership = CourseMembership.where(course: @course, user: current_user).first if @lti_launch && @not_registered

--- a/test/controllers/activities_controller_test.rb
+++ b/test/controllers/activities_controller_test.rb
@@ -838,7 +838,7 @@ class ActivitiesPermissionControllerTest < ActionDispatch::IntegrationTest
 
     get course_series_activity_url(right_course, wrong_series, right_exercise)
 
-    assert_redirected_to root_url
+    assert_redirected_to course_activity_url(right_course, right_exercise)
   end
 
   test 'should not show activity if series not in course' do

--- a/test/controllers/activities_controller_test.rb
+++ b/test/controllers/activities_controller_test.rb
@@ -823,6 +823,40 @@ class ActivitiesPermissionControllerTest < ActionDispatch::IntegrationTest
     assert exercise.reload.draft
     assert_equal 'new name', exercise.name_en
   end
+
+  test 'should not show activity if not in series' do
+    right_course = create :course
+    right_series = create :series, course: right_course
+    right_exercise = create :exercise
+    right_series.exercises << right_exercise
+
+    get course_series_activity_url(right_course, right_series, right_exercise)
+
+    assert_response :success
+
+    wrong_series = create :series, course: right_course
+
+    get course_series_activity_url(right_course, wrong_series, right_exercise)
+
+    assert_redirected_to root_url
+  end
+
+  test 'should not show activity if series not in course' do
+    right_course = create :course
+    right_series = create :series, course: right_course
+    right_exercise = create :exercise
+    right_series.exercises << right_exercise
+
+    get course_series_activity_url(right_course, right_series, right_exercise)
+
+    assert_response :success
+
+    wrong_course = create :course
+
+    get course_series_activity_url(wrong_course, right_series, right_exercise)
+
+    assert_redirected_to root_url
+  end
 end
 
 class ExerciseErrorMailerTest < ActionDispatch::IntegrationTest


### PR DESCRIPTION
This pull request fixes a potential security leak, which allowed user to discover hidden series.

- [x] Tests were added

