### PR TITLE
Fix sentry release information

### DIFF
--- a/.github/workflows/deploy-naos.yml
+++ b/.github/workflows/deploy-naos.yml
@@ -32,18 +32,3 @@ jobs:
         token: ${{secrets.GITHUB_TOKEN}}
         label: deploy naos
         type: remove
-    - name: Get tag name
-      id: tag_name
-      run: echo "tag_name=$(TZ='Europe/Brussels' date +'%Y.%m.%d-%H:%M')" >> "$GITHUB_ENV"
-    - uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
-    - name: Create Sentry release
-      uses: getsentry/action-release@v1
-      env:
-        SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-        SENTRY_ORG: dodona
-        SENTRY_PROJECT: dodona-frontend
-      with:
-        environment: staging
-        version: ${{ env.tag_name }}

--- a/.github/workflows/deploy-naos.yml
+++ b/.github/workflows/deploy-naos.yml
@@ -34,7 +34,7 @@ jobs:
         type: remove
     - name: Get tag name
       id: tag_name
-      run: echo "tag_name=$(date +'%Y.%m.%d-%H:%M')" >> "$GITHUB_ENV"
+      run: echo "tag_name=$(TZ='Europe/Brussels' date +'%Y.%m.%d-%H:%M')" >> "$GITHUB_ENV"
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -22,18 +22,3 @@ jobs:
     - name: Run deploy
       run: |
         echo "deploy production $GITHUB_SHA" | ssh -p 4840 dodona@mestra.ugent.be
-    - name: Get tag name
-      id: tag_name
-      run: echo "tag_name=$(TZ='Europe/Brussels' date +'%Y.%m.%d-%H:%M')" >> "$GITHUB_ENV"
-    - uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
-    - name: Create Sentry release
-      uses: getsentry/action-release@v1
-      env:
-        SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-        SENTRY_ORG: dodona
-        SENTRY_PROJECT: dodona-frontend
-      with:
-        environment: production
-        version: ${{ env.tag_name }}

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -24,7 +24,7 @@ jobs:
         echo "deploy production $GITHUB_SHA" | ssh -p 4840 dodona@mestra.ugent.be
     - name: Get tag name
       id: tag_name
-      run: echo "tag_name=$(date +'%Y.%m.%d-%H:%M')" >> "$GITHUB_ENV"
+      run: echo "tag_name=$(TZ='Europe/Brussels' date +'%Y.%m.%d-%H:%M')" >> "$GITHUB_ENV"
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0

--- a/.github/workflows/monthly-release.yml
+++ b/.github/workflows/monthly-release.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - name: Get tag name
         id: tag_name
-        run: echo "tag_name=$(date +'%Y.%m')" >> "$GITHUB_ENV"
+        run: echo "tag_name=$(TZ='Europe/Brussels' date +'%Y.%m')" >> "$GITHUB_ENV"
       - name: log tag name
         run: echo ${{ env.tag_name }}
       - uses: octokit/request-action@v2.x

--- a/.github/workflows/monthly-release.yml
+++ b/.github/workflows/monthly-release.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - name: Get tag name
         id: tag_name
-        run: echo "tag_name=$(TZ='Europe/Brussels' date +'%Y.%m')" >> "$GITHUB_ENV"
+        run: echo "tag_name=$(date +'%Y.%m')" >> "$GITHUB_ENV"
       - name: log tag name
         run: echo ${{ env.tag_name }}
       - uses: octokit/request-action@v2.x

