### PR TITLE
Don't try to show timezone or iframe warning if not present

### DIFF
--- a/app/assets/javascripts/utilities.ts
+++ b/app/assets/javascripts/utilities.ts
@@ -77,13 +77,13 @@ function getArrayURLParameter(name: string, _url?: string): string[] {
 
 function checkTimeZone(offset: number): void {
     if (offset !== new Date().getTimezoneOffset()) {
-        document.querySelector("#time-zone-warning").classList.remove("hidden");
+        document.querySelector("#time-zone-warning")?.classList?.remove("hidden");
     }
 }
 
 function checkIframe(): void {
     if (isInIframe()) {
-        document.querySelector("#iframe-warning").classList.remove("hidden");
+        document.querySelector("#iframe-warning")?.classList?.remove("hidden");
     }
 }
 


### PR DESCRIPTION
This pull request fixes #5572

I also applied the same fix for check Iframe, but I am open for discussion on that one, as we might want to get notified should that warning not be present when desired.

Closes #5572.
