### PR TITLE
Allow for multiple selection in editor

### DIFF
--- a/app/assets/javascripts/editor.ts
+++ b/app/assets/javascripts/editor.ts
@@ -22,7 +22,7 @@ import {
     lineNumbers
 } from "@codemirror/view";
 import { tags } from "@lezer/highlight";
-import { Extension } from "@codemirror/state";
+import { EditorState, Extension } from "@codemirror/state";
 
 declare type EditorEventHandler = (event: FocusEvent, view: EditorView) => boolean | void;
 const tabCompletionKeyMap = [{ key: "Tab", run: acceptCompletion }];
@@ -127,6 +127,7 @@ const editorSetup = (() => [
     bracketMatching(),
     closeBrackets(),
     highlightActiveLine(),
+    EditorState.allowMultipleSelections.of(true),
     keymap.of([
         ...closeBracketsKeymap,
         ...defaultKeymap,


### PR DESCRIPTION
This pull request adds the allowMultipleSelections facet to the codemirror editor.

![image](https://github.com/dodona-edu/dodona/assets/21177904/946129d6-9025-494f-a2b0-9301a87a7f79)

Closes #5165
