### PR TITLE
Fix series indicator on course page

### DIFF
--- a/app/assets/javascripts/scrollspy.ts
+++ b/app/assets/javascripts/scrollspy.ts
@@ -75,13 +75,12 @@ export class ScrollSpy {
     getCurrentSection(): HTMLElement | null {
         this.sections = document.querySelectorAll(this.options.sectionSelector);
         for (let i = 0; i < this.sections.length; i++) {
-            /**
-            * @type {HTMLElement}
-            */
-            const section = this.sections[i];
-            // get the parent of the parent of the anchor
-            const startAt = section.parentElement.parentElement.parentElement.offsetTop;
-            const endAt = startAt + section.parentElement.parentElement.parentElement.offsetHeight;
+            const section: HTMLElement = this.sections[i];
+            // this is a series card specific modification
+            // it gets the great grand parent of the anchor tag, which is the series card
+            const seriesCard = section.parentElement.parentElement.parentElement;
+            const startAt = seriesCard.offsetTop;
+            const endAt = startAt + seriesCard.offsetHeight;
             const currentPosition =
                 (document.documentElement.scrollTop ||
                     document.body.scrollTop) + this.options.offset;

--- a/app/assets/javascripts/scrollspy.ts
+++ b/app/assets/javascripts/scrollspy.ts
@@ -80,8 +80,8 @@ export class ScrollSpy {
             */
             const section = this.sections[i];
             // get the parent of the parent of the anchor
-            const startAt = section.parentElement.parentElement.offsetTop;
-            const endAt = startAt + section.parentElement.parentElement.offsetHeight;
+            const startAt = section.parentElement.parentElement.parentElement.offsetTop;
+            const endAt = startAt + section.parentElement.parentElement.parentElement.offsetHeight;
             const currentPosition =
                 (document.documentElement.scrollTop ||
                     document.body.scrollTop) + this.options.offset;

--- a/app/assets/javascripts/scrollspy.ts
+++ b/app/assets/javascripts/scrollspy.ts
@@ -77,8 +77,8 @@ export class ScrollSpy {
         for (let i = 0; i < this.sections.length; i++) {
             const section: HTMLElement = this.sections[i];
             // this is a series card specific modification
-            // it gets the great grand parent of the anchor tag, which is the series card
-            const seriesCard = section.parentElement.parentElement.parentElement;
+            // it gets the series card encapsulating the anchor tag
+            const seriesCard = section.closest<HTMLElement>(".series");
             const startAt = seriesCard.offsetTop;
             const endAt = startAt + seriesCard.offsetHeight;
             const currentPosition =


### PR DESCRIPTION
This pull request fixes the correct series indicator being shown as active on the course page.

Probably a change in the series card structure caused this to fail.

Closes #5560.
