### PR TITLE
Correctly transfer 'last_updated_by' for annotations when merging users

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -430,7 +430,8 @@ class User < ApplicationRecord
       events.each { |e| e.update!(user: other) }
       exports.each { |e| e.update!(user: other) }
       notifications.each { |n| n.update!(user: other) }
-      annotations.each { |a| a.update!(user: other, last_updated_by_id: other.id) }
+      annotations.each { |a| a.update!(user: other) }
+      Annotation.where(last_updated_by_id: id).find_each { |a| a.update!(last_updated_by: other) }
       questions.each { |q| q.update!(user: other) }
 
       evaluation_users.each do |eu|

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -846,6 +846,31 @@ class UserHasManyTest < ActiveSupport::TestCase
     assert_equal 2, u2.announcement_views.count
   end
 
+  test 'merge should transfer last_updated_by of non owned annotations' do
+    u1 = create :user
+    u2 = create :user
+
+    student = create :user
+
+    c = create :course, series_count: 1, exercises_per_series: 1
+    c.administrating_members << u1
+    c.enrolled_members << student
+
+    s = create :submission, user: student, course: c
+
+    a1 = create :annotation, user: u1, submission: s
+    a2 = create :annotation, user: create(:user), submission: s
+
+    a2.update(last_updated_by: u1)
+
+    result = u1.merge_into(u2)
+
+    assert result
+    assert_not u1.persisted?
+    assert_equal u2, a1.reload.last_updated_by
+    assert_equal u2, a2.reload.last_updated_by
+  end
+
   test 'jump back in should return most recent incomplete activity' do
     user = create :user
 


### PR DESCRIPTION
This pull request fixes the merge users script for transferring the last_updated_by status on non owned submissions.

- [x] test are added
