### PR TITLE
Allow using `use` tag in sanitized html

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -135,7 +135,7 @@ module ApplicationHelper
   def sanitize(html)
     @tags ||= Rails::Html::SafeListSanitizer.allowed_tags.to_a +
               %w[table thead tbody tr td th colgroup col style summary details img] +
-              %w[svg g style circle line rect path polygon polyline text defs]
+              %w[svg g style circle line rect path polygon polyline text defs use]
     @attributes ||= Rails::Html::SafeListSanitizer.allowed_attributes.to_a +
                     %w[style target data-bs-toggle data-parent data-tab data-line data-element id] +
                     %w[viewBox width height version style class transform id x y rx ry x1 y1 x2 y2 d points fill stroke stroke-width stroke-dasharray cx cy r font-size font-family font-weight font-variant textLength writing-mode glyph-orientation-vertical text-orientation color]

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -74,6 +74,9 @@ class ApplicationHelperTest < ActiveSupport::TestCase
       <svg>
         <script>alert(1)</script>
         <use xlink:href="javascript:alert(1)"/>
+        <use xlink:href="test.svg"/>
+        <use href="javascript:alert(1)"/>
+        <use href="test.svg"/>
       </svg>
       <p>Hello
     HTML
@@ -81,7 +84,7 @@ class ApplicationHelperTest < ActiveSupport::TestCase
 
     assert_no_match(/<script>/, clean_html)
     assert_no_match(/onerror/, clean_html)
-    assert_no_match(/<use/, clean_html)
+    assert_no_match(/xlink:href/, clean_html)
     assert_match(/<p>Hello/, clean_html)
   end
 
@@ -110,7 +113,6 @@ class ApplicationHelperTest < ActiveSupport::TestCase
     dirty_html = <<~HTML
       <img src="https://example.com/image.jpg" alt="Image">
       <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU5ErkJggg==" alt="Red dot">
-      <img alt="Red dot SVG" src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTAiIGhlaWdodD0iMTAiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CjxlbGxpcHNlIHN0eWxlPSJmaWxsOnJlZDsgc3Ryb2tlOm5vbmUiIGN4PSI1IiBjeT0iNSIgcng9IjUiIHJ5PSI1Ii8+Cjwvc3ZnPg==" />
     HTML
     clean_html = sanitize dirty_html
 
@@ -131,6 +133,8 @@ class ApplicationHelperTest < ActiveSupport::TestCase
             <polygon class="border" points="0,1 -0.5773,0 0,-1 0.5773,0 0,1" fill="none"></polygon>
           </g>
         </defs>
+        <use xlink:href="#diamond" x="50" y="50" fill="red"></use>
+        <use href="#diamond" x="50" y="50" fill="red"></use>
         <g id="group1" transform="translate(50,50)">
           <circle cx="0" cy="0" r="40" fill="none"></circle>
           <line class="test" x1="0" y1="0" x2="0" y2="-40"></line>

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -110,6 +110,7 @@ class ApplicationHelperTest < ActiveSupport::TestCase
     dirty_html = <<~HTML
       <img src="https://example.com/image.jpg" alt="Image">
       <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU5ErkJggg==" alt="Red dot">
+      <img alt="Red dot SVG" src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTAiIGhlaWdodD0iMTAiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CjxlbGxpcHNlIHN0eWxlPSJmaWxsOnJlZDsgc3Ryb2tlOm5vbmUiIGN4PSI1IiBjeT0iNSIgcng9IjUiIHJ5PSI1Ii8+Cjwvc3ZnPg==" />
     HTML
     clean_html = sanitize dirty_html
 


### PR DESCRIPTION
This pull request adds the possibility to use `use` tags in html that will pass through our sanitizer.
Looking at the code in the underlying library I deem it safe to use and I have added testcases that should warn us if support in that library changes.

- [x] Tests were added
