### PR TITLE
Fix tab scrollbar in chrome

### DIFF
--- a/app/assets/stylesheets/components/card.css.scss
+++ b/app/assets/stylesheets/components/card.css.scss
@@ -304,7 +304,7 @@ a.card-title-link:hover {
 .nav-tabs.sticky {
   position: sticky;
   top: var(--d-navbar-height);
-  z-index: 4;
+  z-index: 5;
   background-color: var(--d-surface);
   overflow-x: auto;
   flex-wrap: nowrap;

--- a/app/assets/stylesheets/components/card.css.scss
+++ b/app/assets/stylesheets/components/card.css.scss
@@ -306,7 +306,7 @@ a.card-title-link:hover {
   top: var(--d-navbar-height);
   z-index: 4;
   background-color: var(--d-surface);
-  overflow-x: scroll;
+  overflow-x: auto;
   flex-wrap: nowrap;
 
   li {


### PR DESCRIPTION
This pull request adds two fixes for the scroll bar on feedback tabs in chrome.

First of all the scrollbar is hidden when their is enough available width.
![image](https://github.com/dodona-edu/dodona/assets/21177904/663eb086-ebd7-4ef4-95e7-66cbf428b5a0)

Secondly the scrollbar remains visible when scrolled down on smaller screens
![image](https://github.com/dodona-edu/dodona/assets/21177904/3396a551-de29-43af-9374-d1f3c9b7705c)

The padding is not ideal in this case, but it is hard to make it look great with fixed heights that work both with and without scrollbar. And having it look good for the case without scrollbar seems the most common case.

![image](https://github.com/dodona-edu/dodona/assets/21177904/d9fee799-b36e-419e-8420-d0e4a79a9d22)


Closes #5478