--- a/app/assets/javascripts/sentry.ts
+++ b/app/assets/javascripts/sentry.ts
@@ -2,7 +2,7 @@ import * as Sentry from "@sentry/browser";
 
 export function initSentry(): void {
     const environmentTag = document.querySelector("meta[name='environment']");
-    const environment = environmentTag ? environmentTag.getAttribute("content") : "unknown";
+    const environment = environmentTag?.getAttribute("content") ?? "unknown";
     const releaseTag = document.querySelector("meta[name='version']");
     const release = releaseTag ? releaseTag.getAttribute("content") : "unknown";
 

--- a/app/assets/javascripts/sentry.ts
+++ b/app/assets/javascripts/sentry.ts
@@ -4,7 +4,7 @@ export function initSentry(): void {
     const environmentTag = document.querySelector("meta[name='environment']");
     const environment = environmentTag?.getAttribute("content") ?? "unknown";
     const releaseTag = document.querySelector("meta[name='version']");
-    const release = releaseTag ? releaseTag.getAttribute("content") : "unknown";
+    const release = releaseTag?.getAttribute("content") ?? "unknown";
 
     // config options can be found at https://docs.sentry.io/platforms/javascript/configuration/
     Sentry.init({

--- a/app/assets/javascripts/sentry.ts
+++ b/app/assets/javascripts/sentry.ts
@@ -1,18 +1,15 @@
 import * as Sentry from "@sentry/browser";
 
-const HOST_TO_ENVIRONMENT: Record<string, string> = {
-    "dodona.localhost": "development",
-    "naos.dodona.be": "staging",
-    "dodona.be": "production",
-};
-
 export function initSentry(): void {
-    const environment = window.location.hostname in HOST_TO_ENVIRONMENT ?
-        HOST_TO_ENVIRONMENT[window.location.hostname] : "unknown";
+    const environmentTag = document.querySelector("meta[name='environment']");
+    const environment = environmentTag ? environmentTag.getAttribute("content") : "unknown";
+    const releaseTag = document.querySelector("meta[name='version']");
+    const release = releaseTag ? releaseTag.getAttribute("content") : "unknown";
 
     // config options can be found at https://docs.sentry.io/platforms/javascript/configuration/
     Sentry.init({
         dsn: "https://18315b6d60f9329de56983fd94f67db9@o4507329115783168.ingest.de.sentry.io/4507333215256657",
         environment,
+        release,
     });
 }

--- a/app/javascript/packs/frame.js
+++ b/app/javascript/packs/frame.js
@@ -1,5 +1,7 @@
 import "core-js/stable";
 import "regenerator-runtime/runtime";
+import { initSentry } from "sentry";
+initSentry();
 
 // bootstrap
 import { Alert, Button, Collapse, Dropdown, Modal, Popover, Tab, Tooltip } from "bootstrap";

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,6 +16,8 @@
   <meta property="og:image" content="<%= root_url(locale: nil) %>social-image.png">
   <meta name="msapplication-TileColor" content="#2196F3"/>
   <meta name="msapplication-TileImage" content="/icon.png"/>
+  <meta name="version" content="<%= Dodona::Application::VERSION %>">
+  <meta name="environment" content="<%= Rails.env %>">
   <link rel="apple-touch-icon-precomposed" href="/icon.png"/>
   <link rel="shortcut icon" sizes="192x192" href="<%= @dot_icon&.any? ? "/icon-not.png" : "/icon.png" %>">
   <link rel="shortcut icon" href="<%= @dot_icon&.any? ? "/favicon-not.ico" : "/favicon.ico" %>">

--- a/app/views/layouts/frame.html.erb
+++ b/app/views/layouts/frame.html.erb
@@ -7,6 +7,8 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="version" content="<%= Dodona::Application::VERSION %>">
+  <meta name="environment" content="<%= Rails.env %>">
   <%= yield :meta_tags %>
   <meta property="og:image" content="<%= root_url(locale: nil) %>icon.png">
   <link href="https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,300;0,400;0,500;0,700;1,400&display=swap" rel="stylesheet">

--- a/app/views/layouts/lti.html.erb
+++ b/app/views/layouts/lti.html.erb
@@ -4,6 +4,8 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="version" content="<%= Dodona::Application::VERSION %>">
+  <meta name="environment" content="<%= Rails.env %>">
   <%= yield :meta_tags %>
   <title>Dodona<%= " - #{@title}" if @title %></title>
   <link href="https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,300;0,400;0,500;0,700;1,400&display=swap" rel="stylesheet">


### PR DESCRIPTION
This pull request adds release information to sentry. It also takes the environment information from rails instead of recalculating it based on hostname.

It also removes the sending of release info to sentry, as the release name is now contained in the tag. And sourcemaps are already pushed upon build.

I have also loaded sentry within frames (where it wasn't present yet).

