### PR TITLE
Correctly copy all series info when copying courses

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -155,7 +155,7 @@ class CoursesController < ApplicationController
         deadlines: false
       }.merge(@copy_options).symbolize_keys
 
-      @course.series = policy_scope(@copy_options[:base].series).map do |s|
+      @course.series = policy_scope(@copy_options[:base].series.reorder(id: :asc)).map do |s|
         # rubocop:disable Style/MultilineTernaryOperator
         Series.new(
           series_memberships: @copy_options[:exercises] ?
@@ -169,7 +169,9 @@ class CoursesController < ApplicationController
           visibility_start: @copy_options[:hide_series] ? nil : s.visibility_start,
           deadline: @copy_options[:deadlines] ? s.deadline : nil,
           order: s.order,
-          progress_enabled: s.progress_enabled
+          progress_enabled: s.progress_enabled,
+          activities_visible: s.activities_visible,
+          activity_numbers_enabled: s.activity_numbers_enabled
         )
         # rubocop:enable Style/MultilineTernaryOperator
       end

--- a/test/controllers/courses_controller_test.rb
+++ b/test/controllers/courses_controller_test.rb
@@ -747,7 +747,7 @@ class CoursesPermissionControllerTest < ActionDispatch::IntegrationTest
     assert_includes course.subscribed_members, user
   end
 
-  test 'a course copied by staff who isn't course admin should not include hidden/closed series' do
+  test "a course copied by staff who isn't course admin should not include hidden/closed series" do
     user = create :user, permission: :staff
     course = create :course
     course.enrolled_members << user

--- a/test/controllers/courses_controller_test.rb
+++ b/test/controllers/courses_controller_test.rb
@@ -747,7 +747,7 @@ class CoursesPermissionControllerTest < ActionDispatch::IntegrationTest
     assert_includes course.subscribed_members, user
   end
 
-  test 'a course copied by a regular student should not include hidden/closed series' do
+  test 'a course copied by staff who isn't course admin should not include hidden/closed series' do
     user = create :user, permission: :staff
     course = create :course
     course.enrolled_members << user

--- a/test/controllers/courses_controller_test.rb
+++ b/test/controllers/courses_controller_test.rb
@@ -763,7 +763,7 @@ class CoursesPermissionControllerTest < ActionDispatch::IntegrationTest
     new_course = build :course
     post courses_url, params: { course: { name: new_course.name, description: new_course.description, visibility: new_course.visibility, registration: new_course.registration, teacher: new_course.teacher }, copy_options: { base_id: course.id }, format: :json }
 
-    assert_equal 0, Course.find(response.parsed_body['id']).series.count
+    assert_equal 2, Course.find(response.parsed_body['id']).series.count
   end
 
   test 'a copied course should contain all series with the same advanced settings' do

--- a/test/controllers/courses_controller_test.rb
+++ b/test/controllers/courses_controller_test.rb
@@ -748,17 +748,66 @@ class CoursesPermissionControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'a course copied by a regular student should not include hidden/closed series' do
-    add_students
-    user = @students.first
-    user.update(permission: :staff)
+    user = create :user, permission: :staff
     course = create :course
-    _series = create :series, course: course, visibility: :hidden
+    course.enrolled_members << user
+    create :series, course: course, visibility: :hidden
+    create :series, course: course, visibility: :closed
+    create :series, course: course, visibility: :timed, visibility_start: 1.day.from_now
+    create :series, course: course, visibility: :timed, visibility_start: 1.day.ago
+    create :series, course: course, visibility: :open
+
+    assert_equal 5, course.reload.series.count
 
     sign_in user
     new_course = build :course
     post courses_url, params: { course: { name: new_course.name, description: new_course.description, visibility: new_course.visibility, registration: new_course.registration, teacher: new_course.teacher }, copy_options: { base_id: course.id }, format: :json }
 
     assert_equal 0, Course.find(response.parsed_body['id']).series.count
+  end
+
+  test 'a copied course should contain all series with the same advanced settings' do
+    user = create :user, permission: :staff
+    course = create :course
+    course.administrating_members << user
+    create :series, course: course, progress_enabled: false, activities_visible: false, activity_numbers_enabled: true, name: 'foo'
+    create :series, course: course, progress_enabled: true, activities_visible: true, activity_numbers_enabled: false, name: 'bar'
+
+    sign_in user
+    new_course = build :course
+    post courses_url, params: { course: { name: new_course.name, description: new_course.description, visibility: new_course.visibility, registration: new_course.registration, teacher: new_course.teacher }, copy_options: { base_id: course.id }, format: :json }
+    new_course = Course.find(response.parsed_body['id'])
+
+    assert_equal 2, new_course.series.count
+
+    new_course.series.zip(course.series).each do |series, original_series|
+      assert_equal original_series.name, series.name
+      assert_equal original_series.progress_enabled, series.progress_enabled
+      assert_equal original_series.activities_visible, series.activities_visible
+      assert_equal original_series.activity_numbers_enabled, series.activity_numbers_enabled
+    end
+  end
+
+  test 'a copied course should maintain the same series order' do
+    user = create :user, permission: :staff
+    course = create :course
+    course.administrating_members << user
+    create :series, course: course, name: 'second'
+    create :series, course: course, name: 'first'
+    create :series, course: course, name: 'third', order: 1
+    create :series, course: course, name: 'fifth', order: 3
+    create :series, course: course, name: 'fourth', order: 2
+
+    sign_in user
+    new_course = build :course
+    post courses_url, params: { course: { name: new_course.name, description: new_course.description, visibility: new_course.visibility, registration: new_course.registration, teacher: new_course.teacher }, copy_options: { base_id: course.id }, format: :json }
+    new_course = Course.find(response.parsed_body['id'])
+
+    assert_equal course.series.pluck(:name), new_course.series.pluck(:name)
+    new_course.series.zip(course.series).each do |series, original_series|
+      assert_equal original_series.name, series.name
+      assert_equal original_series.order, series.order
+    end
   end
 
   test 'hidden course page shown to unsubscribed student should include registration url with secret' do


### PR DESCRIPTION
This pull request fixes multiple bugs related to copying courses.

Firstly a bug in the test for students not being able to copy hidden series. This test also didn't copy visible series as the student wasn't correctly added to the course in the test.

Secondly a bug caused the order of series which have not been manually reordered to be reversed in a copied course.

Thirdly I made sure that advanced series settings are also copied when a course is copied: https://github.com/dodona-edu/dodona/issues/5743

- [x] Tests were added

Closes #5743
