### PR TITLE
Also log user when legacy sign in methods are used

### DIFF
--- a/app/controllers/auth/omniauth_callbacks_controller.rb
+++ b/app/controllers/auth/omniauth_callbacks_controller.rb
@@ -235,7 +235,7 @@ class Auth::OmniauthCallbacksController < Devise::OmniauthCallbacksController
       identity = Identity.joins(:user).find_by(user: { first_name: auth_hash.info.first_name, last_name: auth_hash.info.last_name }, provider: provider, identifier_based_on_email: true) if identity.nil?
       return nil if identity.nil?
 
-      Event.new(event_type: :other, message: 'Office365 user signed in with legacy identifier').save!
+      Event.new(event_type: :other, message: 'Office365 user signed in with legacy identifier', user: identity.user).save!
 
       # Update the identifier to the new uid
       identity.update(identifier: auth_uid, identifier_based_on_email: false)
@@ -251,7 +251,7 @@ class Auth::OmniauthCallbacksController < Devise::OmniauthCallbacksController
       identity = Identity.joins(:user).find_by(user: { first_name: auth_hash.info.first_name, last_name: auth_hash.info.last_name }, provider: provider, identifier_based_on_username: true) if identity.nil?
       return nil if identity.nil?
 
-      Event.new(event_type: :other, message: 'Smartschool user signed in with legacy identifier').save!
+      Event.new(event_type: :other, message: 'Smartschool user signed in with legacy identifier', user: identity.user).save!
 
       # Update the identifier to the new uid
       identity.update(identifier: auth_uid, identifier_based_on_username: false)


### PR DESCRIPTION
This pull request adds the user to events.

In order to decide if we can get rid of the legacy sign in methods I wanted to see which accounts have been unused for more then 2 years and are picked up again. (Also to verify what the impact would be if we had given them a new account instead).

See https://dodona.be/en/events/?event_type=other
