### PR TITLE
Only show feedback count for unreleased evaluations

### DIFF
--- a/app/helpers/pages_helper.rb
+++ b/app/helpers/pages_helper.rb
@@ -28,11 +28,10 @@ module PagesHelper
       }
     end
 
-    incomplete_unreleased_feedbacks = course.feedbacks.joins(:evaluation).where(evaluation: { released: false }).incomplete
-    if incomplete_unreleased_feedbacks.count > 0
-      linked_feedback = incomplete_unreleased_feedbacks.first
+    if course.incomplete_unreleased_feedbacks.count > 0
+      linked_feedback = course.incomplete_unreleased_feedbacks.first
       result << {
-        title: I18n.t('pages.course_card.incomplete-feedbacks', count: course.feedbacks.incomplete.count),
+        title: I18n.t('pages.course_card.incomplete-feedbacks', count: course.incomplete_unreleased_feedbacks.count),
         link: evaluation_feedback_path(I18n.locale, linked_feedback.evaluation, linked_feedback),
         icon: 'mdi-comment-multiple-outline',
         subtitle: I18n.t('pages.course_card.incomplete-feedbacks-subtitle', count: course.feedbacks.incomplete.count)

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -274,6 +274,10 @@ class Course < ApplicationRecord
     series.visible.reject { |s| s.completed?(user: user) }
   end
 
+  def incomplete_unreleased_feedbacks
+    feedbacks.joins(:evaluation).where(evaluation: { released: false }).incomplete
+  end
+
   def formatted_year
     Course.format_year year
   end


### PR DESCRIPTION
This pull request fixes https://github.com/dodona-edu/dodona/issues/5461

The actual bug was caused by the text not using the precomputed variable.

While debugging I made this calculation a course method and added a new test. While these changes didn't fix or detect the bug, I still opted to leave this extra test in.

- [x] Tests were added

Closes #5461
