### PR TITLE
Add dark invert class for images

### DIFF
--- a/app/assets/stylesheets/theme/m3-theme-dark.css.scss
+++ b/app/assets/stylesheets/theme/m3-theme-dark.css.scss
@@ -206,6 +206,10 @@
     display: unset;
   }
 
+  .dark-invert {
+    filter: invert(100%);
+  }
+
   :root {
     color-scheme: dark;
   }


### PR DESCRIPTION
This pull request adds a css class that inverts images in dark mode, as an extra tool for users creating exercises.

I opted not to implement the requested `data-large-dark` atribute style css as that would add more rather complex css, while the only benefit is less duplication in the exercise description.

- [x] Documentation update can be found at dodona-edu/dodona-edu.github.io#435

Closes #3175
