### PR TITLE
Only perform eager search after url is set

### DIFF
--- a/app/assets/javascripts/components/search/search_field.ts
+++ b/app/assets/javascripts/components/search/search_field.ts
@@ -79,8 +79,6 @@ export class SearchFieldSuggestion extends FilterElement {
 export class SearchField extends FilterCollection {
     @property({ type: String })
     placeholder: string;
-    @property({ type: Boolean })
-    eager: boolean;
 
     @property({ state: true })
     filter?: string = "";
@@ -108,13 +106,6 @@ export class SearchField extends FilterCollection {
         const setFilter = (): string => this.filter = searchQueryState.queryParams.get("filter") || "";
         searchQueryState.queryParams.subscribe(setFilter, "filter");
         setFilter();
-    }
-
-    update(changedProperties: Map<string, unknown>): void {
-        if (changedProperties.has("eager") && this.eager) {
-            search.search();
-        }
-        super.update(changedProperties);
     }
 
     keydown(e: KeyboardEvent): void {

--- a/app/views/layouts/_searchbar.html.erb
+++ b/app/views/layouts/_searchbar.html.erb
@@ -49,7 +49,7 @@
 
         dodona.search.updateFilters(<%= raw json_escape(@filters.to_json) %>);
 
-        <%= if local_assigns.fetch :eager, false %>
+        <% if local_assigns.fetch :eager, false %>
             dodona.search.search();
         <% end %>
     });

--- a/app/views/layouts/_searchbar.html.erb
+++ b/app/views/layouts/_searchbar.html.erb
@@ -49,8 +49,8 @@
 
         dodona.search.updateFilters(<%= raw json_escape(@filters.to_json) %>);
 
-        if (<%= local_assigns.fetch :eager, false %>) {
+        <%= if local_assigns.fetch :eager, false %>
             dodona.search.search();
-        }
+        <% end %>
     });
 </script>

--- a/app/views/layouts/_searchbar.html.erb
+++ b/app/views/layouts/_searchbar.html.erb
@@ -13,7 +13,6 @@
     <i class="mdi mdi-magnify"></i>
     <form class='search' onsubmit="return false;">
       <d-search-field placeholder="<%= t("layout.search.search") %>"
-                      eager="<%= local_assigns.fetch :eager, false %>"
                       hide="<%= no_filter_for.to_json %>"
       ></d-search-field>
       <d-loading-bar search-based></d-loading-bar>
@@ -49,5 +48,9 @@
         dodona.search.setLocalStorageKey(localStorageKey);
 
         dodona.search.updateFilters(<%= raw json_escape(@filters.to_json) %>);
+
+        if (<%= local_assigns.fetch :eager, false %>) {
+            dodona.search.search();
+        }
     });
 </script>

--- a/app/views/series/edit.html.erb
+++ b/app/views/series/edit.html.erb
@@ -22,6 +22,7 @@
                   <div class="col-sm-9">
                     <div class="d-flex" id="access_token_field">
                       <%= render partial: 'token_field',
+                                 formats: [:html],
                                  locals: {
                                      name: :access_token,
                                      value: series_url(@series, token: @series.access_token),


### PR DESCRIPTION
This pull request makes sure eager search requests are only performed after the desired url has been set.

This solves a bug which caused eager search requests on the series edit page to try a js search request on the edit page instead of the activity index page. Because it requested js, the series edit page also rendered the js `token_field` partial instead of the html `token_field` partial. I also added a fix for that now, as the html page should always render the html partial.

this bug was caused by changes in searchbar in #5471