### PR TITLE
Log usage of legacy identities

### DIFF
--- a/app/controllers/auth/omniauth_callbacks_controller.rb
+++ b/app/controllers/auth/omniauth_callbacks_controller.rb
@@ -235,6 +235,8 @@ class Auth::OmniauthCallbacksController < Devise::OmniauthCallbacksController
       identity = Identity.joins(:user).find_by(user: { first_name: auth_hash.info.first_name, last_name: auth_hash.info.last_name }, provider: provider, identifier_based_on_email: true) if identity.nil?
       return nil if identity.nil?
 
+      Event.new(event_type: :other, message: 'Office365 user signed in with legacy identifier').save!
+
       # Update the identifier to the new uid
       identity.update(identifier: auth_uid, identifier_based_on_email: false)
     elsif provider.class.sym == :smartschool && auth_username.present?
@@ -248,6 +250,8 @@ class Auth::OmniauthCallbacksController < Devise::OmniauthCallbacksController
       # Try to find user by name
       identity = Identity.joins(:user).find_by(user: { first_name: auth_hash.info.first_name, last_name: auth_hash.info.last_name }, provider: provider, identifier_based_on_username: true) if identity.nil?
       return nil if identity.nil?
+
+      Event.new(event_type: :other, message: 'Smartschool user signed in with legacy identifier').save!
 
       # Update the identifier to the new uid
       identity.update(identifier: auth_uid, identifier_based_on_username: false)

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -11,7 +11,7 @@
 #
 
 class Event < ApplicationRecord
-  enum :event_type, { rejudge: 0, permission_change: 1, exercise_repository: 2, error: 3 }
+  enum :event_type, { rejudge: 0, permission_change: 1, exercise_repository: 2, error: 3, other: 4 }
   belongs_to :user, optional: true
 
   validates :event_type, presence: true

--- a/config/locales/models/en.yml
+++ b/config/locales/models/en.yml
@@ -175,6 +175,7 @@ en:
           permission_change: Change in permission level
           exercise_repository: Creation of exercise repository
           error: Error
+          other: Other
       export:
         statuses:
           started: Started

--- a/config/locales/models/nl.yml
+++ b/config/locales/models/nl.yml
@@ -176,6 +176,7 @@ nl:
           permission_change: Verandering in toegangsniveau
           exercise_repository: Aanmaak van oefeningenrepository
           error: Error
+          other: Overige
       export:
         statuses:
           started: Begonnen


### PR DESCRIPTION
This pull request adds logging of usage of legacy sign in methods. If they remain unused for at least 1 month, they will be removed by #5791

