### PR TITLE
Add ctrl+enter/cmd+enter keyboard shortcut to submit code from editor

### DIFF
--- a/app/assets/javascripts/editor.ts
+++ b/app/assets/javascripts/editor.ts
@@ -18,6 +18,7 @@ import {
     highlightActiveLine,
     highlightActiveLineGutter,
     highlightSpecialChars,
+    KeyBinding,
     keymap,
     lineNumbers
 } from "@codemirror/view";
@@ -25,7 +26,11 @@ import { tags } from "@lezer/highlight";
 import { EditorState, Extension } from "@codemirror/state";
 
 declare type EditorEventHandler = (event: FocusEvent, view: EditorView) => boolean | void;
-const tabCompletionKeyMap = [{ key: "Tab", run: acceptCompletion }];
+const tabCompletionKeyMap: KeyBinding = { key: "Tab", run: acceptCompletion };
+const submitKeyMap: KeyBinding = { key: "Mod-Enter", run: () => {
+    document.getElementById("editor-process-btn")?.click();
+    return true;
+} };
 
 // A custom theme for CodeMirror that applies the same CSS as Rouge does,
 // meaning we can use our existing themes.
@@ -129,11 +134,12 @@ const editorSetup = (() => [
     highlightActiveLine(),
     EditorState.allowMultipleSelections.of(true),
     keymap.of([
+        submitKeyMap,
         ...closeBracketsKeymap,
         ...defaultKeymap,
         ...historyKeymap,
         ...foldKeymap,
-        ...tabCompletionKeyMap,
+        tabCompletionKeyMap,
         indentWithTab
     ]),
     syntaxHighlighting(rougeStyle, {


### PR DESCRIPTION
This pull request adds the keyboard shortcut Ctrl-Enter (and cmd+enter on mac) for submitting from the editor.

Closes #3564
