### PR TITLE
Add img as allowed tag to sanitizer

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -134,7 +134,7 @@ module ApplicationHelper
 
   def sanitize(html)
     @tags ||= Rails::Html::SafeListSanitizer.allowed_tags.to_a +
-              %w[table thead tbody tr td th colgroup col style summary details] +
+              %w[table thead tbody tr td th colgroup col style summary details img] +
               %w[svg g style circle line rect path polygon polyline text defs]
     @attributes ||= Rails::Html::SafeListSanitizer.allowed_attributes.to_a +
                     %w[style target data-bs-toggle data-parent data-tab data-line data-element id] +

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -71,12 +71,17 @@ class ApplicationHelperTest < ActiveSupport::TestCase
     dirty_html = <<~HTML
       <script>alert(1)</script>
       <img src=x onerror=alert(1)>
+      <svg>
+        <script>alert(1)</script>
+        <use xlink:href="javascript:alert(1)"/>
+      </svg>
       <p>Hello
     HTML
     clean_html = sanitize dirty_html
 
     assert_no_match(/<script>/, clean_html)
     assert_no_match(/onerror/, clean_html)
+    assert_no_match(/<use/, clean_html)
     assert_match(/<p>Hello/, clean_html)
   end
 
@@ -94,6 +99,17 @@ class ApplicationHelperTest < ActiveSupport::TestCase
           </tr>
         </tbody>
       </table>
+    HTML
+    clean_html = sanitize dirty_html
+
+    assert_equal dirty_html, clean_html
+  end
+
+  test 'sanitize helper should allow images' do
+    # test link image and base64 image
+    dirty_html = <<~HTML
+      <img src="https://example.com/image.jpg" alt="Image">
+      <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU5ErkJggg==" alt="Red dot">
     HTML
     clean_html = sanitize dirty_html
 


### PR DESCRIPTION
This pull request adds `img` as allowed tag in sanitized html.
This to support more complex SVG's without allowing scripts.

- [x] Tests were added
