### PR TITLE
Allow expand/collapse of targeted feedback groups

### DIFF
--- a/app/assets/javascripts/submission.ts
+++ b/app/assets/javascripts/submission.ts
@@ -7,6 +7,7 @@ function initSubmissionShow(parentClass: string, mediaPath: string, token: strin
         initTabLinks();
         initCollapseButtons();
         initHideCorrect();
+        initTabSummaryLinks();
         contextualizeMediaPaths(parentClass, mediaPath, token);
     }
 
@@ -34,6 +35,16 @@ function initSubmissionShow(parentClass: string, mediaPath: string, token: strin
                 const button = e.currentTarget;
                 const group = getParentByClassName(button, "group");
                 group.classList.toggle("collapsed");
+            });
+        });
+    }
+
+    function initTabSummaryLinks(): void {
+        document.querySelectorAll(".tab-summary-icons a").forEach(l => {
+            l.addEventListener("click", () => {
+                const groupId = l.attributes["href"].value;
+                const group = document.getElementById(groupId.substring(1));
+                group.classList.remove("collapsed");
             });
         });
     }

--- a/app/assets/javascripts/submission.ts
+++ b/app/assets/javascripts/submission.ts
@@ -42,8 +42,10 @@ function initSubmissionShow(parentClass: string, mediaPath: string, token: strin
     function initTabSummaryLinks(): void {
         document.querySelectorAll(".tab-summary-icons a").forEach(l => {
             l.addEventListener("click", () => {
-                const groupId = l.attributes["href"].value;
-                const group = document.getElementById(groupId.substring(1));
+                // The href is a hash followed by the id of the group
+                // We remove the hash and get the group by id
+                const groupId = l.attributes["href"].value.substring(1);
+                const group = document.getElementById(groupId);
                 group.classList.remove("collapsed");
             });
         });

--- a/app/assets/stylesheets/models/submissions.css.scss
+++ b/app/assets/stylesheets/models/submissions.css.scss
@@ -118,12 +118,7 @@
         }
       }
 
-      &:target .btn-collapse {
-        pointer-events: none;
-      }
-
-      // if a group is the target, never collapse
-      &.collapsed:not(:target) {
+      &.collapsed {
         .card-supporting-text {
           display: none;
         }


### PR DESCRIPTION
This pull request allows targeted feedback groups to be toggled. They are still expanded upon clicking the link by javascript instead of css.

Closes #5135
