### PR TITLE
Prevent unneeded scroll to top

### DIFF
--- a/app/assets/javascripts/components/theme_picker.ts
+++ b/app/assets/javascripts/components/theme_picker.ts
@@ -27,7 +27,7 @@ export class ThemePicker extends DodonaElement {
     protected render(): TemplateResult {
         return html`
             <li >
-                <a href="#" class="dropdown-item">
+                <a class="dropdown-item">
                     <i class="mdi mdi-theme-light-dark"></i>
                     ${i18n.t(`js.theme.theme`)}
                     <i class="mdi mdi-menu-right float-end"></i>

--- a/app/assets/javascripts/exercise.ts
+++ b/app/assets/javascripts/exercise.ts
@@ -479,8 +479,10 @@ function afterResize(details): void {
      */
     if (details.type === "init") {
         const hash = location.hash;
-        location.hash = "#"; // some browsers only scroll after a change
-        location.hash = hash;
+        if (hash && hash.length > 1) {
+            location.hash = "#"; // some browsers only scroll after a change
+            location.hash = hash;
+        }
     }
 }
 

--- a/app/assets/javascripts/file_viewer.ts
+++ b/app/assets/javascripts/file_viewer.ts
@@ -52,6 +52,7 @@ function showRealFile(name: string, activityPath: string, filePath: string): voi
 }
 export function initFileViewers(activityPath: string): void {
     document.querySelectorAll("a.file-link").forEach(l => l.addEventListener("click", e => {
+        e.preventDefault();
         const link = e.currentTarget as HTMLLinkElement;
         const fileName = link.innerText;
         const tc = link.closest(".testcase.contains-file") as HTMLDivElement;


### PR DESCRIPTION
This pull request prevents unnecessary hash changes which triggered scrolling to the top of the page and extra logs in browser history.

All cases discussed in #5423 are now fixed.

Closes #5423
