### PR TITLE
Fix 'visible after start time' when creating series

### DIFF
--- a/app/assets/javascripts/series.ts
+++ b/app/assets/javascripts/series.ts
@@ -19,6 +19,25 @@ const DRAG_AND_DROP_ARGS = {
     },
 };
 
+function initSeriesForm(): void {
+    function init(): void {
+        initTimedVisibility();
+    }
+
+    function initTimedVisibility(): void {
+        const timedVisibilityOption = document.getElementById("series_visibility_timed") as HTMLInputElement;
+        const timingOptions = document.getElementById("timing-options");
+        const visibilityOptions = document.querySelectorAll("[name=\"series[visibility]\"]");
+        visibilityOptions.forEach( option => {
+            option.addEventListener("change", () => {
+                timingOptions.classList.toggle("visually-hidden", !timedVisibilityOption.checked);
+            });
+        });
+    }
+
+    init();
+}
+
 function initSeriesEdit(): void {
     function init(): void {
         initAddButtons();
@@ -28,7 +47,6 @@ function initSeriesEdit(): void {
         dodona.seriesEditActivitiesLoaded = () => {
             initAddButtons();
         };
-        initTimedVisibility();
     }
 
     function initAddButtons(): void {
@@ -151,17 +169,6 @@ function initSeriesEdit(): void {
         document.getElementById("to-many-activities-info").classList.toggle("d-none", count <= 10);
     }
 
-    function initTimedVisibility(): void {
-        const timedVisibilityOption = document.getElementById("series_visibility_timed") as HTMLInputElement;
-        const timingOptions = document.getElementById("timing-options");
-        const visibilityOptions = document.querySelectorAll("[name=\"series[visibility]\"]");
-        visibilityOptions.forEach( option => {
-            option.addEventListener("change", () => {
-                timingOptions.classList.toggle("visually-hidden", !timedVisibilityOption.checked);
-            });
-        });
-    }
-
     init();
 }
 
@@ -190,4 +197,4 @@ function initSeriesShow(id: string): void {
     });
 }
 
-export { initSeriesEdit, initSeriesShow };
+export { initSeriesEdit, initSeriesShow, initSeriesForm };

--- a/app/javascript/packs/series.js
+++ b/app/javascript/packs/series.js
@@ -1,6 +1,7 @@
-import { initSeriesEdit, initSeriesShow } from "series.ts";
+import { initSeriesEdit, initSeriesShow, initSeriesForm } from "series.ts";
 import { initDatePicker } from "utilities.ts";
 
 window.dodona.initDeadlinePicker = initDatePicker;
 window.dodona.initSeriesEdit = initSeriesEdit;
 window.dodona.initSeriesShow = initSeriesShow;
+window.dodona.initSeriesForm = initSeriesForm;

--- a/app/views/series/_form.html.erb
+++ b/app/views/series/_form.html.erb
@@ -108,5 +108,6 @@
     dodona.ready.then(function () {
       dodona.initDeadlinePicker("#deadline-group");
       dodona.initDeadlinePicker("#start-group");
+      dodona.initSeriesForm();
     });
 </script>


### PR DESCRIPTION
This pull request fixes the option to pick visible after start time when creating a series. The relevant javascript was only loaded on the series edit page.

![image](https://github.com/dodona-edu/dodona/assets/21177904/f056f3fb-0bec-4b3c-b848-253fed0d83ca)

