### PR TITLE
Separate series activity icons into columns

### DIFF
--- a/app/assets/stylesheets/models/activities.css.scss
+++ b/app/assets/stylesheets/models/activities.css.scss
@@ -1,9 +1,5 @@
 // activity table
 .activity-table {
-  th.status-icon {
-    width: 30px;
-  }
-
   td.popularity-icon {
     color: var(--d-on-surface-muted);
   }
@@ -16,12 +12,22 @@
   td.type-icon {
     width: 18px;
     color: var(--d-on-surface-muted);
-    padding-left: 0;
+    padding-left: 4px;
     padding-right: 0;
   }
 
-  td.status-icon {
-    padding-left: 4px;
+  td.status-icon,
+  th.status-icon,
+  th.repository-status-icon,
+  td.repository-status-icon {
+    width: 0;
+    padding-left: 0;
+    padding-right: 0;
+
+    .mdi {
+      margin-left: 4px;
+      margin-right: 4px;
+    }
   }
 
   .status {

--- a/app/views/activities/_series_activities_table.html.erb
+++ b/app/views/activities/_series_activities_table.html.erb
@@ -10,6 +10,7 @@
     <thead>
     <tr>
       <th class='status-icon'></th>
+      <th class='repository-status-icon'></th>
       <th class='type-icon'></th>
       <th><%= t "activities.index.activity_title" %></th>
       <% if @course.blank? || policy(local_assigns[:series]).show_progress? %>
@@ -38,12 +39,13 @@
       <tr>
         <td class='status-icon'>
           <% if user_signed_in? %>
-            <% if current_user.repository_admin?(activity.repository) || current_user.course_admin?(@course) %>
-              <%= render partial: 'activities/repository_status', locals: {activity: activity, series: local_assigns[:series]} %>
-            <% end %>
             <%= render partial: 'activities/user_status_icon', locals: {activity: activity, series: local_assigns[:series], user: user} %>
           <% end %>
         </td>
+        <td class='repository-status-icon'><%
+          if user_signed_in? && (current_user.repository_admin?(activity.repository) || current_user.course_admin?(@course)) %>
+                <%= render partial: 'activities/repository_status', locals: {activity: activity, series: local_assigns[:series]} %>
+          <% end %></td>
 
         <td class='type-icon'>
           <%= activity_icon(activity) %>


### PR DESCRIPTION
This pull request creates a column for each type of activity icon. This makes them more clearly stacked underneath one another when present.

![image](https://github.com/dodona-edu/dodona/assets/21177904/1b68f822-940e-404b-af14-542ce2395782)
![image](https://github.com/dodona-edu/dodona/assets/21177904/12b91e60-702e-4abc-a1ac-5d6e70eec2b4)
![image](https://github.com/dodona-edu/dodona/assets/21177904/12b598fe-a7ae-4018-8053-b2e72cad80d0)
![image](https://github.com/dodona-edu/dodona/assets/21177904/5de50a60-dffd-459e-9977-db59418f5fba)

Closes #5238
