### PR TITLE
Add regex to make sure git remote is an ssh url

### DIFF
--- a/app/models/judge.rb
+++ b/app/models/judge.rb
@@ -22,7 +22,7 @@ class Judge < ApplicationRecord
 
   validates :name, presence: true, uniqueness: { case_sensitive: false }
   validates :image, presence: true
-  validates :remote, presence: true, uniqueness: { case_sensitive: false }, format: { without: /\Ahttp/ }
+  validates :remote, presence: true, format: { without: /\Ahttp/ }
 
   validate :renderer_is_renderer
   validate :repo_is_accessible, on: :create

--- a/app/models/judge.rb
+++ b/app/models/judge.rb
@@ -22,7 +22,9 @@ class Judge < ApplicationRecord
 
   validates :name, presence: true, uniqueness: { case_sensitive: false }
   validates :image, presence: true
-  validates :remote, presence: true
+  # slightly modified regex from https://stackoverflow.com/questions/2514859/regular-expression-for-git-repository
+  # to allow for ssh:// and git@ urls, but not http(s)://
+  validates :remote, presence: true, uniqueness: { case_sensitive: false }, format: { with: /((git|ssh):\/\/|(git@[\w\.]+):)([\w\.@\:\/\-~]+)(\.git)(\/)?/ }
 
   validate :renderer_is_renderer
   validate :repo_is_accessible, on: :create

--- a/app/models/judge.rb
+++ b/app/models/judge.rb
@@ -22,9 +22,7 @@ class Judge < ApplicationRecord
 
   validates :name, presence: true, uniqueness: { case_sensitive: false }
   validates :image, presence: true
-  # slightly modified regex from https://stackoverflow.com/questions/2514859/regular-expression-for-git-repository
-  # to allow for ssh:// and git@ urls, but not http(s)://
-  validates :remote, presence: true, uniqueness: { case_sensitive: false }, format: { with: /((git|ssh):\/\/|(git@[\w\.]+):)([\w\.@\:\/\-~]+)(\.git)(\/)?/ }
+  validates :remote, presence: true, uniqueness: { case_sensitive: false }, format: { without: /\Ahttp/ }
 
   validate :renderer_is_renderer
   validate :repo_is_accessible, on: :create

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -23,9 +23,7 @@ class Repository < ApplicationRecord
   MEDIA_DIR = 'media'.freeze
 
   validates :name, presence: true, uniqueness: { case_sensitive: false }
-  # slightly modified regex from https://stackoverflow.com/questions/2514859/regular-expression-for-git-repository
-  # to allow for ssh:// and git@ urls, but not http(s)://
-  validates :remote, presence: true, uniqueness: { case_sensitive: false }, format: { with: /((git|ssh):\/\/|(git@[\w\.]+):)([\w\.@\:\/\-~]+)(\.git)(\/)?/ }
+  validates :remote, presence: true, uniqueness: { case_sensitive: false }, format: { without: /\Ahttp/ }
 
   validate :repo_is_accessible, on: :create
 

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -23,7 +23,9 @@ class Repository < ApplicationRecord
   MEDIA_DIR = 'media'.freeze
 
   validates :name, presence: true, uniqueness: { case_sensitive: false }
-  validates :remote, presence: true, uniqueness: { case_sensitive: false }
+  # slightly modified regex from https://stackoverflow.com/questions/2514859/regular-expression-for-git-repository
+  # to allow for ssh:// and git@ urls, but not http(s)://
+  validates :remote, presence: true, uniqueness: { case_sensitive: false }, format: { with: /((git|ssh):\/\/|(git@[\w\.]+):)([\w\.@\:\/\-~]+)(\.git)(\/)?/ }
 
   validate :repo_is_accessible, on: :create
 

--- a/test/fixtures/repository.yml
+++ b/test/fixtures/repository.yml
@@ -14,6 +14,6 @@
 python_repo:
   id: 1
   name: "Python exercises"
-  remote: "https://github.com"
+  remote: "git@github.com:dodona-edu/python-exercises.git"
   path: "path/to/repo"
   judge_id: 1

--- a/test/models/repository_test.rb
+++ b/test/models/repository_test.rb
@@ -460,4 +460,19 @@ class EchoRepositoryTest < ActiveSupport::TestCase
 
     assert_not_includes Repository.featured, @repository
   end
+
+  test 'Remotes should not be http(s) urls' do
+    assert_raises(ActiveRecord::RecordInvalid) do
+      create :repository, :git_stubbed,remote: 'http://foo.bar'
+    end
+    assert_raises(ActiveRecord::RecordInvalid) do
+      create :repository, :git_stubbed,remote: 'https://foo.bar'
+    end
+  end
+
+  test 'git, ssh and local remotes should be valid' do
+    create :repository, :git_stubbed, remote: 'git@foo.bar:baz.git'
+    create :repository, :git_stubbed,remote: 'ssh://foo.bar/baz.git'
+    create :repository, :git_stubbed,remote: '/foo/bar/baz.git'
+  end
 end

--- a/test/models/repository_test.rb
+++ b/test/models/repository_test.rb
@@ -463,16 +463,16 @@ class EchoRepositoryTest < ActiveSupport::TestCase
 
   test 'Remotes should not be http(s) urls' do
     assert_raises(ActiveRecord::RecordInvalid) do
-      create :repository, :git_stubbed,remote: 'http://foo.bar'
+      create :repository, :git_stubbed, remote: 'http://foo.bar'
     end
     assert_raises(ActiveRecord::RecordInvalid) do
-      create :repository, :git_stubbed,remote: 'https://foo.bar'
+      create :repository, :git_stubbed, remote: 'https://foo.bar'
     end
   end
 
   test 'git, ssh and local remotes should be valid' do
     create :repository, :git_stubbed, remote: 'git@foo.bar:baz.git'
-    create :repository, :git_stubbed,remote: 'ssh://foo.bar/baz.git'
-    create :repository, :git_stubbed,remote: '/foo/bar/baz.git'
+    create :repository, :git_stubbed, remote: 'ssh://foo.bar/baz.git'
+    create :repository, :git_stubbed, remote: '/foo/bar/baz.git'
   end
 end


### PR DESCRIPTION
This pull request adds a validation on repository and judge remotes to make sure they aren't http(s) urls.

We do this because we can't interact with https remotes.

I added a more complex regex in [8806ce1](https://github.com/dodona-edu/dodona/pull/5456/commits/8806ce18cc75f2197ca90fb1077513bf1c6ac274) but that caused a lot of issues with our tests because we use local remotes there.

The validation now only focuses on the url starting with https. Other mistakes, such as typo's should be noticed by our existing validation that checks is the host is readable.

![image](https://github.com/dodona-edu/dodona/assets/21177904/3b9f7f8a-396b-4419-aba4-6ed224729d6c)
![image](https://github.com/dodona-edu/dodona/assets/21177904/435ffe1a-74c7-4800-9e44-25895a1986de)



- [x] Tests were added

Closes #5445
