### PR TITLE
Add update_activity errors to aggregated errors for mailing

### DIFF
--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -274,6 +274,9 @@ class Repository < ApplicationRecord
     end
 
     act.save
+  rescue ConfigParseError => e
+    # add error to the list of errors
+    errors.push e
   end
 
   def github_url(path = nil, mode: nil)

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -154,7 +154,7 @@ class Repository < ApplicationRecord
       read_config_file(full_path.join(Activity::DIRCONFIG_FILE))
     rescue ConfigParseError => e
       errors.push e
-      raise AggregatedConfigErrors.new(self, errors)
+      activity_dirs_and_configs = []
     end
 
     existing_activities = activity_dirs_and_configs

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -275,7 +275,8 @@ class Repository < ApplicationRecord
 
     act.save
   rescue ConfigParseError => e
-    # add error to the list of errors
+    # Add error to the list of errors encountered during processing
+    # This way the error will be picked up and aggregated in the process_activities method
     errors.push e
   end
 

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -162,9 +162,9 @@ class Repository < ApplicationRecord
                           .map { |d, c| [d, Activity.find_by(repository_token: c['internals']['token'], repository_id: id)] }
                           # rubocop:disable Style/CollectionCompact
                           # This is a false positive for Hash#compact, where this is Array#compact
-                          .reject { |_, e| e.nil? }
+                          .reject { |_, a| a.nil? }
                           # rubocop:enable Style/CollectionCompact
-                          .group_by { |_, e| e }
+                          .group_by { |_, a| a }
                           .transform_values { |l| l.pluck(0) }
     handled_directories = []
     handled_activity_ids = []


### PR DESCRIPTION
This pull request fixes a config parser error email not being sent when the error was in the outer `dirconfig.json`

Also renamed some variables from `e(xercise)`  to `a(ctivity)` to please robocop variable reuse issues with the `e(rror)` variable