### PR TITLE
Don't try to enable submit button when not logged in

### DIFF
--- a/app/assets/javascripts/exercise.ts
+++ b/app/assets/javascripts/exercise.ts
@@ -318,7 +318,9 @@ async function initExerciseShow(exerciseId: number, programmingLanguage: string,
     }
 
     function enableSubmitButton(): void {
-        if (!loggedIn) return;
+        if (!loggedIn) {
+            return;
+        }
 
         const btn = document.getElementById("editor-process-btn") as HTMLButtonElement;
         btn.disabled = false;
@@ -327,7 +329,9 @@ async function initExerciseShow(exerciseId: number, programmingLanguage: string,
     }
 
     function disableSubmitButton(): void {
-        if (!loggedIn) return;
+        if (!loggedIn) {
+            return;
+        }
 
         const btn = document.getElementById("editor-process-btn") as HTMLButtonElement;
         btn.disabled = true;

--- a/app/assets/javascripts/exercise.ts
+++ b/app/assets/javascripts/exercise.ts
@@ -318,6 +318,8 @@ async function initExerciseShow(exerciseId: number, programmingLanguage: string,
     }
 
     function enableSubmitButton(): void {
+        if (!loggedIn) return;
+
         const btn = document.getElementById("editor-process-btn") as HTMLButtonElement;
         btn.disabled = false;
         btn.classList.remove("busy", "mdi-timer-sand-empty", "mdi-spin");
@@ -325,6 +327,8 @@ async function initExerciseShow(exerciseId: number, programmingLanguage: string,
     }
 
     function disableSubmitButton(): void {
+        if (!loggedIn) return;
+
         const btn = document.getElementById("editor-process-btn") as HTMLButtonElement;
         btn.disabled = true;
         btn.classList.remove("mdi-send");


### PR DESCRIPTION
For some reason the error does not reproduce on my devise, which made it take a lot longer to debug.
But simply logging the the button showed it as null when not logged in.

When logged in, the button is always present.

Fixes [DODONA-FRONTEND-9](https://dodona.sentry.io/issues/773861/)