### PR TITLE
Remove unused authentication option

### DIFF
--- a/app/controllers/auth/omniauth_callbacks_controller.rb
+++ b/app/controllers/auth/omniauth_callbacks_controller.rb
@@ -113,17 +113,11 @@ class Auth::OmniauthCallbacksController < Devise::OmniauthCallbacksController
     # Ensure that an appropriate provider is used.
     return redirect_to_preferred_provider! if provider.redirect?
 
-    identity = nil
+    # ensure that an auth uid is present
+    return redirect_with_flash!(I18n.t('devise.failure.no_auth_id')) if auth_uid.blank?
+
     # First try to find an existing identity
-    if auth_uid.present?
-      # Basic case
-      identity = find_identity_by_uid
-    else
-      # For providers without auth uid
-      user = find_user_in_institution
-      identity = find_identity_by_user(user) if user.present?
-      Event.create(event_type: :no_auth_id_sign_in, user: user, message: "User #{user.id} logged in without auth_id using identity #{identity.id}") if identity.present? && user.present?
-    end
+    identity = find_identity_by_uid
     # At this point identity should have a value if it exists in our database
 
     if identity.blank?

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -11,7 +11,7 @@
 #
 
 class Event < ApplicationRecord
-  enum event_type: { rejudge: 0, permission_change: 1, exercise_repository: 2, error: 3, no_auth_id_sign_in: 4 }
+  enum event_type: { rejudge: 0, permission_change: 1, exercise_repository: 2, error: 3 }
   belongs_to :user, optional: true
 
   validates :event_type, presence: true

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -17,6 +17,7 @@ en:
       unauthenticated: "You need to sign in or sign up before continuing."
       unconfirmed: "You have to confirm your email address before continuing."
       smartschool_co_account: "Smartschool co-accounts are not supported by Dodona. Use a student's Smartschool account to sign in."
+      no_auth_id: "No authentication ID found."
     mailer:
       confirmation_instructions:
         subject: "Confirmation instructions"

--- a/config/locales/devise.nl.yml
+++ b/config/locales/devise.nl.yml
@@ -17,6 +17,7 @@ nl:
       unauthenticated: "Je moet eerst inloggen of aanmelden, voordat je verder kunt gaan."
       unconfirmed: "Je moet eerst je account bevestigen, voordat je verder kunt gaan"
       smartschool_co_account: "Smartschool co-accounts worden niet ondersteund door Dodona. Gebruik een leerlingaccount om aan te melden."
+      no_auth_id: "Geen authenticatie ID gevonden."
     mailer:
       confirmation_instructions:
         subject: "Bevestigingsinstructies"


### PR DESCRIPTION
This pull request removes the option to login without an auth_id being provided.

It was unclear why this option existed in the first place and it was never used in the past two years.

Closes #5545.
