### PR TITLE
Disable plagiarism detection when language is not supported by dolos

### DIFF
--- a/app/assets/javascripts/dolos.ts
+++ b/app/assets/javascripts/dolos.ts
@@ -6,9 +6,19 @@ import { i18n } from "i18n/i18n";
 
 const LOADER_ID = "dolos-loader";
 const DOLOS_URL = "/dolos_reports";
+// List from https://github.com/dodona-edu/dolos/issues/1029 on 2024-06-13
+const SUPPORTED_LANGUAGES = new Set(["sh", "c", "cpp", "csharp", "elm", "java", "javascript", "python", "typescript", "tsx"]);
 
-export function initDolosBtn(btnID: string, url: string): void {
+export function initDolosBtn(btnID: string, url: string, lang: string): void {
     const btn = document.getElementById(btnID) as HTMLLinkElement;
+
+    const langName = lang.toLowerCase();
+    if (!SUPPORTED_LANGUAGES.has(langName)) {
+        btn.classList.add("disabled-with-tooltip");
+        btn.title = i18n.t("js.dolos.unsupported_language", { lang: lang });
+        return;
+    }
+
     btn.addEventListener("click", () => startDolos(btn, url));
 }
 

--- a/app/assets/javascripts/i18n/translations.json
+++ b/app/assets/javascripts/i18n/translations.json
@@ -188,6 +188,7 @@
       "date_on": "on",
       "description_languages": "Language of the description",
       "dolos": {
+        "unsupported_language": "%{lang} is not supported by the plagiarism checker.",
         "view_report": "Open plagiarism report"
       },
       "draft": "Draft",
@@ -722,6 +723,7 @@
       "date_on": "op",
       "description_languages": "Taal van de beschrijving",
       "dolos": {
+        "unsupported_language": "%{lang} wordt niet ondersteund door Dolos",
         "view_report": "Rapport bekijken"
       },
       "draft": "Concept",

--- a/app/assets/stylesheets/components/btn.css.scss
+++ b/app/assets/stylesheets/components/btn.css.scss
@@ -45,6 +45,12 @@
     pointer-events: none;
   }
 
+  &.disabled-with-tooltip {
+    opacity: 0.38;
+    pointer-events: auto;
+    cursor: default;
+  }
+
   // define the default button colors
   // makes it easier to combine with other classes such as d-btn-danger, d-btn-success, etc.
   --d-btn-color: var(--d-primary);
@@ -95,6 +101,11 @@
   &:active {
     opacity: 1;
     background: rgba(var(--d-btn-color-rgb), 0.1);
+
+    &.disabled-with-tooltip {
+      opacity: 0.38;
+      background: none;
+    }
   }
 }
 
@@ -135,7 +146,8 @@
   }
 
   &.disabled,
-  &:disabled {
+  &:disabled,
+  &.disabled-with-tooltip {
     color: var(--d-on-surface);
     border: 1px solid rgba(var(--d-on-surface-rgb), 0.12);
     opacity: 0.38;

--- a/app/views/evaluations/_exercises_progress_table.html.erb
+++ b/app/views/evaluations/_exercises_progress_table.html.erb
@@ -50,7 +50,7 @@
           </a>
           <script>
             dodona.ready.then(() =>{
-              dodona.initDolosBtn('dolos-btn-<%= meta[:exercise].id %>', "<%= series_exports_path(@evaluation.series, token: (@evaluation.series.access_token if @evaluation.series.hidden?), selected_ids: [meta[:exercise].id], evaluation: true) %>");
+              dodona.initDolosBtn('dolos-btn-<%= meta[:exercise].id %>', "<%= series_exports_path(@evaluation.series, token: (@evaluation.series.access_token if @evaluation.series.hidden?), selected_ids: [meta[:exercise].id], evaluation: true) %>", "<%= meta[:exercise].programming_language.renderer_name %>");
             })
           </script>
         </td>

--- a/app/views/evaluations/_exercises_progress_table.html.erb
+++ b/app/views/evaluations/_exercises_progress_table.html.erb
@@ -50,7 +50,7 @@
           </a>
           <script>
             dodona.ready.then(() =>{
-              dodona.initDolosBtn('dolos-btn-<%= meta[:exercise].id %>', "<%= series_exports_path(@evaluation.series, token: (@evaluation.series.access_token if @evaluation.series.hidden?), selected_ids: [meta[:exercise].id], evaluation: true) %>", "<%= meta[:exercise].programming_language.renderer_name %>");
+              dodona.initDolosBtn('dolos-btn-<%= meta[:exercise].id %>', "<%= series_exports_path(@evaluation.series, token: (@evaluation.series.access_token if @evaluation.series.hidden?), selected_ids: [meta[:exercise].id], evaluation: true) %>", "<%= meta[:exercise].programming_language&.renderer_name %>");
             })
           </script>
         </td>

--- a/app/views/submissions/index.html.erb
+++ b/app/views/submissions/index.html.erb
@@ -52,7 +52,7 @@
             <% actions << {icon: 'graph-outline', text: t('.detect_plagiarism'), id: "dolos-btn" } if @series && @activity %>
             <script>
               dodona.ready.then(() => {
-                dodona.initDolosBtn("dolos-btn", "<%= series_exports_path(@series, token: (@series.access_token if @series.hidden?), selected_ids: [@activity.id]) %>");
+                dodona.initDolosBtn("dolos-btn", "<%= series_exports_path(@series, token: (@series.access_token if @series.hidden?), selected_ids: [@activity.id]) %>", "<%= @activity.programming_language.renderer_name %>");
               });
             </script>
           <% end %>

--- a/app/views/submissions/index.html.erb
+++ b/app/views/submissions/index.html.erb
@@ -52,7 +52,7 @@
             <% actions << {icon: 'graph-outline', text: t('.detect_plagiarism'), id: "dolos-btn" } if @series && @activity %>
             <script>
               dodona.ready.then(() => {
-                dodona.initDolosBtn("dolos-btn", "<%= series_exports_path(@series, token: (@series.access_token if @series.hidden?), selected_ids: [@activity.id]) %>", "<%= @activity.programming_language.renderer_name %>");
+                dodona.initDolosBtn("dolos-btn", "<%= series_exports_path(@series, token: (@series.access_token if @series.hidden?), selected_ids: [@activity.id]) %>", "<%= @activity.programming_language&.renderer_name %>");
               });
             </script>
           <% end %>

--- a/config/locales/js/en.yml
+++ b/config/locales/js/en.yml
@@ -334,3 +334,4 @@ en:
     popularity: Popularity
     dolos:
       view_report: Open plagiarism report
+      unsupported_language: "%{lang} is not supported by the plagiarism checker."

--- a/config/locales/js/nl.yml
+++ b/config/locales/js/nl.yml
@@ -334,4 +334,5 @@ nl:
     popularity: Populariteit
     dolos:
       view_report: Rapport bekijken
+      unsupported_language: "%{lang} wordt niet ondersteund door Dolos"
 


### PR DESCRIPTION
This pull request disables the detect plagiarism button for languages that aren't supported by dolos:
![image](https://github.com/dodona-edu/dodona/assets/21177904/359f6d53-e9f8-4abd-9516-174da5587daa)

A tooltip with this explanation is shown on the disabled button.
I had to introduce some new disabled button css to be able to support this tooltip.

The dolos languages are now also hardcoded. Making an API call every time for the supported languages seems a bit overkill. But we'll have to maintain this list. @rien I don't know how often these are expected to change? 


Closes #5591
