### PR TITLE
Allow collapsing series on a course page

### DIFF
--- a/app/assets/javascripts/course.ts
+++ b/app/assets/javascripts/course.ts
@@ -69,6 +69,11 @@ class Series {
         return document.getElementById(this.cardId);
     }
 
+    private get scrollspy(): HTMLElement {
+        const anchor = this.card.querySelector(".anchor");
+        return document.querySelector(`#scrollspy-nav a[href="#${anchor.id}"]`);
+    }
+
     static findAll(cardsSelector = ".series.card"): Array<Series> {
         const cards = document.querySelectorAll(cardsSelector);
         return Array.from(cards, card => new Series(card));
@@ -108,17 +113,17 @@ class Series {
     }
 
     collapse(): void {
-        this.card.classList.add("collapsed");
         localStorage.setItem(this.cardId, "collapsed");
+        this.renderCollapsed();
     }
 
     expand(): void {
-        this.card.classList.remove("collapsed");
         localStorage.removeItem(this.cardId);
+        this.renderCollapsed();
     }
 
     initCollapse(): void {
-        this.card.classList.toggle("collapsed", localStorage.getItem(this.cardId) === "collapsed");
+        this.renderCollapsed();
 
         if (this.loaded) {
             const expandButton = this.card.querySelector(".expand-button");
@@ -126,6 +131,12 @@ class Series {
             const collapseButton = this.card.querySelector(".collapse-button");
             collapseButton.addEventListener("click", this.collapse.bind(this));
         }
+    }
+
+    renderCollapsed(): void {
+        const collapsed = localStorage.getItem(this.cardId) === "collapsed";
+        this.card.classList.toggle("collapsed", collapsed);
+        this.scrollspy.classList.toggle("d-none", collapsed);
     }
 }
 

--- a/app/assets/javascripts/course.ts
+++ b/app/assets/javascripts/course.ts
@@ -61,6 +61,14 @@ class Series {
         return this._bottom;
     }
 
+    private get cardId(): string {
+        return `series-card-${this.id}`;
+    }
+
+    private get card(): HTMLElement {
+        return document.getElementById(this.cardId);
+    }
+
     static findAll(cardsSelector = ".series.card"): Array<Series> {
         const cards = document.querySelectorAll(cardsSelector);
         return Array.from(cards, card => new Series(card));
@@ -79,6 +87,7 @@ class Series {
         this.loading = false;
         this._top = card.getBoundingClientRect().top + window.scrollY;
         this._bottom = this.top + card.getBoundingClientRect().height;
+        this.initCollapse();
     }
 
     needsLoading(): boolean {
@@ -93,9 +102,30 @@ class Series {
             if (response.ok) {
                 eval(await response.text());
                 this.loading = false;
-                this.reselect(document.getElementById(`series-card-${this.id}`));
+                this.reselect(this.card);
             }
         });
+    }
+
+    collapse(): void {
+        this.card.classList.add("collapsed");
+        localStorage.setItem(this.cardId, "collapsed");
+    }
+
+    expand(): void {
+        this.card.classList.remove("collapsed");
+        localStorage.removeItem(this.cardId);
+    }
+
+    initCollapse(): void {
+        this.card.classList.toggle("collapsed", localStorage.getItem(this.cardId) === "collapsed");
+
+        if (this.loaded) {
+            const expandButton = this.card.querySelector(".expand-button");
+            expandButton.addEventListener("click", this.expand.bind(this));
+            const collapseButton = this.card.querySelector(".collapse-button");
+            collapseButton.addEventListener("click", this.collapse.bind(this));
+        }
     }
 }
 

--- a/app/assets/stylesheets/models/series.css.scss
+++ b/app/assets/stylesheets/models/series.css.scss
@@ -104,6 +104,10 @@
       }
     }
 
