### PR TITLE
Add button to undo submission selection in evaluations

### DIFF
--- a/app/assets/stylesheets/components/table.css.scss
+++ b/app/assets/stylesheets/components/table.css.scss
@@ -58,8 +58,6 @@
   text-align: right;
 
   &.submissions-table {
-    text-align: center;
-
     // by default the size of the element in the col is used as width if width is smaller than that element.
     // This width is just here to force everything to the right
     width: 1px;

--- a/app/views/feedbacks/_submissions_table.html.erb
+++ b/app/views/feedbacks/_submissions_table.html.erb
@@ -34,7 +34,7 @@
           <td class="actions submissions-table">
             <% if @feedback.submission&.id == submission.id %>
               <%= link_to feedback_path(@feedback, feedback: { submission_id: nil }),
-                          class: "btn btn-outline d-btn-danger with-icon",
+                          class: "btn btn-outline d-btn-danger",
                           title: t(".undo_selection_tip"),
                           data: { confirm: t('.undo_selection_confirm') },
                           method: :patch do %>

--- a/app/views/feedbacks/_submissions_table.html.erb
+++ b/app/views/feedbacks/_submissions_table.html.erb
@@ -33,15 +33,20 @@
           </td>
           <td class="actions submissions-table">
             <% if @feedback.submission&.id == submission.id %>
-              <button class="btn btn-outline" disabled>
-                <%= t 'submissions.submissions_table.selected' %>
-              </button>
+              <%= link_to feedback_path(@feedback, feedback: { submission_id: nil }),
+                          class: "btn btn-outline d-btn-danger with-icon",
+                          title: t(".undo_selection_tip"),
+                          data: { confirm: t('.undo_selection_confirm') },
+                          method: :patch do %>
+                <i class="mdi mdi-delete mdi-18"></i>
+                <%= (t '.undo_selection') %>
+              <% end %>
             <% else %>
               <%= link_to (t 'submissions.submissions_table.select'),
                           feedback_path(@feedback, feedback: { submission_id: submission.id }),
                           class: "btn btn-outline",
                           title: t(".update-submission"),
-                          confirm: t('.confirm'),
+                          data: { confirm: t('.confirm') },
                           method: :patch %>
             <% end %>
           </td>

--- a/app/views/feedbacks/_submissions_table.html.erb
+++ b/app/views/feedbacks/_submissions_table.html.erb
@@ -38,7 +38,6 @@
                           title: t(".undo_selection_tip"),
                           data: { confirm: t('.undo_selection_confirm') },
                           method: :patch do %>
-                <i class="mdi mdi-delete mdi-18"></i>
                 <%= (t '.undo_selection') %>
               <% end %>
             <% else %>

--- a/config/locales/views/feedbacks/en.yml
+++ b/config/locales/views/feedbacks/en.yml
@@ -59,6 +59,9 @@ en:
     submissions_table:
       update-submission: "Change to this submission"
       confirm: "Are you sure? All comments on the previous submission will be deleted."
+      undo_selection: Deselect
+      undo_selection_tip: Undo the selection of this submission
+      undo_selection_confirm: Are you sure? All comments on the current submission will be deleted.
     score_card:
       total_score: Total grade
       evaluation: Evaluation

--- a/config/locales/views/feedbacks/nl.yml
+++ b/config/locales/views/feedbacks/nl.yml
@@ -59,6 +59,9 @@ nl:
     submissions_table:
       update-submission: "Veranderen naar deze oplossing"
       confirm: "Ben je zeker? Alle opmerkingen op de vorige oplossing zullen verwijderd worden."
+      undo_selection: Selectie wissen
+      undo_selection_tip: Selectie van deze oplossing ongedaan maken
+      undo_selection_confirm: "Ben je zeker? Alle opmerkingen op de huidige oplossing zullen verwijderd worden."
     score_card:
       total_score: Totaalscore
       evaluation: Evaluatie


### PR DESCRIPTION
This pull request introduces a 'deselect' button when selecting submissions for a given feedback.
![image](https://github.com/dodona-edu/dodona/assets/21177904/2a2896d6-43e7-4663-872d-7a69e882d7fb)

I also fixed the confirm messages on these buttons, which used a deprecated style (see https://stackoverflow.com/questions/16668949/how-to-add-confirm-message-with-link-to-ruby-on-rails)


Closes #5501
