### PR TITLE
Use exercise name for dolos report

### DIFF
--- a/app/assets/javascripts/i18n/translations.json
+++ b/app/assets/javascripts/i18n/translations.json
@@ -722,7 +722,7 @@
       "date_on": "op",
       "description_languages": "Taal van de beschrijving",
       "dolos": {
-        "view_report": "Rapport bekijken"
+        "view_report": "Plagiaat bekijken"
       },
       "draft": "Concept",
       "dropdown": {

--- a/app/assets/javascripts/i18n/translations.json
+++ b/app/assets/javascripts/i18n/translations.json
@@ -722,7 +722,7 @@
       "date_on": "op",
       "description_languages": "Taal van de beschrijving",
       "dolos": {
-        "view_report": "Plagiaat bekijken"
+        "view_report": "Rapport bekijken"
       },
       "draft": "Concept",
       "dropdown": {

--- a/app/controllers/dolos_reports_controller.rb
+++ b/app/controllers/dolos_reports_controller.rb
@@ -11,7 +11,7 @@ class DolosReportsController < ApplicationController
         body: {
           dataset: {
             zipfile: file,
-            name: export.archive.filename.base.gsub('-', ' ')
+            name: export.archive.filename.base
           }
         }
       )

--- a/app/controllers/dolos_reports_controller.rb
+++ b/app/controllers/dolos_reports_controller.rb
@@ -11,7 +11,7 @@ class DolosReportsController < ApplicationController
         body: {
           dataset: {
             zipfile: file,
-            name: export.archive.filename
+            name: export.archive.filename.base.gsub('-', ' ')
           }
         }
       )

--- a/app/helpers/export_helper.rb
+++ b/app/helpers/export_helper.rb
@@ -93,9 +93,9 @@ module ExportHelper
     end
 
     def zip_filename
-      name_source = @item
-      name_source = @list.first if @list.present? && @list.length == 1
-      name_source.is_a?(User) ? "#{name_source.full_name.parameterize}.zip" : "#{name_source.name.parameterize}.zip"
+      name_source = @list.present? && @list.one? ? @list.first : @item
+      base_name = name_source.is_a?(User) ? name_source.full_name : name_source.name
+      "#{base_name.parameterize}.zip"
     end
 
     def ex_fn(ex)

--- a/app/helpers/export_helper.rb
+++ b/app/helpers/export_helper.rb
@@ -93,7 +93,9 @@ module ExportHelper
     end
 
     def zip_filename
-      @item.is_a?(User) ? "#{@item.full_name.parameterize}.zip" : "#{@item.name.parameterize}.zip"
+      name_source = @item
+      name_source = @list.first if @list.present? && @list.length == 1
+      name_source.is_a?(User) ? "#{name_source.full_name.parameterize}.zip" : "#{name_source.name.parameterize}.zip"
     end
 
     def ex_fn(ex)

--- a/config/locales/js/nl.yml
+++ b/config/locales/js/nl.yml
@@ -333,5 +333,5 @@ nl:
     draft: Concept
     popularity: Populariteit
     dolos:
-      view_report: Plagiaat bekijken
+      view_report: Rapport bekijken
 


### PR DESCRIPTION
This pull request makes it so that for all exports, if only one option (eg. course, series, exercise) is selected, the name of that option is used for the exported file.

I have also removed the `.zip` extension in the name of the dolos report.

Closes #5525