+    .series-dropdown {
+      display: none;
+    }
+
     .expand-button {
       display: block;
       margin-top: -7px;

--- a/app/assets/stylesheets/models/series.css.scss
+++ b/app/assets/stylesheets/models/series.css.scss
@@ -75,8 +75,6 @@
   }
 
   &.collapsed {
-    opacity: 0.8;
-
     .card-subtitle {
       margin-bottom: 0;
     }

--- a/app/assets/stylesheets/models/series.css.scss
+++ b/app/assets/stylesheets/models/series.css.scss
@@ -69,6 +69,49 @@
   .series-icon {
     margin-right: 16px;
   }
+
+  .expand-button {
+    display: none;
+  }
+
+  &.collapsed {
+    opacity: 0.8;
+
+    .card-subtitle {
+      margin-bottom: 0;
+    }
+
+    .btn-group {
+      display: none !important;
+    }
+
+    .tab-content {
+      display: none;
+    }
+
+    .card-actions {
+      display: none;
+    }
+
+    d-series-icon {
+      svg {
+        width: 24px !important;
+        height: 24px !important;
+      }
+    }
+
+    h4 {
+      small {
+        display: none;
+      }
+    }
+
+    .expand-button {
+      display: block;
+      margin-top: -7px;
+      margin-bottom: -9px;
+    }
+  }
 }
 
 .series-icon {

--- a/app/views/series/_series.html.erb
+++ b/app/views/series/_series.html.erb
@@ -24,7 +24,7 @@
       </h4>
       <div class="flex-spacer"></div>
       <button class="btn btn-text expand-button">
-        Expand
+        <%= t "series.show.expand" %>
       </button>
       <% if policy(series).statistics? %>
         <div id="series-view-<%= series.id %>" class="btn-group btn-toggle nav d-none d-sm-flex" role="tablist">
@@ -73,7 +73,7 @@
               <% end %>
               <li>
                 <a class="dropdown-item collapse-button">
-                  <i class='mdi mdi-eye-off mdi-18'></i> Collapse
+                  <i class='mdi mdi-eye-off mdi-18'></i> <%= t "series.show.collapse" %>
                 </a>
               </li>
             </ul>
@@ -257,7 +257,7 @@
             <% end %>
             <li>
               <a class="dropdown-item collapse-button">
-                <i class='mdi mdi-eye-off mdi-18'></i> Collapse
+                <i class='mdi mdi-eye-off mdi-18'></i> <%= t "series.show.collapse" %>
               </a>
             </li>
           </ul>

--- a/app/views/series/_series.html.erb
+++ b/app/views/series/_series.html.erb
@@ -9,7 +9,7 @@
    end %>
 <% ActivityStatus.add_status_for_user_and_series(user, series, [:last_submission, :best_submission]) if loaded %>
 
-<div class="card series"
+<div class="card series collapsed"
      id="series-card-<%= series.id %>"
      data-series-url="<%= user&.id ? series_path(series, format: :js, user_id: user.id) : series_path(series, format: :js) %>"
      data-loaded="<%= loaded %>">
@@ -23,6 +23,9 @@
         <%= render partial: 'deadlines/absolute', locals: {deadline: series.deadline, met: user && loaded ? series.completed_before_deadline?(user) : false} %>
       </h4>
       <div class="flex-spacer"></div>
+      <button class="btn btn-text expand-button">
+        Expand
+      </button>
       <% if policy(series).statistics? %>
         <div id="series-view-<%= series.id %>" class="btn-group btn-toggle nav d-none d-sm-flex" role="tablist">
           <button class="btn active" data-bs-target="#series-content-<%= series.id %>" data-bs-toggle="tab" role="tab" title="<%= t("series.show.series_overview") %>">

--- a/app/views/series/_series.html.erb
+++ b/app/views/series/_series.html.erb
@@ -71,6 +71,11 @@
                   <% end %>
                 </li>
               <% end %>
+              <li>
+                <a class="dropdown-item collapse-button">
+                  <i class='mdi mdi-eye-off mdi-18'></i> Collapse
+                </a>
+              </li>
             </ul>
           </div>
         </div>

--- a/app/views/series/_series.html.erb
+++ b/app/views/series/_series.html.erb
@@ -9,7 +9,7 @@
    end %>
 <% ActivityStatus.add_status_for_user_and_series(user, series, [:last_submission, :best_submission]) if loaded %>
 
-<div class="card series collapsed"
+<div class="card series"
      id="series-card-<%= series.id %>"
      data-series-url="<%= user&.id ? series_path(series, format: :js, user_id: user.id) : series_path(series, format: :js) %>"
      data-loaded="<%= loaded %>">
@@ -250,6 +250,11 @@
                 <% end %>
               </li>
             <% end %>
+            <li>
+              <a class="dropdown-item collapse-button">
+                <i class='mdi mdi-eye-off mdi-18'></i> Collapse
+              </a>
+            </li>
           </ul>
         </div>
       </div>

--- a/config/locales/views/series/en.yml
+++ b/config/locales/views/series/en.yml
@@ -48,6 +48,8 @@ en:
       series_overview: Series overview
       apply: apply
       hidden_not_registered: You are not registered for this course. You must register before you can start solving the exercises.
+      collapse: Collapse
+      expand: Expand
     edit:
       title: Edit series
       add_activities: Add activities

--- a/config/locales/views/series/nl.yml
+++ b/config/locales/views/series/nl.yml
@@ -48,6 +48,8 @@ nl:
       series_overview: Reeksoverzicht
       apply: toepassen
       hidden_not_registered: Je bent niet ingeschreven voor deze cursus. Je kan de oefeningen pas oplossen nadat je je ingeschreven hebt.
+      collapse: Inklappen
+      expand: Uitklappen
     edit:
       title: Reeks bewerken
       add_activities: Activiteiten toevoegen


### PR DESCRIPTION
This pull request adds buttons to expand/collapse a series on a course page.

This option is stored in local storage, so remembered while on the same machine, without creating unwanted database tables.

Can be useful for teachers with too many series because of tests/exams.
But it can also be useful for students who want to hide past/finished series.

Right now this is quite hidden as I consider it an advanced feature. Should we notice that it is highly appreciated we should consider moving it to a chevron in the top right corner. 

![image](https://github.com/dodona-edu/dodona/assets/21177904/ed06c9b0-4095-4b2b-914a-a5af08495259)
![image](https://github.com/dodona-edu/dodona/assets/21177904/1b04dc55-0642-4600-84b8-f38d0ce0b760)
![image](https://github.com/dodona-edu/dodona/assets/21177904/54321081-c946-4adc-a726-6cc4ba2dcf2d)


![Peek 2024-06-27 14-47](https://github.com/dodona-edu/dodona/assets/21177904/ee6d08dc-f5e1-4752-ba0c-f17556cdd126)



- [ ] Documentation update can be found at dodona-edu/dodona-edu.github.io#

Closes #5457
