### PR TITLE
Add user manual to footer

### DIFF
--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -4,13 +4,16 @@
   </div>
   <div class='footer-spacer'></div>
   <div class="footer-block">
-    <a href="https://twitter.com/DodonaEdu" target="_blank" rel="noopener">
-      <i class="mdi mdi-twitter"></i>
-    </a>
-    <a href="https://facebook.com/DodonaEdu" target="_blank" rel="noopener">
-      <i class="mdi mdi-facebook"></i>
-    </a>
+    <div>
+      <a href="https://twitter.com/DodonaEdu" target="_blank" rel="noopener">
+        <i class="mdi mdi-twitter"></i>
+      </a>
+      <a href="https://facebook.com/DodonaEdu" target="_blank" rel="noopener">
+        <i class="mdi mdi-facebook"></i>
+      </a>
+    </div>
     <%= link_to t("layout.footer.support_dodona"), support_us_path, class: "btn btn-outline support" %>
+    <%= link_to t("layout.menu.manual"), "https://docs.dodona.be/#{I18n.locale}" %>
     <%= link_to 'Contact', contact_path %>
     <%= link_to 'Status', status_path, target: "_blank", rel: "noopener", class: "d-none d-lg-inline" %>
     <%= link_to t("layout.footer.privacy_statement"), privacy_path %>

--- a/yarn.lock
+++ b/yarn.lock
@@ -4352,7 +4352,7 @@ eslint-visitor-keys@^3.3.0, eslint-visitor-keys@^3.4.3:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz#0cd72fe8550e3c2eae156a96a4dddcd1c8ac5800"
   integrity sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==
 
-eslint-visitor-keys@^4.0.0, eslint-visitor-keys@^4.1.0:
+eslint-visitor-keys@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-4.1.0.tgz#1f785cc5e81eb7534523d85922248232077d2f8c"
   integrity sha512-Q7lok0mqMUSf5a/AdAZkA5a/gHcO6snwQClVNNvFKCAVlxXucdU8pKydU5ZVZjBx5xr37vGbFFWtLQYreLzrZg==
@@ -4398,7 +4398,7 @@ eslint@^9.12.0:
     optionator "^0.9.3"
     text-table "^0.2.0"
 
-espree@^10.0.1, espree@^10.1.0, espree@^10.2.0:
+espree@^10.0.1, espree@^10.2.0:
   version "10.2.0"
   resolved "https://registry.yarnpkg.com/espree/-/espree-10.2.0.tgz#f4bcead9e05b0615c968e85f83816bc386a45df6"
   integrity sha512-upbkBJbckcCNBDBDXEbuhjbP68n+scUd3k/U2EkyM9nw+I/jPiL4cLF/Al06CF96wRltFda16sxDFrxsI1v0/g==


### PR DESCRIPTION
This pull request adds a link to our documentation to the footer of our website.
I also grouped the Facebook and twitter icons so that the footer doesn't take up too much height on small screens.

![image](https://github.com/user-attachments/assets/a677982d-3dd2-4437-acb5-3f30360a9dbc)

![image](https://github.com/user-attachments/assets/e782b7f8-765c-432b-982e-14ffd42dc261)
