### PR TITLE
Fix styling for close button of sandbox

### DIFF
--- a/app/views/activities/_coding_scratchpad.html.erb
+++ b/app/views/activities/_coding_scratchpad.html.erb
@@ -10,8 +10,10 @@
       &nbsp; <%= t('.title', programming_language: activity.programming_language.name.titleize) %>
   </h4>
   <div class="flex-spacer"></div>
-  <button class="btn-close btn-close-white" id="scratchpad-offcanvas-close-btn"
-  data-bs-dismiss="offcanvas" aria-label="<%= t '.close' %>"></button>
+  <button class="btn btn-icon btn-icon-inverted" id="scratchpad-offcanvas-close-btn"
+  data-bs-dismiss="offcanvas" aria-label="<%= t '.close' %>">
+    <i class="mdi mdi-close mdi-24"></i>
+  </button>
   </div>
   <div class="offcanvas-body scratchpad-margin">
     <div class="row scratchpad-body">


### PR DESCRIPTION
This pull request fixes the style of the sandbox dismiss button.

![image](https://github.com/dodona-edu/dodona/assets/21177904/0d6cb77c-9e6f-4e39-9319-a7145570a1ec)

Closes #5436
