### PR TITLE
Fix legacy 'exercises' path support

### DIFF
--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -175,7 +175,9 @@ class SubmissionsController < ApplicationController
     end
 
     @series = Series.find(params[:series_id]) if params[:series_id]
-    @activity = Exercise.find(params[:activity_id]) if params[:activity_id]
+    # both /activities/:id/submissions and /exercises/:id/submissions are valid routes
+    activity_id = params[:activity_id] || params[:exercise_id]
+    @activity = Exercise.find(activity_id) if activity_id
     @judge = Judge.find(params[:judge_id]) if params[:judge_id]
 
     if @activity

--- a/test/controllers/submissions_controller_test.rb
+++ b/test/controllers/submissions_controller_test.rb
@@ -460,4 +460,11 @@ class SubmissionsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :ok
   end
+
+  test 'should be able to use legacy paths containing `exercise`' do
+    course = create :course, series_count: 1, activities_per_series: 1
+    get course_series_exercise_submissions_path(course, course.series.first, course.series.first.exercises.first)
+
+    assert_response :ok
+  end
 end


### PR DESCRIPTION
This pull request fixes the support for the path `/courses/?/series/?/exercises/?/submissions`. 

The `/exercises` paths have all been renamed to `/activities`, yet our routes still offer legacy support for `/exercises`. I didn't find any internal references that use the `/exercises` name, so I assume the bug was discovered by an external link.

I am also open to dropping the support for `/exercises`

- [x] test were added

Fixes an issue come in by mail, where a user tried to navigate to https://dodona.be/en/courses/156/series/2328/exercises/1963184607/submissions
For reference, the internally linked path https://dodona.be/en/courses/156/series/2328/activities/1963184607/submissions does work
