### PR TITLE
Add option to deselect only submission for evaluation

### DIFF
--- a/app/views/feedbacks/show.html.erb
+++ b/app/views/feedbacks/show.html.erb
@@ -36,14 +36,14 @@
                       <br/>
                     <%= t('.submission.later_attempts_html', count: @feedback.later_attempts) %>
                   <% end %>
-                    <br/>
-                    <%= link_to edit_feedback_path(@feedback) do %>
-                      <% if @feedback.later_attempts + @feedback.previous_attempts > 0 %>
-                        <%= t("feedbacks.edit.select_another_submission") %>
-                      <% else %>
-                        <%= t("feedbacks.edit.select_no_submission") %>
-                      <% end %>
+                  <br/>
+                  <%= link_to edit_feedback_path(@feedback) do %>
+                    <% if @feedback.later_attempts + @feedback.previous_attempts > 0 %>
+                      <%= t("feedbacks.edit.select_another_submission") %>
+                    <% else %>
+                      <%= t("feedbacks.edit.select_no_submission") %>
                     <% end %>
+                  <% end %>
                 <% elsif @feedback.total_attempts > 0 %>
                   <%= t('.submission.total_attempts_html', count: @feedback.total_attempts) %>
                   <%= link_to edit_feedback_path(@feedback) do %>

--- a/app/views/feedbacks/show.html.erb
+++ b/app/views/feedbacks/show.html.erb
@@ -41,6 +41,11 @@
                     <%= link_to edit_feedback_path(@feedback) do %>
                       <%= t("feedbacks.edit.select_another_submission") %>
                     <% end %>
+                  <% else %>
+                      <br/>
+                    <%= link_to edit_feedback_path(@feedback) do %>
+                      <%= t("feedbacks.edit.select_no_submission") %>
+                    <% end %>
                   <% end %>
                 <% elsif @feedback.total_attempts > 0 %>
                   <%= t('.submission.total_attempts_html', count: @feedback.total_attempts) %>

--- a/app/views/feedbacks/show.html.erb
+++ b/app/views/feedbacks/show.html.erb
@@ -36,17 +36,14 @@
                       <br/>
                     <%= t('.submission.later_attempts_html', count: @feedback.later_attempts) %>
                   <% end %>
-                  <% if @feedback.later_attempts + @feedback.previous_attempts > 0 %>
-                      <br/>
+                    <br/>
                     <%= link_to edit_feedback_path(@feedback) do %>
-                      <%= t("feedbacks.edit.select_another_submission") %>
+                      <% if @feedback.later_attempts + @feedback.previous_attempts > 0 %>
+                        <%= t("feedbacks.edit.select_another_submission") %>
+                      <% else %>
+                        <%= t("feedbacks.edit.select_no_submission") %>
+                      <% end %>
                     <% end %>
-                  <% else %>
-                      <br/>
-                    <%= link_to edit_feedback_path(@feedback) do %>
-                      <%= t("feedbacks.edit.select_no_submission") %>
-                    <% end %>
-                  <% end %>
                 <% elsif @feedback.total_attempts > 0 %>
                   <%= t('.submission.total_attempts_html', count: @feedback.total_attempts) %>
                   <%= link_to edit_feedback_path(@feedback) do %>

--- a/config/locales/views/feedbacks/en.yml
+++ b/config/locales/views/feedbacks/en.yml
@@ -56,6 +56,7 @@ en:
       short_title: "Select another submission."
       select_a_submission: "Do select a submission."
       select_another_submission: "Select another submission."
+      select_no_submission: "De-select this submission."
     submissions_table:
       update-submission: "Change to this submission"
       confirm: "Are you sure? All comments on the previous submission will be deleted."

--- a/config/locales/views/feedbacks/nl.yml
+++ b/config/locales/views/feedbacks/nl.yml
@@ -56,6 +56,7 @@ nl:
       short_title: "Selecteer een andere ingediende oplossing."
       select_a_submission: "Selecteer toch een ingediende oplossing."
       select_another_submission: "Selecteer een andere ingediende oplossing."
+      select_no_submission: "Selectie van deze oplossing wissen."
     submissions_table:
       update-submission: "Veranderen naar deze oplossing"
       confirm: "Ben je zeker? Alle opmerkingen op de vorige oplossing zullen verwijderd worden."


### PR DESCRIPTION
This pull request adds a link to the manage submissions page for the edge case where there is only a single submission.

![image](https://github.com/dodona-edu/dodona/assets/21177904/2198f7c0-03b4-4860-bfeb-fd84ab97f228)


Closes #5564
