### PR TITLE
Update all annotions to new gem order

### DIFF
--- a/.annotaterb.yml
+++ b/.annotaterb.yml
@@ -26,8 +26,8 @@
 :include_version: false
 :show_check_constraints: false
 :show_complete_foreign_keys: false
-:show_foreign_keys: true
-:show_indexes: true
+:show_foreign_keys: false
+:show_indexes: false
 :simple_indexes: false
 :sort: false
 :timestamp: false

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -3,26 +3,26 @@
 # Table name: activities
 #
 #  id                      :integer          not null, primary key
-#  name_nl                 :string(255)
+#  access                  :integer          default("public"), not null
+#  access_token            :string(16)       not null
+#  allow_unsafe            :boolean          default(FALSE), not null
+#  description_en_present  :boolean          default(FALSE)
+#  description_format      :string(255)
+#  description_nl_present  :boolean          default(FALSE)
+#  draft                   :boolean          default(TRUE)
 #  name_en                 :string(255)
+#  name_nl                 :string(255)
+#  path                    :string(255)
+#  repository_token        :string(64)       not null
+#  search                  :string(4096)
+#  series_count            :integer          default(0), not null
+#  status                  :integer          default("ok")
+#  type                    :string(255)      default("Exercise"), not null
 #  created_at              :datetime         not null
 #  updated_at              :datetime         not null
-#  path                    :string(255)
-#  description_format      :string(255)
-#  repository_id           :integer
 #  judge_id                :integer
-#  status                  :integer          default("ok")
-#  access                  :integer          default("public"), not null
 #  programming_language_id :bigint
-#  search                  :string(4096)
-#  access_token            :string(16)       not null
-#  repository_token        :string(64)       not null
-#  allow_unsafe            :boolean          default(FALSE), not null
-#  type                    :string(255)      default("Exercise"), not null
-#  description_nl_present  :boolean          default(FALSE)
-#  description_en_present  :boolean          default(FALSE)
-#  series_count            :integer          default(0), not null
-#  draft                   :boolean          default(TRUE)
+#  repository_id           :integer
 #
 
 require 'pathname'

--- a/app/models/activity_read_state.rb
+++ b/app/models/activity_read_state.rb
@@ -3,12 +3,12 @@
 # Table name: activity_read_states
 #
 #  id          :bigint           not null, primary key
-#  activity_id :integer          not null
-#  course_id   :integer
-#  user_id     :integer          not null
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
+#  activity_id :integer          not null
+#  course_id   :integer
 #  series_id   :integer
+#  user_id     :integer          not null
 #
 class ActivityReadState < ApplicationRecord
   include FilterableByCourseLabels

--- a/app/models/activity_status.rb
+++ b/app/models/activity_status.rb
@@ -5,19 +5,19 @@
 #  id                          :bigint           not null, primary key
 #  accepted                    :boolean          default(FALSE), not null
 #  accepted_before_deadline    :boolean          default(FALSE), not null
+#  series_id_non_nil           :integer          not null
 #  solved                      :boolean          default(FALSE), not null
-#  started                     :boolean          default(FALSE), not null
 #  solved_at                   :datetime
-#  activity_id                 :integer          not null
-#  series_id                   :integer
-#  user_id                     :integer          not null
+#  started                     :boolean          default(FALSE), not null
 #  created_at                  :datetime         not null
 #  updated_at                  :datetime         not null
-#  last_submission_id          :integer
-#  last_submission_deadline_id :integer
-#  best_submission_id          :integer
+#  activity_id                 :integer          not null
 #  best_submission_deadline_id :integer
-#  series_id_non_nil           :integer          not null
+#  best_submission_id          :integer
+#  last_submission_deadline_id :integer
+#  last_submission_id          :integer
+#  series_id                   :integer
+#  user_id                     :integer          not null
 #
 class ActivityStatus < ApplicationRecord
   # the reverse relations aren't defined because this doesn't make sense and there are no

--- a/app/models/annotation.rb
+++ b/app/models/annotation.rb
@@ -3,22 +3,22 @@
 # Table name: annotations
 #
 #  id                  :bigint           not null, primary key
-#  line_nr             :integer
-#  submission_id       :integer
-#  user_id             :integer
 #  annotation_text     :text(16777215)
+#  column              :integer
+#  columns             :integer
+#  line_nr             :integer
+#  question_state      :integer
+#  rows                :integer          default(1), not null
+#  type                :string(255)      default("Annotation"), not null
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null
-#  evaluation_id       :bigint
-#  type                :string(255)      default("Annotation"), not null
-#  question_state      :integer
-#  last_updated_by_id  :integer          not null
 #  course_id           :integer          not null
+#  evaluation_id       :bigint
+#  last_updated_by_id  :integer          not null
 #  saved_annotation_id :bigint
+#  submission_id       :integer
 #  thread_root_id      :integer
-#  column              :integer
-#  rows                :integer          default(1), not null
-#  columns             :integer
+#  user_id             :integer
 #
 class Annotation < ApplicationRecord
   include ApplicationHelper

--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -3,15 +3,15 @@
 # Table name: announcements
 #
 #  id                  :bigint           not null, primary key
-#  text_nl             :text(65535)      not null
-#  text_en             :text(65535)      not null
 #  start_delivering_at :datetime
 #  stop_delivering_at  :datetime
-#  user_group          :integer          not null
-#  institution_id      :bigint
 #  style               :integer          not null
+#  text_en             :text(65535)      not null
+#  text_nl             :text(65535)      not null
+#  user_group          :integer          not null
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null
+#  institution_id      :bigint
 #
 class Announcement < ApplicationRecord
   has_many :announcement_views, dependent: :destroy

--- a/app/models/announcement_view.rb
+++ b/app/models/announcement_view.rb
@@ -3,10 +3,10 @@
 # Table name: announcement_views
 #
 #  id              :bigint           not null, primary key
-#  announcement_id :bigint           not null
-#  user_id         :integer          not null
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
+#  announcement_id :bigint           not null
+#  user_id         :integer          not null
 #
 class AnnouncementView < ApplicationRecord
   belongs_to :announcement

--- a/app/models/api_token.rb
+++ b/app/models/api_token.rb
@@ -3,11 +3,11 @@
 # Table name: api_tokens
 #
 #  id           :bigint           not null, primary key
-#  user_id      :bigint
-#  token_digest :string(255)
 #  description  :string(255)
+#  token_digest :string(255)
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
+#  user_id      :bigint
 #
 
 require 'digest'

--- a/app/models/content_page.rb
+++ b/app/models/content_page.rb
@@ -3,26 +3,26 @@
 # Table name: activities
 #
 #  id                      :integer          not null, primary key
-#  name_nl                 :string(255)
+#  access                  :integer          default("public"), not null
+#  access_token            :string(16)       not null
+#  allow_unsafe            :boolean          default(FALSE), not null
+#  description_en_present  :boolean          default(FALSE)
+#  description_format      :string(255)
+#  description_nl_present  :boolean          default(FALSE)
+#  draft                   :boolean          default(TRUE)
 #  name_en                 :string(255)
+#  name_nl                 :string(255)
+#  path                    :string(255)
+#  repository_token        :string(64)       not null
+#  search                  :string(4096)
+#  series_count            :integer          default(0), not null
+#  status                  :integer          default("ok")
+#  type                    :string(255)      default("Exercise"), not null
 #  created_at              :datetime         not null
 #  updated_at              :datetime         not null
-#  path                    :string(255)
-#  description_format      :string(255)
-#  repository_id           :integer
 #  judge_id                :integer
-#  status                  :integer          default("ok")
-#  access                  :integer          default("public"), not null
 #  programming_language_id :bigint
-#  search                  :string(4096)
-#  access_token            :string(16)       not null
-#  repository_token        :string(64)       not null
-#  allow_unsafe            :boolean          default(FALSE), not null
-#  type                    :string(255)      default("Exercise"), not null
-#  description_nl_present  :boolean          default(FALSE)
-#  description_en_present  :boolean          default(FALSE)
-#  series_count            :integer          default(0), not null
-#  draft                   :boolean          default(TRUE)
+#  repository_id           :integer
 #
 
 class ContentPage < Activity

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -3,20 +3,20 @@
 # Table name: courses
 #
 #  id                :integer          not null, primary key
-#  name              :string(255)
-#  year              :string(255)
-#  secret            :string(255)
-#  created_at        :datetime         not null
-#  updated_at        :datetime         not null
 #  description       :text(4294967295)
-#  visibility        :integer          default("visible_for_all")
-#  registration      :integer          default("open_for_institutional_users")
-#  teacher           :string(255)
-#  institution_id    :bigint
-#  search            :string(4096)
-#  moderated         :boolean          default(FALSE), not null
 #  enabled_questions :boolean          default(TRUE), not null
 #  featured          :boolean          default(FALSE), not null
+#  moderated         :boolean          default(FALSE), not null
+#  name              :string(255)
+#  registration      :integer          default("open_for_institutional_users")
+#  search            :string(4096)
+#  secret            :string(255)
+#  teacher           :string(255)
+#  visibility        :integer          default("visible_for_all")
+#  year              :string(255)
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  institution_id    :bigint
 #
 
 require 'securerandom'

--- a/app/models/course_label.rb
+++ b/app/models/course_label.rb
@@ -3,10 +3,10 @@
 # Table name: course_labels
 #
 #  id         :bigint           not null, primary key
-#  course_id  :integer          not null
 #  name       :string(255)      not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
+#  course_id  :integer          not null
 #
 
 class CourseLabel < ApplicationRecord

--- a/app/models/course_membership.rb
+++ b/app/models/course_membership.rb
@@ -3,12 +3,12 @@
 # Table name: course_memberships
 #
 #  id         :integer          not null, primary key
-#  course_id  :integer          not null
-#  user_id    :integer          not null
+#  favorite   :boolean          default(FALSE)
 #  status     :integer          default("student"), not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
-#  favorite   :boolean          default(FALSE)
+#  course_id  :integer          not null
+#  user_id    :integer          not null
 #
 
 class CourseMembership < ApplicationRecord

--- a/app/models/course_membership_label.rb
+++ b/app/models/course_membership_label.rb
@@ -3,8 +3,8 @@
 # Table name: course_membership_labels
 #
 #  id                   :bigint           not null, primary key
-#  course_membership_id :integer          not null
 #  course_label_id      :bigint           not null
+#  course_membership_id :integer          not null
 #
 
 class CourseMembershipLabel < ApplicationRecord

--- a/app/models/evaluation.rb
+++ b/app/models/evaluation.rb
@@ -3,11 +3,11 @@
 # Table name: evaluations
 #
 #  id         :bigint           not null, primary key
-#  series_id  :integer
-#  released   :boolean          default(FALSE), not null
 #  deadline   :datetime         not null
+#  released   :boolean          default(FALSE), not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
+#  series_id  :integer
 #
 
 require 'csv'

--- a/app/models/evaluation_exercise.rb
+++ b/app/models/evaluation_exercise.rb
@@ -3,11 +3,11 @@
 # Table name: evaluation_exercises
 #
 #  id            :bigint           not null, primary key
-#  evaluation_id :bigint
-#  exercise_id   :integer
+#  visible_score :boolean          default(TRUE), not null
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
-#  visible_score :boolean          default(TRUE), not null
+#  evaluation_id :bigint
+#  exercise_id   :integer
 #
 class EvaluationExercise < ApplicationRecord
   belongs_to :exercise

--- a/app/models/evaluation_user.rb
+++ b/app/models/evaluation_user.rb
@@ -3,10 +3,10 @@
 # Table name: evaluation_users
 #
 #  id            :bigint           not null, primary key
-#  evaluation_id :bigint
-#  user_id       :integer
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
+#  evaluation_id :bigint
+#  user_id       :integer
 #
 class EvaluationUser < ApplicationRecord
   belongs_to :user

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -4,10 +4,10 @@
 #
 #  id         :bigint           not null, primary key
 #  event_type :integer          not null
-#  user_id    :integer
 #  message    :string(255)      not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
+#  user_id    :integer
 #
 
 class Event < ApplicationRecord

--- a/app/models/exercise.rb
+++ b/app/models/exercise.rb
@@ -3,26 +3,26 @@
 # Table name: activities
 #
 #  id                      :integer          not null, primary key
-#  name_nl                 :string(255)
+#  access                  :integer          default("public"), not null
+#  access_token            :string(16)       not null
+#  allow_unsafe            :boolean          default(FALSE), not null
+#  description_en_present  :boolean          default(FALSE)
+#  description_format      :string(255)
+#  description_nl_present  :boolean          default(FALSE)
+#  draft                   :boolean          default(TRUE)
 #  name_en                 :string(255)
+#  name_nl                 :string(255)
+#  path                    :string(255)
+#  repository_token        :string(64)       not null
+#  search                  :string(4096)
+#  series_count            :integer          default(0), not null
+#  status                  :integer          default("ok")
+#  type                    :string(255)      default("Exercise"), not null
 #  created_at              :datetime         not null
 #  updated_at              :datetime         not null
-#  path                    :string(255)
-#  description_format      :string(255)
-#  repository_id           :integer
 #  judge_id                :integer
-#  status                  :integer          default("ok")
-#  access                  :integer          default("public"), not null
 #  programming_language_id :bigint
-#  search                  :string(4096)
-#  access_token            :string(16)       not null
-#  repository_token        :string(64)       not null
-#  allow_unsafe            :boolean          default(FALSE), not null
-#  type                    :string(255)      default("Exercise"), not null
-#  description_nl_present  :boolean          default(FALSE)
-#  description_en_present  :boolean          default(FALSE)
-#  series_count            :integer          default(0), not null
-#  draft                   :boolean          default(TRUE)
+#  repository_id           :integer
 #
 
 require 'pathname'

--- a/app/models/export.rb
+++ b/app/models/export.rb
@@ -3,10 +3,10 @@
 # Table name: exports
 #
 #  id         :bigint           not null, primary key
-#  user_id    :integer
 #  status     :integer          default("started"), not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
+#  user_id    :integer
 #
 
 class Export < ApplicationRecord

--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -3,13 +3,13 @@
 # Table name: feedbacks
 #
 #  id                     :bigint           not null, primary key
-#  submission_id          :integer
-#  evaluation_id          :bigint
-#  evaluation_user_id     :bigint
-#  evaluation_exercise_id :bigint
 #  completed              :boolean          default(FALSE), not null
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
+#  evaluation_exercise_id :bigint
+#  evaluation_id          :bigint
+#  evaluation_user_id     :bigint
+#  submission_id          :integer
 #
 class Feedback < ApplicationRecord
   include ActiveModel::Dirty

--- a/app/models/identity.rb
+++ b/app/models/identity.rb
@@ -4,12 +4,12 @@
 #
 #  id                           :bigint           not null, primary key
 #  identifier                   :string(255)      not null
-#  provider_id                  :bigint           not null
-#  user_id                      :integer          not null
-#  created_at                   :datetime         not null
-#  updated_at                   :datetime         not null
 #  identifier_based_on_email    :boolean          default(FALSE), not null
 #  identifier_based_on_username :boolean          default(FALSE), not null
+#  created_at                   :datetime         not null
+#  updated_at                   :datetime         not null
+#  provider_id                  :bigint           not null
+#  user_id                      :integer          not null
 #
 class Identity < ApplicationRecord
   belongs_to :provider, inverse_of: :identities

--- a/app/models/judge.rb
+++ b/app/models/judge.rb
@@ -3,15 +3,15 @@
 # Table name: judges
 #
 #  id           :integer          not null, primary key
-#  name         :string(255)
-#  image        :string(255)
-#  path         :string(255)
-#  created_at   :datetime         not null
-#  updated_at   :datetime         not null
-#  renderer     :string(255)      not null
-#  remote       :string(255)
 #  clone_status :integer          default("queued"), not null
 #  deprecated   :boolean          default(FALSE), not null
+#  image        :string(255)
+#  name         :string(255)
+#  path         :string(255)
+#  remote       :string(255)
+#  renderer     :string(255)      not null
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #
 
 class Judge < ApplicationRecord

--- a/app/models/label.rb
+++ b/app/models/label.rb
@@ -3,8 +3,8 @@
 # Table name: labels
 #
 #  id    :bigint           not null, primary key
-#  name  :string(255)      not null
 #  color :integer          not null
+#  name  :string(255)      not null
 #
 
 class Label < ApplicationRecord

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -4,12 +4,12 @@
 #
 #  id              :bigint           not null, primary key
 #  message         :string(255)      not null
-#  read            :boolean          default(FALSE), not null
-#  user_id         :integer          not null
 #  notifiable_type :string(255)
-#  notifiable_id   :bigint
+#  read            :boolean          default(FALSE), not null
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
+#  notifiable_id   :bigint
+#  user_id         :integer          not null
 #
 
 class Notification < ApplicationRecord

--- a/app/models/programming_language.rb
+++ b/app/models/programming_language.rb
@@ -3,13 +3,13 @@
 # Table name: programming_languages
 #
 #  id            :bigint           not null, primary key
-#  name          :string(255)      not null
 #  editor_name   :string(255)      not null
 #  extension     :string(255)      not null
+#  icon          :string(255)
+#  name          :string(255)      not null
+#  renderer_name :string(255)      not null
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
-#  icon          :string(255)
-#  renderer_name :string(255)      not null
 #
 
 class ProgrammingLanguage < ApplicationRecord

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -3,21 +3,21 @@
 # Table name: providers
 #
 #  id                :bigint           not null, primary key
-#  type              :string(255)      default("Provider::Saml"), not null
-#  institution_id    :bigint
-#  identifier        :string(255)
-#  certificate       :text(16777215)
-#  entity_id         :string(255)
-#  slo_url           :string(255)
-#  sso_url           :string(255)
-#  created_at        :datetime         not null
-#  updated_at        :datetime         not null
-#  mode              :integer          default("prefer"), not null
 #  active            :boolean          default(TRUE)
 #  authorization_uri :string(255)
-#  client_id         :string(255)
+#  certificate       :text(16777215)
+#  identifier        :string(255)
 #  issuer            :string(255)
 #  jwks_uri          :string(255)
+#  mode              :integer          default("prefer"), not null
+#  slo_url           :string(255)
+#  sso_url           :string(255)
+#  type              :string(255)      default("Provider::Saml"), not null
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  client_id         :string(255)
+#  entity_id         :string(255)
+#  institution_id    :bigint
 #
 class Provider < ApplicationRecord
   enum :mode, { prefer: 0, redirect: 1, link: 2, secondary: 3 }

--- a/app/models/provider/elixir.rb
+++ b/app/models/provider/elixir.rb
@@ -3,21 +3,21 @@
 # Table name: providers
 #
 #  id                :bigint           not null, primary key
-#  type              :string(255)      default("Provider::Saml"), not null
-#  institution_id    :bigint
-#  identifier        :string(255)
-#  certificate       :text(16777215)
-#  entity_id         :string(255)
-#  slo_url           :string(255)
-#  sso_url           :string(255)
-#  created_at        :datetime         not null
-#  updated_at        :datetime         not null
-#  mode              :integer          default("prefer"), not null
 #  active            :boolean          default(TRUE)
 #  authorization_uri :string(255)
-#  client_id         :string(255)
+#  certificate       :text(16777215)
+#  identifier        :string(255)
 #  issuer            :string(255)
 #  jwks_uri          :string(255)
+#  mode              :integer          default("prefer"), not null
+#  slo_url           :string(255)
+#  sso_url           :string(255)
+#  type              :string(255)      default("Provider::Saml"), not null
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  client_id         :string(255)
+#  entity_id         :string(255)
+#  institution_id    :bigint
 #
 class Provider::Elixir < Provider
   validates :certificate, :entity_id, :sso_url, :slo_url, absence: true

--- a/app/models/provider/g_suite.rb
+++ b/app/models/provider/g_suite.rb
@@ -3,21 +3,21 @@
 # Table name: providers
 #
 #  id                :bigint           not null, primary key
-#  type              :string(255)      default("Provider::Saml"), not null
-#  institution_id    :bigint
-#  identifier        :string(255)
-#  certificate       :text(16777215)
-#  entity_id         :string(255)
-#  slo_url           :string(255)
-#  sso_url           :string(255)
-#  created_at        :datetime         not null
-#  updated_at        :datetime         not null
-#  mode              :integer          default("prefer"), not null
 #  active            :boolean          default(TRUE)
 #  authorization_uri :string(255)
-#  client_id         :string(255)
+#  certificate       :text(16777215)
+#  identifier        :string(255)
 #  issuer            :string(255)
 #  jwks_uri          :string(255)
+#  mode              :integer          default("prefer"), not null
+#  slo_url           :string(255)
+#  sso_url           :string(255)
+#  type              :string(255)      default("Provider::Saml"), not null
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  client_id         :string(255)
+#  entity_id         :string(255)
+#  institution_id    :bigint
 #
 class Provider::GSuite < Provider
   validates :certificate, :entity_id, :sso_url, :slo_url, absence: true

--- a/app/models/provider/lti.rb
+++ b/app/models/provider/lti.rb
@@ -3,21 +3,21 @@
 # Table name: providers
 #
 #  id                :bigint           not null, primary key
-#  type              :string(255)      default("Provider::Saml"), not null
-#  institution_id    :bigint
-#  identifier        :string(255)
-#  certificate       :text(16777215)
-#  entity_id         :string(255)
-#  slo_url           :string(255)
-#  sso_url           :string(255)
-#  created_at        :datetime         not null
-#  updated_at        :datetime         not null
-#  mode              :integer          default("prefer"), not null
 #  active            :boolean          default(TRUE)
 #  authorization_uri :string(255)
-#  client_id         :string(255)
+#  certificate       :text(16777215)
+#  identifier        :string(255)
 #  issuer            :string(255)
 #  jwks_uri          :string(255)
+#  mode              :integer          default("prefer"), not null
+#  slo_url           :string(255)
+#  sso_url           :string(255)
+#  type              :string(255)      default("Provider::Saml"), not null
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  client_id         :string(255)
+#  entity_id         :string(255)
+#  institution_id    :bigint
 #
 class Provider::Lti < Provider
   validates :certificate, :entity_id, :sso_url, :slo_url, absence: true

--- a/app/models/provider/office365.rb
+++ b/app/models/provider/office365.rb
@@ -3,21 +3,21 @@
 # Table name: providers
 #
 #  id                :bigint           not null, primary key
-#  type              :string(255)      default("Provider::Saml"), not null
-#  institution_id    :bigint
-#  identifier        :string(255)
-#  certificate       :text(16777215)
-#  entity_id         :string(255)
-#  slo_url           :string(255)
-#  sso_url           :string(255)
-#  created_at        :datetime         not null
-#  updated_at        :datetime         not null
-#  mode              :integer          default("prefer"), not null
 #  active            :boolean          default(TRUE)
 #  authorization_uri :string(255)
-#  client_id         :string(255)
+#  certificate       :text(16777215)
+#  identifier        :string(255)
 #  issuer            :string(255)
 #  jwks_uri          :string(255)
+#  mode              :integer          default("prefer"), not null
+#  slo_url           :string(255)
+#  sso_url           :string(255)
+#  type              :string(255)      default("Provider::Saml"), not null
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  client_id         :string(255)
+#  entity_id         :string(255)
+#  institution_id    :bigint
 #
 class Provider::Office365 < Provider
   validates :certificate, :entity_id, :sso_url, :slo_url, absence: true

--- a/app/models/provider/oidc.rb
+++ b/app/models/provider/oidc.rb
@@ -3,21 +3,21 @@
 # Table name: providers
 #
 #  id                :bigint           not null, primary key
-#  type              :string(255)      default("Provider::Saml"), not null
-#  institution_id    :bigint
-#  identifier        :string(255)
-#  certificate       :text(16777215)
-#  entity_id         :string(255)
-#  slo_url           :string(255)
-#  sso_url           :string(255)
-#  created_at        :datetime         not null
-#  updated_at        :datetime         not null
-#  mode              :integer          default("prefer"), not null
 #  active            :boolean          default(TRUE)
 #  authorization_uri :string(255)
-#  client_id         :string(255)
+#  certificate       :text(16777215)
+#  identifier        :string(255)
 #  issuer            :string(255)
 #  jwks_uri          :string(255)
+#  mode              :integer          default("prefer"), not null
+#  slo_url           :string(255)
+#  sso_url           :string(255)
+#  type              :string(255)      default("Provider::Saml"), not null
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  client_id         :string(255)
+#  entity_id         :string(255)
+#  institution_id    :bigint
 #
 class Provider::Oidc < Provider
   validates :certificate, :entity_id, :sso_url, :slo_url, absence: true

--- a/app/models/provider/saml.rb
+++ b/app/models/provider/saml.rb
@@ -3,21 +3,21 @@
 # Table name: providers
 #
 #  id                :bigint           not null, primary key
-#  type              :string(255)      default("Provider::Saml"), not null
-#  institution_id    :bigint
-#  identifier        :string(255)
-#  certificate       :text(16777215)
-#  entity_id         :string(255)
-#  slo_url           :string(255)
-#  sso_url           :string(255)
-#  created_at        :datetime         not null
-#  updated_at        :datetime         not null
-#  mode              :integer          default("prefer"), not null
 #  active            :boolean          default(TRUE)
 #  authorization_uri :string(255)
-#  client_id         :string(255)
+#  certificate       :text(16777215)
+#  identifier        :string(255)
 #  issuer            :string(255)
 #  jwks_uri          :string(255)
+#  mode              :integer          default("prefer"), not null
+#  slo_url           :string(255)
+#  sso_url           :string(255)
+#  type              :string(255)      default("Provider::Saml"), not null
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  client_id         :string(255)
+#  entity_id         :string(255)
+#  institution_id    :bigint
 #
 class Provider::Saml < Provider
   validates :certificate, :entity_id, :sso_url, :slo_url, presence: true

--- a/app/models/provider/smartschool.rb
+++ b/app/models/provider/smartschool.rb
@@ -3,21 +3,21 @@
 # Table name: providers
 #
 #  id                :bigint           not null, primary key
-#  type              :string(255)      default("Provider::Saml"), not null
-#  institution_id    :bigint
-#  identifier        :string(255)
-#  certificate       :text(16777215)
-#  entity_id         :string(255)
-#  slo_url           :string(255)
-#  sso_url           :string(255)
-#  created_at        :datetime         not null
-#  updated_at        :datetime         not null
-#  mode              :integer          default("prefer"), not null
 #  active            :boolean          default(TRUE)
 #  authorization_uri :string(255)
-#  client_id         :string(255)
+#  certificate       :text(16777215)
+#  identifier        :string(255)
 #  issuer            :string(255)
 #  jwks_uri          :string(255)
+#  mode              :integer          default("prefer"), not null
+#  slo_url           :string(255)
+#  sso_url           :string(255)
+#  type              :string(255)      default("Provider::Saml"), not null
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  client_id         :string(255)
+#  entity_id         :string(255)
+#  institution_id    :bigint
 #
 class Provider::Smartschool < Provider
   validates :certificate, :entity_id, :sso_url, :slo_url, absence: true

--- a/app/models/provider/surf.rb
+++ b/app/models/provider/surf.rb
@@ -3,21 +3,21 @@
 # Table name: providers
 #
 #  id                :bigint           not null, primary key
-#  type              :string(255)      default("Provider::Saml"), not null
-#  institution_id    :bigint
-#  identifier        :string(255)
-#  certificate       :text(16777215)
-#  entity_id         :string(255)
-#  slo_url           :string(255)
-#  sso_url           :string(255)
-#  created_at        :datetime         not null
-#  updated_at        :datetime         not null
-#  mode              :integer          default("prefer"), not null
 #  active            :boolean          default(TRUE)
 #  authorization_uri :string(255)
-#  client_id         :string(255)
+#  certificate       :text(16777215)
+#  identifier        :string(255)
 #  issuer            :string(255)
 #  jwks_uri          :string(255)
+#  mode              :integer          default("prefer"), not null
+#  slo_url           :string(255)
+#  sso_url           :string(255)
+#  type              :string(255)      default("Provider::Saml"), not null
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  client_id         :string(255)
+#  entity_id         :string(255)
+#  institution_id    :bigint
 #
 class Provider::Surf < Provider
   validates :certificate, :entity_id, :sso_url, :slo_url, absence: true

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -3,22 +3,22 @@
 # Table name: annotations
 #
 #  id                  :bigint           not null, primary key
-#  line_nr             :integer
-#  submission_id       :integer
-#  user_id             :integer
 #  annotation_text     :text(16777215)
+#  column              :integer
+#  columns             :integer
+#  line_nr             :integer
+#  question_state      :integer
+#  rows                :integer          default(1), not null
+#  type                :string(255)      default("Annotation"), not null
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null
-#  evaluation_id       :bigint
-#  type                :string(255)      default("Annotation"), not null
-#  question_state      :integer
-#  last_updated_by_id  :integer          not null
 #  course_id           :integer          not null
+#  evaluation_id       :bigint
+#  last_updated_by_id  :integer          not null
 #  saved_annotation_id :bigint
+#  submission_id       :integer
 #  thread_root_id      :integer
-#  column              :integer
-#  rows                :integer          default(1), not null
-#  columns             :integer
+#  user_id             :integer
 #
 class Question < Annotation
   include Filterable

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -3,14 +3,14 @@
 # Table name: repositories
 #
 #  id           :integer          not null, primary key
-#  name         :string(255)
-#  remote       :string(255)
-#  path         :string(255)
-#  judge_id     :integer          default(17)
-#  created_at   :datetime         not null
-#  updated_at   :datetime         not null
 #  clone_status :integer          default("queued"), not null
 #  featured     :boolean          default(FALSE)
+#  name         :string(255)
+#  path         :string(255)
+#  remote       :string(255)
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  judge_id     :integer          default(17)
 #
 require 'open3'
 require 'pathname'

--- a/app/models/rights_request.rb
+++ b/app/models/rights_request.rb
@@ -3,11 +3,11 @@
 # Table name: rights_requests
 #
 #  id               :bigint           not null, primary key
-#  user_id          :integer          not null
-#  institution_name :string(255)
 #  context          :text(65535)      not null
+#  institution_name :string(255)
 #  created_at       :datetime         not null
 #  updated_at       :datetime         not null
+#  user_id          :integer          not null
 #
 class RightsRequest < ApplicationRecord
   belongs_to :user

--- a/app/models/saved_annotation.rb
+++ b/app/models/saved_annotation.rb
@@ -3,14 +3,14 @@
 # Table name: saved_annotations
 #
 #  id                :bigint           not null, primary key
-#  title             :string(255)      not null
 #  annotation_text   :text(16777215)
-#  user_id           :integer          not null
-#  exercise_id       :integer
-#  course_id         :integer
+#  annotations_count :integer          default(0)
+#  title             :string(255)      not null
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
-#  annotations_count :integer          default(0)
+#  course_id         :integer
+#  exercise_id       :integer
+#  user_id           :integer          not null
 #
 class SavedAnnotation < ApplicationRecord
   include Filterable

--- a/app/models/score.rb
+++ b/app/models/score.rb
@@ -3,12 +3,12 @@
 # Table name: scores
 #
 #  id                 :bigint           not null, primary key
-#  score_item_id      :bigint           not null
-#  feedback_id        :bigint           not null
 #  score              :decimal(5, 2)    not null
-#  last_updated_by_id :integer          not null
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null
+#  feedback_id        :bigint           not null
+#  last_updated_by_id :integer          not null
+#  score_item_id      :bigint           not null
 #
 class Score < ApplicationRecord
   attribute :score, :decimal

--- a/app/models/score_item.rb
+++ b/app/models/score_item.rb
@@ -3,14 +3,14 @@
 # Table name: score_items
 #
 #  id                     :bigint           not null, primary key
-#  evaluation_exercise_id :bigint           not null
+#  description            :text(65535)
 #  maximum                :decimal(5, 2)    not null
 #  name                   :string(255)      not null
+#  order                  :integer
 #  visible                :boolean          default(TRUE), not null
-#  description            :text(65535)
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
-#  order                  :integer
+#  evaluation_exercise_id :bigint           not null
 #
 class ScoreItem < ApplicationRecord
   belongs_to :evaluation_exercise

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -3,20 +3,20 @@
 # Table name: series
 #
 #  id                       :integer          not null, primary key
-#  course_id                :integer
-#  name                     :string(255)
+#  access_token             :string(255)
+#  activities_count         :integer
+#  activities_visible       :boolean          default(TRUE), not null
+#  activity_numbers_enabled :boolean          default(FALSE), not null
+#  deadline                 :datetime
 #  description              :text(4294967295)
-#  visibility               :integer
+#  name                     :string(255)
 #  order                    :integer          default(0), not null
+#  progress_enabled         :boolean          default(TRUE), not null
+#  visibility               :integer
+#  visibility_start         :datetime
 #  created_at               :datetime         not null
 #  updated_at               :datetime         not null
-#  deadline                 :datetime
-#  access_token             :string(255)
-#  progress_enabled         :boolean          default(TRUE), not null
-#  activities_visible       :boolean          default(TRUE), not null
-#  activities_count         :integer
-#  activity_numbers_enabled :boolean          default(FALSE), not null
-#  visibility_start         :datetime
+#  course_id                :integer
 #
 
 require 'csv'

--- a/app/models/series_membership.rb
+++ b/app/models/series_membership.rb
@@ -3,11 +3,11 @@
 # Table name: series_memberships
 #
 #  id          :integer          not null, primary key
-#  series_id   :integer
-#  activity_id :integer
 #  order       :integer          default(999)
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
+#  activity_id :integer
+#  series_id   :integer
 #
 
 class SeriesMembership < ApplicationRecord

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -3,18 +3,18 @@
 # Table name: submissions
 #
 #  id          :integer          not null, primary key
-#  exercise_id :integer
-#  user_id     :integer
+#  accepted    :boolean          default(FALSE)
+#  annotated   :boolean          default(FALSE), not null
+#  fs_key      :string(24)
+#  number      :integer
+#  status      :integer
 #  summary     :string(255)
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
-#  status      :integer
-#  accepted    :boolean          default(FALSE)
 #  course_id   :integer
-#  fs_key      :string(24)
-#  number      :integer
-#  annotated   :boolean          default(FALSE), not null
+#  exercise_id :integer
 #  series_id   :integer
+#  user_id     :integer
 #
 
 class Submission < ApplicationRecord

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,22 +3,22 @@
 # Table name: users
 #
 #  id                   :integer          not null, primary key
-#  username             :string(255)
-#  first_name           :string(255)
-#  last_name            :string(255)
 #  email                :string(255)
-#  permission           :integer          default("student")
-#  created_at           :datetime         not null
-#  updated_at           :datetime         not null
+#  first_name           :string(255)
 #  lang                 :string(255)      default("nl")
-#  token                :string(255)
-#  time_zone            :string(255)      default("Brussels")
-#  institution_id       :bigint
+#  last_name            :string(255)
+#  open_questions_count :integer          default(0), not null
+#  permission           :integer          default("student")
 #  search               :string(4096)
 #  seen_at              :datetime
 #  sign_in_at           :datetime
-#  open_questions_count :integer          default(0), not null
 #  theme                :integer          default("system"), not null
+#  time_zone            :string(255)      default("Brussels")
+#  token                :string(255)
+#  username             :string(255)
+#  created_at           :datetime         not null
+#  updated_at           :datetime         not null
+#  institution_id       :bigint
 #
 
 require 'securerandom'

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_10_17_143229) do
+ActiveRecord::Schema[8.0].define(version: 2024_10_17_143229) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false

--- a/test/factories/activity_statuses.rb
+++ b/test/factories/activity_statuses.rb
@@ -5,19 +5,19 @@
 #  id                          :bigint           not null, primary key
 #  accepted                    :boolean          default(FALSE), not null
 #  accepted_before_deadline    :boolean          default(FALSE), not null
+#  series_id_non_nil           :integer          not null
 #  solved                      :boolean          default(FALSE), not null
-#  started                     :boolean          default(FALSE), not null
 #  solved_at                   :datetime
-#  activity_id                 :integer          not null
-#  series_id                   :integer
-#  user_id                     :integer          not null
+#  started                     :boolean          default(FALSE), not null
 #  created_at                  :datetime         not null
 #  updated_at                  :datetime         not null
-#  last_submission_id          :integer
-#  last_submission_deadline_id :integer
-#  best_submission_id          :integer
+#  activity_id                 :integer          not null
 #  best_submission_deadline_id :integer
-#  series_id_non_nil           :integer          not null
+#  best_submission_id          :integer
+#  last_submission_deadline_id :integer
+#  last_submission_id          :integer
+#  series_id                   :integer
+#  user_id                     :integer          not null
 #
 FactoryBot.define do
   factory :activity_status

--- a/test/factories/annotations.rb
+++ b/test/factories/annotations.rb
@@ -3,22 +3,22 @@
 # Table name: annotations
 #
 #  id                  :bigint           not null, primary key
-#  line_nr             :integer
-#  submission_id       :integer
-#  user_id             :integer
 #  annotation_text     :text(16777215)
+#  column              :integer
+#  columns             :integer
+#  line_nr             :integer
+#  question_state      :integer
+#  rows                :integer          default(1), not null
+#  type                :string(255)      default("Annotation"), not null
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null
-#  evaluation_id       :bigint
-#  type                :string(255)      default("Annotation"), not null
-#  question_state      :integer
-#  last_updated_by_id  :integer          not null
 #  course_id           :integer          not null
+#  evaluation_id       :bigint
+#  last_updated_by_id  :integer          not null
 #  saved_annotation_id :bigint
+#  submission_id       :integer
 #  thread_root_id      :integer
-#  column              :integer
-#  rows                :integer          default(1), not null
-#  columns             :integer
+#  user_id             :integer
 #
 FactoryBot.define do
   factory :annotation do

--- a/test/factories/api_tokens.rb
+++ b/test/factories/api_tokens.rb
@@ -3,11 +3,11 @@
 # Table name: api_tokens
 #
 #  id           :bigint           not null, primary key
-#  user_id      :bigint
-#  token_digest :string(255)
 #  description  :string(255)
+#  token_digest :string(255)
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
+#  user_id      :bigint
 #
 
 FactoryBot.define do

--- a/test/factories/content_pages.rb
+++ b/test/factories/content_pages.rb
@@ -3,26 +3,26 @@
 # Table name: activities
 #
 #  id                      :integer          not null, primary key
-#  name_nl                 :string(255)
+#  access                  :integer          default("public"), not null
+#  access_token            :string(16)       not null
+#  allow_unsafe            :boolean          default(FALSE), not null
+#  description_en_present  :boolean          default(FALSE)
+#  description_format      :string(255)
+#  description_nl_present  :boolean          default(FALSE)
+#  draft                   :boolean          default(TRUE)
 #  name_en                 :string(255)
+#  name_nl                 :string(255)
+#  path                    :string(255)
+#  repository_token        :string(64)       not null
+#  search                  :string(4096)
+#  series_count            :integer          default(0), not null
+#  status                  :integer          default("ok")
+#  type                    :string(255)      default("Exercise"), not null
 #  created_at              :datetime         not null
 #  updated_at              :datetime         not null
-#  path                    :string(255)
-#  description_format      :string(255)
-#  repository_id           :integer
 #  judge_id                :integer
-#  status                  :integer          default("ok")
-#  access                  :integer          default("public"), not null
 #  programming_language_id :bigint
-#  search                  :string(4096)
-#  access_token            :string(16)       not null
-#  repository_token        :string(64)       not null
-#  allow_unsafe            :boolean          default(FALSE), not null
-#  type                    :string(255)      default("Exercise"), not null
-#  description_nl_present  :boolean          default(FALSE)
-#  description_en_present  :boolean          default(FALSE)
-#  series_count            :integer          default(0), not null
-#  draft                   :boolean          default(TRUE)
+#  repository_id           :integer
 #
 
 require "#{File.dirname(__FILE__)}/../testhelpers/stub_helper.rb"

--- a/test/factories/courses.rb
+++ b/test/factories/courses.rb
@@ -3,20 +3,20 @@
 # Table name: courses
 #
 #  id                :integer          not null, primary key
-#  name              :string(255)
-#  year              :string(255)
-#  secret            :string(255)
-#  created_at        :datetime         not null
-#  updated_at        :datetime         not null
 #  description       :text(4294967295)
-#  visibility        :integer          default("visible_for_all")
-#  registration      :integer          default("open_for_institutional_users")
-#  teacher           :string(255)
-#  institution_id    :bigint
-#  search            :string(4096)
-#  moderated         :boolean          default(FALSE), not null
 #  enabled_questions :boolean          default(TRUE), not null
 #  featured          :boolean          default(FALSE), not null
+#  moderated         :boolean          default(FALSE), not null
+#  name              :string(255)
+#  registration      :integer          default("open_for_institutional_users")
+#  search            :string(4096)
+#  secret            :string(255)
+#  teacher           :string(255)
+#  visibility        :integer          default("visible_for_all")
+#  year              :string(255)
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  institution_id    :bigint
 #
 
 FactoryBot.define do

--- a/test/factories/evaluation_exercises.rb
+++ b/test/factories/evaluation_exercises.rb
@@ -3,11 +3,11 @@
 # Table name: evaluation_exercises
 #
 #  id            :bigint           not null, primary key
-#  evaluation_id :bigint
-#  exercise_id   :integer
+#  visible_score :boolean          default(TRUE), not null
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
-#  visible_score :boolean          default(TRUE), not null
+#  evaluation_id :bigint
+#  exercise_id   :integer
 #
 FactoryBot.define do
   factory :evaluation_exercise do

--- a/test/factories/evaluation_users.rb
+++ b/test/factories/evaluation_users.rb
@@ -3,10 +3,10 @@
 # Table name: evaluation_users
 #
 #  id            :bigint           not null, primary key
-#  evaluation_id :bigint
-#  user_id       :integer
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
+#  evaluation_id :bigint
+#  user_id       :integer
 #
 FactoryBot.define do
   factory :evaluation_user do

--- a/test/factories/evaluations.rb
+++ b/test/factories/evaluations.rb
@@ -3,11 +3,11 @@
 # Table name: evaluations
 #
 #  id         :bigint           not null, primary key
-#  series_id  :integer
-#  released   :boolean          default(FALSE), not null
 #  deadline   :datetime         not null
+#  released   :boolean          default(FALSE), not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
+#  series_id  :integer
 #
 FactoryBot.define do
   factory :evaluation do

--- a/test/factories/events.rb
+++ b/test/factories/events.rb
@@ -4,10 +4,10 @@
 #
 #  id         :bigint           not null, primary key
 #  event_type :integer          not null
-#  user_id    :integer
 #  message    :string(255)      not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
+#  user_id    :integer
 #
 
 FactoryBot.define do

--- a/test/factories/exercises.rb
+++ b/test/factories/exercises.rb
@@ -3,26 +3,26 @@
 # Table name: activities
 #
 #  id                      :integer          not null, primary key
-#  name_nl                 :string(255)
+#  access                  :integer          default("public"), not null
+#  access_token            :string(16)       not null
+#  allow_unsafe            :boolean          default(FALSE), not null
+#  description_en_present  :boolean          default(FALSE)
+#  description_format      :string(255)
+#  description_nl_present  :boolean          default(FALSE)
+#  draft                   :boolean          default(TRUE)
 #  name_en                 :string(255)
+#  name_nl                 :string(255)
+#  path                    :string(255)
+#  repository_token        :string(64)       not null
+#  search                  :string(4096)
+#  series_count            :integer          default(0), not null
+#  status                  :integer          default("ok")
+#  type                    :string(255)      default("Exercise"), not null
 #  created_at              :datetime         not null
 #  updated_at              :datetime         not null
-#  path                    :string(255)
-#  description_format      :string(255)
-#  repository_id           :integer
 #  judge_id                :integer
-#  status                  :integer          default("ok")
-#  access                  :integer          default("public"), not null
 #  programming_language_id :bigint
-#  search                  :string(4096)
-#  access_token            :string(16)       not null
-#  repository_token        :string(64)       not null
-#  allow_unsafe            :boolean          default(FALSE), not null
-#  type                    :string(255)      default("Exercise"), not null
-#  description_nl_present  :boolean          default(FALSE)
-#  description_en_present  :boolean          default(FALSE)
-#  series_count            :integer          default(0), not null
-#  draft                   :boolean          default(TRUE)
+#  repository_id           :integer
 #
 
 require "#{File.dirname(__FILE__)}/../testhelpers/stub_helper.rb"

--- a/test/factories/exports.rb
+++ b/test/factories/exports.rb
@@ -3,10 +3,10 @@
 # Table name: exports
 #
 #  id         :bigint           not null, primary key
-#  user_id    :integer
 #  status     :integer          default("started"), not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
+#  user_id    :integer
 #
 
 FactoryBot.define do

--- a/test/factories/identities.rb
+++ b/test/factories/identities.rb
@@ -4,12 +4,12 @@
 #
 #  id                           :bigint           not null, primary key
 #  identifier                   :string(255)      not null
-#  provider_id                  :bigint           not null
-#  user_id                      :integer          not null
-#  created_at                   :datetime         not null
-#  updated_at                   :datetime         not null
 #  identifier_based_on_email    :boolean          default(FALSE), not null
 #  identifier_based_on_username :boolean          default(FALSE), not null
+#  created_at                   :datetime         not null
+#  updated_at                   :datetime         not null
+#  provider_id                  :bigint           not null
+#  user_id                      :integer          not null
 #
 FactoryBot.define do
   factory :identity do

--- a/test/factories/judges.rb
+++ b/test/factories/judges.rb
@@ -3,15 +3,15 @@
 # Table name: judges
 #
 #  id           :integer          not null, primary key
-#  name         :string(255)
-#  image        :string(255)
-#  path         :string(255)
-#  created_at   :datetime         not null
-#  updated_at   :datetime         not null
-#  renderer     :string(255)      not null
-#  remote       :string(255)
 #  clone_status :integer          default("queued"), not null
 #  deprecated   :boolean          default(FALSE), not null
+#  image        :string(255)
+#  name         :string(255)
+#  path         :string(255)
+#  remote       :string(255)
+#  renderer     :string(255)      not null
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #
 
 require "#{File.dirname(__FILE__)}/../testhelpers/stub_helper.rb"

--- a/test/factories/labels.rb
+++ b/test/factories/labels.rb
@@ -3,8 +3,8 @@
 # Table name: labels
 #
 #  id    :bigint           not null, primary key
-#  name  :string(255)      not null
 #  color :integer          not null
+#  name  :string(255)      not null
 #
 
 FactoryBot.define do

--- a/test/factories/notifications.rb
+++ b/test/factories/notifications.rb
@@ -4,12 +4,12 @@
 #
 #  id              :bigint           not null, primary key
 #  message         :string(255)      not null
-#  read            :boolean          default(FALSE), not null
-#  user_id         :integer          not null
 #  notifiable_type :string(255)
-#  notifiable_id   :bigint
+#  read            :boolean          default(FALSE), not null
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
+#  notifiable_id   :bigint
+#  user_id         :integer          not null
 #
 
 FactoryBot.define do

--- a/test/factories/programming_languages.rb
+++ b/test/factories/programming_languages.rb
@@ -3,13 +3,13 @@
 # Table name: programming_languages
 #
 #  id            :bigint           not null, primary key
-#  name          :string(255)      not null
 #  editor_name   :string(255)      not null
 #  extension     :string(255)      not null
+#  icon          :string(255)
+#  name          :string(255)      not null
+#  renderer_name :string(255)      not null
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
-#  icon          :string(255)
-#  renderer_name :string(255)      not null
 #
 
 FactoryBot.define do

--- a/test/factories/providers.rb
+++ b/test/factories/providers.rb
@@ -3,21 +3,21 @@
 # Table name: providers
 #
 #  id                :bigint           not null, primary key
-#  type              :string(255)      default("Provider::Saml"), not null
-#  institution_id    :bigint
-#  identifier        :string(255)
-#  certificate       :text(16777215)
-#  entity_id         :string(255)
-#  slo_url           :string(255)
-#  sso_url           :string(255)
-#  created_at        :datetime         not null
-#  updated_at        :datetime         not null
-#  mode              :integer          default("prefer"), not null
 #  active            :boolean          default(TRUE)
 #  authorization_uri :string(255)
-#  client_id         :string(255)
+#  certificate       :text(16777215)
+#  identifier        :string(255)
 #  issuer            :string(255)
 #  jwks_uri          :string(255)
+#  mode              :integer          default("prefer"), not null
+#  slo_url           :string(255)
+#  sso_url           :string(255)
+#  type              :string(255)      default("Provider::Saml"), not null
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  client_id         :string(255)
+#  entity_id         :string(255)
+#  institution_id    :bigint
 #
 FactoryBot.define do
   factory :gsuite_provider, class: 'Provider::GSuite' do

--- a/test/factories/repositories.rb
+++ b/test/factories/repositories.rb
@@ -3,14 +3,14 @@
 # Table name: repositories
 #
 #  id           :integer          not null, primary key
-#  name         :string(255)
-#  remote       :string(255)
-#  path         :string(255)
-#  judge_id     :integer          default(17)
-#  created_at   :datetime         not null
-#  updated_at   :datetime         not null
 #  clone_status :integer          default("queued"), not null
 #  featured     :boolean          default(FALSE)
+#  name         :string(255)
+#  path         :string(255)
+#  remote       :string(255)
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  judge_id     :integer          default(17)
 #
 
 require "#{File.dirname(__FILE__)}/../testhelpers/stub_helper.rb"

--- a/test/factories/rights_requests.rb
+++ b/test/factories/rights_requests.rb
@@ -3,11 +3,11 @@
 # Table name: rights_requests
 #
 #  id               :bigint           not null, primary key
-#  user_id          :integer          not null
-#  institution_name :string(255)
 #  context          :text(65535)      not null
+#  institution_name :string(255)
 #  created_at       :datetime         not null
 #  updated_at       :datetime         not null
+#  user_id          :integer          not null
 #
 FactoryBot.define do
   factory :rights_request do

--- a/test/factories/saved_annotations.rb
+++ b/test/factories/saved_annotations.rb
@@ -3,14 +3,14 @@
 # Table name: saved_annotations
 #
 #  id                :bigint           not null, primary key
-#  title             :string(255)      not null
 #  annotation_text   :text(16777215)
-#  user_id           :integer          not null
-#  exercise_id       :integer
-#  course_id         :integer
+#  annotations_count :integer          default(0)
+#  title             :string(255)      not null
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
-#  annotations_count :integer          default(0)
+#  course_id         :integer
+#  exercise_id       :integer
+#  user_id           :integer          not null
 #
 FactoryBot.define do
   factory :saved_annotation do

--- a/test/factories/score_items.rb
+++ b/test/factories/score_items.rb
@@ -3,14 +3,14 @@
 # Table name: score_items
 #
 #  id                     :bigint           not null, primary key
-#  evaluation_exercise_id :bigint           not null
+#  description            :text(65535)
 #  maximum                :decimal(5, 2)    not null
 #  name                   :string(255)      not null
+#  order                  :integer
 #  visible                :boolean          default(TRUE), not null
-#  description            :text(65535)
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
-#  order                  :integer
+#  evaluation_exercise_id :bigint           not null
 #
 FactoryBot.define do
   factory :score_item do

--- a/test/factories/scores.rb
+++ b/test/factories/scores.rb
@@ -3,12 +3,12 @@
 # Table name: scores
 #
 #  id                 :bigint           not null, primary key
-#  score_item_id      :bigint           not null
-#  feedback_id        :bigint           not null
 #  score              :decimal(5, 2)    not null
-#  last_updated_by_id :integer          not null
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null
+#  feedback_id        :bigint           not null
+#  last_updated_by_id :integer          not null
+#  score_item_id      :bigint           not null
 #
 FactoryBot.define do
   factory :score do

--- a/test/factories/series.rb
+++ b/test/factories/series.rb
@@ -3,20 +3,20 @@
 # Table name: series
 #
 #  id                       :integer          not null, primary key
-#  course_id                :integer
-#  name                     :string(255)
+#  access_token             :string(255)
+#  activities_count         :integer
+#  activities_visible       :boolean          default(TRUE), not null
+#  activity_numbers_enabled :boolean          default(FALSE), not null
+#  deadline                 :datetime
 #  description              :text(4294967295)
-#  visibility               :integer
+#  name                     :string(255)
 #  order                    :integer          default(0), not null
+#  progress_enabled         :boolean          default(TRUE), not null
+#  visibility               :integer
+#  visibility_start         :datetime
 #  created_at               :datetime         not null
 #  updated_at               :datetime         not null
-#  deadline                 :datetime
-#  access_token             :string(255)
-#  progress_enabled         :boolean          default(TRUE), not null
-#  activities_visible       :boolean          default(TRUE), not null
-#  activities_count         :integer
-#  activity_numbers_enabled :boolean          default(FALSE), not null
-#  visibility_start         :datetime
+#  course_id                :integer
 #
 
 FactoryBot.define do

--- a/test/factories/submissions.rb
+++ b/test/factories/submissions.rb
@@ -3,18 +3,18 @@
 # Table name: submissions
 #
 #  id          :integer          not null, primary key
-#  exercise_id :integer
-#  user_id     :integer
+#  accepted    :boolean          default(FALSE)
+#  annotated   :boolean          default(FALSE), not null
+#  fs_key      :string(24)
+#  number      :integer
+#  status      :integer
 #  summary     :string(255)
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
-#  status      :integer
-#  accepted    :boolean          default(FALSE)
 #  course_id   :integer
-#  fs_key      :string(24)
-#  number      :integer
-#  annotated   :boolean          default(FALSE), not null
+#  exercise_id :integer
 #  series_id   :integer
+#  user_id     :integer
 #
 
 FactoryBot.define do

--- a/test/factories/users.rb
+++ b/test/factories/users.rb
@@ -3,22 +3,22 @@
 # Table name: users
 #
 #  id                   :integer          not null, primary key
-#  username             :string(255)
-#  first_name           :string(255)
-#  last_name            :string(255)
 #  email                :string(255)
-#  permission           :integer          default("student")
-#  created_at           :datetime         not null
-#  updated_at           :datetime         not null
+#  first_name           :string(255)
 #  lang                 :string(255)      default("nl")
-#  token                :string(255)
-#  time_zone            :string(255)      default("Brussels")
-#  institution_id       :bigint
+#  last_name            :string(255)
+#  open_questions_count :integer          default(0), not null
+#  permission           :integer          default("student")
 #  search               :string(4096)
 #  seen_at              :datetime
 #  sign_in_at           :datetime
-#  open_questions_count :integer          default(0), not null
 #  theme                :integer          default("system"), not null
+#  time_zone            :string(255)      default("Brussels")
+#  token                :string(255)
+#  username             :string(255)
+#  created_at           :datetime         not null
+#  updated_at           :datetime         not null
+#  institution_id       :bigint
 #
 
 FactoryBot.define do

--- a/test/fixtures/courses.yml
+++ b/test/fixtures/courses.yml
@@ -3,20 +3,20 @@
 # Table name: courses
 #
 #  id                :integer          not null, primary key
-#  name              :string(255)
-#  year              :string(255)
-#  secret            :string(255)
-#  created_at        :datetime         not null
-#  updated_at        :datetime         not null
 #  description       :text(4294967295)
-#  visibility        :integer          default("visible_for_all")
-#  registration      :integer          default("open_for_institutional_users")
-#  teacher           :string(255)
-#  institution_id    :bigint
-#  search            :string(4096)
-#  moderated         :boolean          default(FALSE), not null
 #  enabled_questions :boolean          default(TRUE), not null
 #  featured          :boolean          default(FALSE), not null
+#  moderated         :boolean          default(FALSE), not null
+#  name              :string(255)
+#  registration      :integer          default("open_for_institutional_users")
+#  search            :string(4096)
+#  secret            :string(255)
+#  teacher           :string(255)
+#  visibility        :integer          default("visible_for_all")
+#  year              :string(255)
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  institution_id    :bigint
 #
 
 course1:

--- a/test/fixtures/exercises.yml
+++ b/test/fixtures/exercises.yml
@@ -3,26 +3,26 @@
 # Table name: activities
 #
 #  id                      :integer          not null, primary key
-#  name_nl                 :string(255)
+#  access                  :integer          default("public"), not null
+#  access_token            :string(16)       not null
+#  allow_unsafe            :boolean          default(FALSE), not null
+#  description_en_present  :boolean          default(FALSE)
+#  description_format      :string(255)
+#  description_nl_present  :boolean          default(FALSE)
+#  draft                   :boolean          default(TRUE)
 #  name_en                 :string(255)
+#  name_nl                 :string(255)
+#  path                    :string(255)
+#  repository_token        :string(64)       not null
+#  search                  :string(4096)
+#  series_count            :integer          default(0), not null
+#  status                  :integer          default("ok")
+#  type                    :string(255)      default("Exercise"), not null
 #  created_at              :datetime         not null
 #  updated_at              :datetime         not null
-#  path                    :string(255)
-#  description_format      :string(255)
-#  repository_id           :integer
 #  judge_id                :integer
-#  status                  :integer          default("ok")
-#  access                  :integer          default("public"), not null
 #  programming_language_id :bigint
-#  search                  :string(4096)
-#  access_token            :string(16)       not null
-#  repository_token        :string(64)       not null
-#  allow_unsafe            :boolean          default(FALSE), not null
-#  type                    :string(255)      default("Exercise"), not null
-#  description_nl_present  :boolean          default(FALSE)
-#  description_en_present  :boolean          default(FALSE)
-#  series_count            :integer          default(0), not null
-#  draft                   :boolean          default(TRUE)
+#  repository_id           :integer
 #
 
 python_exercise:

--- a/test/fixtures/judges.yml
+++ b/test/fixtures/judges.yml
@@ -3,15 +3,15 @@
 # Table name: judges
 #
 #  id           :integer          not null, primary key
-#  name         :string(255)
-#  image        :string(255)
-#  path         :string(255)
-#  created_at   :datetime         not null
-#  updated_at   :datetime         not null
-#  renderer     :string(255)      not null
-#  remote       :string(255)
 #  clone_status :integer          default("queued"), not null
 #  deprecated   :boolean          default(FALSE), not null
+#  image        :string(255)
+#  name         :string(255)
+#  path         :string(255)
+#  remote       :string(255)
+#  renderer     :string(255)      not null
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #
 
 python_judge:

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -3,22 +3,22 @@
 # Table name: users
 #
 #  id                   :integer          not null, primary key
-#  username             :string(255)
-#  first_name           :string(255)
-#  last_name            :string(255)
 #  email                :string(255)
-#  permission           :integer          default("student")
-#  created_at           :datetime         not null
-#  updated_at           :datetime         not null
+#  first_name           :string(255)
 #  lang                 :string(255)      default("nl")
-#  token                :string(255)
-#  time_zone            :string(255)      default("Brussels")
-#  institution_id       :bigint
+#  last_name            :string(255)
+#  open_questions_count :integer          default(0), not null
+#  permission           :integer          default("student")
 #  search               :string(4096)
 #  seen_at              :datetime
 #  sign_in_at           :datetime
-#  open_questions_count :integer          default(0), not null
 #  theme                :integer          default("system"), not null
+#  time_zone            :string(255)      default("Brussels")
+#  token                :string(255)
+#  username             :string(255)
+#  created_at           :datetime         not null
+#  updated_at           :datetime         not null
+#  institution_id       :bigint
 #
 
 zeus:

--- a/test/models/activity_read_state_test.rb
+++ b/test/models/activity_read_state_test.rb
@@ -3,12 +3,12 @@
 # Table name: activity_read_states
 #
 #  id          :bigint           not null, primary key
-#  activity_id :integer          not null
-#  course_id   :integer
-#  user_id     :integer          not null
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
+#  activity_id :integer          not null
+#  course_id   :integer
 #  series_id   :integer
+#  user_id     :integer          not null
 #
 
 require 'test_helper'

--- a/test/models/activity_status_test.rb
+++ b/test/models/activity_status_test.rb
@@ -5,19 +5,19 @@
 #  id                          :bigint           not null, primary key
 #  accepted                    :boolean          default(FALSE), not null
 #  accepted_before_deadline    :boolean          default(FALSE), not null
+#  series_id_non_nil           :integer          not null
 #  solved                      :boolean          default(FALSE), not null
-#  started                     :boolean          default(FALSE), not null
 #  solved_at                   :datetime
-#  activity_id                 :integer          not null
-#  series_id                   :integer
-#  user_id                     :integer          not null
+#  started                     :boolean          default(FALSE), not null
 #  created_at                  :datetime         not null
 #  updated_at                  :datetime         not null
-#  last_submission_id          :integer
-#  last_submission_deadline_id :integer
-#  best_submission_id          :integer
+#  activity_id                 :integer          not null
 #  best_submission_deadline_id :integer
-#  series_id_non_nil           :integer          not null
+#  best_submission_id          :integer
+#  last_submission_deadline_id :integer
+#  last_submission_id          :integer
+#  series_id                   :integer
+#  user_id                     :integer          not null
 #
 require 'test_helper'
 

--- a/test/models/activity_test.rb
+++ b/test/models/activity_test.rb
@@ -3,26 +3,26 @@
 # Table name: activities
 #
 #  id                      :integer          not null, primary key
-#  name_nl                 :string(255)
+#  access                  :integer          default("public"), not null
+#  access_token            :string(16)       not null
+#  allow_unsafe            :boolean          default(FALSE), not null
+#  description_en_present  :boolean          default(FALSE)
+#  description_format      :string(255)
+#  description_nl_present  :boolean          default(FALSE)
+#  draft                   :boolean          default(TRUE)
 #  name_en                 :string(255)
+#  name_nl                 :string(255)
+#  path                    :string(255)
+#  repository_token        :string(64)       not null
+#  search                  :string(4096)
+#  series_count            :integer          default(0), not null
+#  status                  :integer          default("ok")
+#  type                    :string(255)      default("Exercise"), not null
 #  created_at              :datetime         not null
 #  updated_at              :datetime         not null
-#  path                    :string(255)
-#  description_format      :string(255)
-#  repository_id           :integer
 #  judge_id                :integer
-#  status                  :integer          default("ok")
-#  access                  :integer          default("public"), not null
 #  programming_language_id :bigint
-#  search                  :string(4096)
-#  access_token            :string(16)       not null
-#  repository_token        :string(64)       not null
-#  allow_unsafe            :boolean          default(FALSE), not null
-#  type                    :string(255)      default("Exercise"), not null
-#  description_nl_present  :boolean          default(FALSE)
-#  description_en_present  :boolean          default(FALSE)
-#  series_count            :integer          default(0), not null
-#  draft                   :boolean          default(TRUE)
+#  repository_id           :integer
 #
 
 require 'test_helper'

--- a/test/models/annotation_test.rb
+++ b/test/models/annotation_test.rb
@@ -3,22 +3,22 @@
 # Table name: annotations
 #
 #  id                  :bigint           not null, primary key
-#  line_nr             :integer
-#  submission_id       :integer
-#  user_id             :integer
 #  annotation_text     :text(16777215)
+#  column              :integer
+#  columns             :integer
+#  line_nr             :integer
+#  question_state      :integer
+#  rows                :integer          default(1), not null
+#  type                :string(255)      default("Annotation"), not null
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null
-#  evaluation_id       :bigint
-#  type                :string(255)      default("Annotation"), not null
-#  question_state      :integer
-#  last_updated_by_id  :integer          not null
 #  course_id           :integer          not null
+#  evaluation_id       :bigint
+#  last_updated_by_id  :integer          not null
 #  saved_annotation_id :bigint
+#  submission_id       :integer
 #  thread_root_id      :integer
-#  column              :integer
-#  rows                :integer          default(1), not null
-#  columns             :integer
+#  user_id             :integer
 #
 require 'test_helper'
 

--- a/test/models/announcement_test.rb
+++ b/test/models/announcement_test.rb
@@ -3,15 +3,15 @@
 # Table name: announcements
 #
 #  id                  :bigint           not null, primary key
-#  text_nl             :text(65535)      not null
-#  text_en             :text(65535)      not null
 #  start_delivering_at :datetime
 #  stop_delivering_at  :datetime
-#  user_group          :integer          not null
-#  institution_id      :bigint
 #  style               :integer          not null
+#  text_en             :text(65535)      not null
+#  text_nl             :text(65535)      not null
+#  user_group          :integer          not null
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null
+#  institution_id      :bigint
 #
 require 'test_helper'
 

--- a/test/models/api_token_test.rb
+++ b/test/models/api_token_test.rb
@@ -3,11 +3,11 @@
 # Table name: api_tokens
 #
 #  id           :bigint           not null, primary key
-#  user_id      :bigint
-#  token_digest :string(255)
 #  description  :string(255)
+#  token_digest :string(255)
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
+#  user_id      :bigint
 #
 
 require 'test_helper'

--- a/test/models/course_membership_test.rb
+++ b/test/models/course_membership_test.rb
@@ -3,12 +3,12 @@
 # Table name: course_memberships
 #
 #  id         :integer          not null, primary key
-#  course_id  :integer          not null
-#  user_id    :integer          not null
+#  favorite   :boolean          default(FALSE)
 #  status     :integer          default("student"), not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
-#  favorite   :boolean          default(FALSE)
+#  course_id  :integer          not null
+#  user_id    :integer          not null
 #
 
 require 'test_helper'

--- a/test/models/course_test.rb
+++ b/test/models/course_test.rb
@@ -3,20 +3,20 @@
 # Table name: courses
 #
 #  id                :integer          not null, primary key
-#  name              :string(255)
-#  year              :string(255)
-#  secret            :string(255)
-#  created_at        :datetime         not null
-#  updated_at        :datetime         not null
 #  description       :text(4294967295)
-#  visibility        :integer          default("visible_for_all")
-#  registration      :integer          default("open_for_institutional_users")
-#  teacher           :string(255)
-#  institution_id    :bigint
-#  search            :string(4096)
-#  moderated         :boolean          default(FALSE), not null
 #  enabled_questions :boolean          default(TRUE), not null
 #  featured          :boolean          default(FALSE), not null
+#  moderated         :boolean          default(FALSE), not null
+#  name              :string(255)
+#  registration      :integer          default("open_for_institutional_users")
+#  search            :string(4096)
+#  secret            :string(255)
+#  teacher           :string(255)
+#  visibility        :integer          default("visible_for_all")
+#  year              :string(255)
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  institution_id    :bigint
 #
 
 require 'test_helper'

--- a/test/models/evaluation_exercise_test.rb
+++ b/test/models/evaluation_exercise_test.rb
@@ -3,11 +3,11 @@
 # Table name: evaluation_exercises
 #
 #  id            :bigint           not null, primary key
-#  evaluation_id :bigint
-#  exercise_id   :integer
+#  visible_score :boolean          default(TRUE), not null
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
-#  visible_score :boolean          default(TRUE), not null
+#  evaluation_id :bigint
+#  exercise_id   :integer
 #
 require 'test_helper'
 

--- a/test/models/evaluation_test.rb
+++ b/test/models/evaluation_test.rb
@@ -3,11 +3,11 @@
 # Table name: evaluations
 #
 #  id         :bigint           not null, primary key
-#  series_id  :integer
-#  released   :boolean          default(FALSE), not null
 #  deadline   :datetime         not null
+#  released   :boolean          default(FALSE), not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
+#  series_id  :integer
 #
 require 'test_helper'
 

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -4,10 +4,10 @@
 #
 #  id         :bigint           not null, primary key
 #  event_type :integer          not null
-#  user_id    :integer
 #  message    :string(255)      not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
+#  user_id    :integer
 #
 
 require 'test_helper'

--- a/test/models/exercise_test.rb
+++ b/test/models/exercise_test.rb
@@ -3,26 +3,26 @@
 # Table name: activities
 #
 #  id                      :integer          not null, primary key
-#  name_nl                 :string(255)
+#  access                  :integer          default("public"), not null
+#  access_token            :string(16)       not null
+#  allow_unsafe            :boolean          default(FALSE), not null
+#  description_en_present  :boolean          default(FALSE)
+#  description_format      :string(255)
+#  description_nl_present  :boolean          default(FALSE)
+#  draft                   :boolean          default(TRUE)
 #  name_en                 :string(255)
+#  name_nl                 :string(255)
+#  path                    :string(255)
+#  repository_token        :string(64)       not null
+#  search                  :string(4096)
+#  series_count            :integer          default(0), not null
+#  status                  :integer          default("ok")
+#  type                    :string(255)      default("Exercise"), not null
 #  created_at              :datetime         not null
 #  updated_at              :datetime         not null
-#  path                    :string(255)
-#  description_format      :string(255)
-#  repository_id           :integer
 #  judge_id                :integer
-#  status                  :integer          default("ok")
-#  access                  :integer          default("public"), not null
 #  programming_language_id :bigint
-#  search                  :string(4096)
-#  access_token            :string(16)       not null
-#  repository_token        :string(64)       not null
-#  allow_unsafe            :boolean          default(FALSE), not null
-#  type                    :string(255)      default("Exercise"), not null
-#  description_nl_present  :boolean          default(FALSE)
-#  description_en_present  :boolean          default(FALSE)
-#  series_count            :integer          default(0), not null
-#  draft                   :boolean          default(TRUE)
+#  repository_id           :integer
 #
 
 require 'test_helper'

--- a/test/models/export_test.rb
+++ b/test/models/export_test.rb
@@ -3,10 +3,10 @@
 # Table name: exports
 #
 #  id         :bigint           not null, primary key
-#  user_id    :integer
 #  status     :integer          default("started"), not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
+#  user_id    :integer
 #
 
 require 'test_helper'

--- a/test/models/feedback_test.rb
+++ b/test/models/feedback_test.rb
@@ -3,13 +3,13 @@
 # Table name: feedbacks
 #
 #  id                     :bigint           not null, primary key
-#  submission_id          :integer
-#  evaluation_id          :bigint
-#  evaluation_user_id     :bigint
-#  evaluation_exercise_id :bigint
 #  completed              :boolean          default(FALSE), not null
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
+#  evaluation_exercise_id :bigint
+#  evaluation_id          :bigint
+#  evaluation_user_id     :bigint
+#  submission_id          :integer
 #
 require 'test_helper'
 

--- a/test/models/identity_test.rb
+++ b/test/models/identity_test.rb
@@ -4,12 +4,12 @@
 #
 #  id                           :bigint           not null, primary key
 #  identifier                   :string(255)      not null
-#  provider_id                  :bigint           not null
-#  user_id                      :integer          not null
-#  created_at                   :datetime         not null
-#  updated_at                   :datetime         not null
 #  identifier_based_on_email    :boolean          default(FALSE), not null
 #  identifier_based_on_username :boolean          default(FALSE), not null
+#  created_at                   :datetime         not null
+#  updated_at                   :datetime         not null
+#  provider_id                  :bigint           not null
+#  user_id                      :integer          not null
 #
 require 'test_helper'
 

--- a/test/models/judge_test.rb
+++ b/test/models/judge_test.rb
@@ -3,15 +3,15 @@
 # Table name: judges
 #
 #  id           :integer          not null, primary key
-#  name         :string(255)
-#  image        :string(255)
-#  path         :string(255)
-#  created_at   :datetime         not null
-#  updated_at   :datetime         not null
-#  renderer     :string(255)      not null
-#  remote       :string(255)
 #  clone_status :integer          default("queued"), not null
 #  deprecated   :boolean          default(FALSE), not null
+#  image        :string(255)
+#  name         :string(255)
+#  path         :string(255)
+#  remote       :string(255)
+#  renderer     :string(255)      not null
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #
 
 require 'test_helper'

--- a/test/models/label_test.rb
+++ b/test/models/label_test.rb
@@ -3,8 +3,8 @@
 # Table name: labels
 #
 #  id    :bigint           not null, primary key
-#  name  :string(255)      not null
 #  color :integer          not null
+#  name  :string(255)      not null
 #
 
 require 'test_helper'

--- a/test/models/notification_test.rb
+++ b/test/models/notification_test.rb
@@ -4,12 +4,12 @@
 #
 #  id              :bigint           not null, primary key
 #  message         :string(255)      not null
-#  read            :boolean          default(FALSE), not null
-#  user_id         :integer          not null
 #  notifiable_type :string(255)
-#  notifiable_id   :bigint
+#  read            :boolean          default(FALSE), not null
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
+#  notifiable_id   :bigint
+#  user_id         :integer          not null
 #
 
 require 'test_helper'

--- a/test/models/provider_test.rb
+++ b/test/models/provider_test.rb
@@ -3,21 +3,21 @@
 # Table name: providers
 #
 #  id                :bigint           not null, primary key
-#  type              :string(255)      default("Provider::Saml"), not null
-#  institution_id    :bigint
-#  identifier        :string(255)
-#  certificate       :text(16777215)
-#  entity_id         :string(255)
-#  slo_url           :string(255)
-#  sso_url           :string(255)
-#  created_at        :datetime         not null
-#  updated_at        :datetime         not null
-#  mode              :integer          default("prefer"), not null
 #  active            :boolean          default(TRUE)
 #  authorization_uri :string(255)
-#  client_id         :string(255)
+#  certificate       :text(16777215)
+#  identifier        :string(255)
 #  issuer            :string(255)
 #  jwks_uri          :string(255)
+#  mode              :integer          default("prefer"), not null
+#  slo_url           :string(255)
+#  sso_url           :string(255)
+#  type              :string(255)      default("Provider::Saml"), not null
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  client_id         :string(255)
+#  entity_id         :string(255)
+#  institution_id    :bigint
 #
 require 'test_helper'
 

--- a/test/models/repository_test.rb
+++ b/test/models/repository_test.rb
@@ -3,14 +3,14 @@
 # Table name: repositories
 #
 #  id           :integer          not null, primary key
-#  name         :string(255)
-#  remote       :string(255)
-#  path         :string(255)
-#  judge_id     :integer          default(17)
-#  created_at   :datetime         not null
-#  updated_at   :datetime         not null
 #  clone_status :integer          default("queued"), not null
 #  featured     :boolean          default(FALSE)
+#  name         :string(255)
+#  path         :string(255)
+#  remote       :string(255)
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  judge_id     :integer          default(17)
 #
 
 require 'test_helper'

--- a/test/models/rights_request_test.rb
+++ b/test/models/rights_request_test.rb
@@ -3,11 +3,11 @@
 # Table name: rights_requests
 #
 #  id               :bigint           not null, primary key
-#  user_id          :integer          not null
-#  institution_name :string(255)
 #  context          :text(65535)      not null
+#  institution_name :string(255)
 #  created_at       :datetime         not null
 #  updated_at       :datetime         not null
+#  user_id          :integer          not null
 #
 require 'test_helper'
 

--- a/test/models/saved_annotation_test.rb
+++ b/test/models/saved_annotation_test.rb
@@ -3,14 +3,14 @@
 # Table name: saved_annotations
 #
 #  id                :bigint           not null, primary key
-#  title             :string(255)      not null
 #  annotation_text   :text(16777215)
-#  user_id           :integer          not null
-#  exercise_id       :integer
-#  course_id         :integer
+#  annotations_count :integer          default(0)
+#  title             :string(255)      not null
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
-#  annotations_count :integer          default(0)
+#  course_id         :integer
+#  exercise_id       :integer
+#  user_id           :integer          not null
 #
 require 'test_helper'
 

--- a/test/models/score_item_test.rb
+++ b/test/models/score_item_test.rb
@@ -3,14 +3,14 @@
 # Table name: score_items
 #
 #  id                     :bigint           not null, primary key
-#  evaluation_exercise_id :bigint           not null
+#  description            :text(65535)
 #  maximum                :decimal(5, 2)    not null
 #  name                   :string(255)      not null
+#  order                  :integer
 #  visible                :boolean          default(TRUE), not null
-#  description            :text(65535)
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
-#  order                  :integer
+#  evaluation_exercise_id :bigint           not null
 #
 require 'test_helper'
 

--- a/test/models/score_test.rb
+++ b/test/models/score_test.rb
@@ -3,12 +3,12 @@
 # Table name: scores
 #
 #  id                 :bigint           not null, primary key
-#  score_item_id      :bigint           not null
-#  feedback_id        :bigint           not null
 #  score              :decimal(5, 2)    not null
-#  last_updated_by_id :integer          not null
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null
+#  feedback_id        :bigint           not null
+#  last_updated_by_id :integer          not null
+#  score_item_id      :bigint           not null
 #
 require 'test_helper'
 

--- a/test/models/series_test.rb
+++ b/test/models/series_test.rb
@@ -3,20 +3,20 @@
 # Table name: series
 #
 #  id                       :integer          not null, primary key
-#  course_id                :integer
-#  name                     :string(255)
+#  access_token             :string(255)
+#  activities_count         :integer
+#  activities_visible       :boolean          default(TRUE), not null
+#  activity_numbers_enabled :boolean          default(FALSE), not null
+#  deadline                 :datetime
 #  description              :text(4294967295)
-#  visibility               :integer
+#  name                     :string(255)
 #  order                    :integer          default(0), not null
+#  progress_enabled         :boolean          default(TRUE), not null
+#  visibility               :integer
+#  visibility_start         :datetime
 #  created_at               :datetime         not null
 #  updated_at               :datetime         not null
-#  deadline                 :datetime
-#  access_token             :string(255)
-#  progress_enabled         :boolean          default(TRUE), not null
-#  activities_visible       :boolean          default(TRUE), not null
-#  activities_count         :integer
-#  activity_numbers_enabled :boolean          default(FALSE), not null
-#  visibility_start         :datetime
+#  course_id                :integer
 #
 
 require 'test_helper'

--- a/test/models/submission_test.rb
+++ b/test/models/submission_test.rb
@@ -3,18 +3,18 @@
 # Table name: submissions
 #
 #  id          :integer          not null, primary key
-#  exercise_id :integer
-#  user_id     :integer
+#  accepted    :boolean          default(FALSE)
+#  annotated   :boolean          default(FALSE), not null
+#  fs_key      :string(24)
+#  number      :integer
+#  status      :integer
 #  summary     :string(255)
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
-#  status      :integer
-#  accepted    :boolean          default(FALSE)
 #  course_id   :integer
-#  fs_key      :string(24)
-#  number      :integer
-#  annotated   :boolean          default(FALSE), not null
+#  exercise_id :integer
 #  series_id   :integer
+#  user_id     :integer
 #
 
 require 'test_helper'

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -3,22 +3,22 @@
 # Table name: users
 #
 #  id                   :integer          not null, primary key
-#  username             :string(255)
-#  first_name           :string(255)
-#  last_name            :string(255)
 #  email                :string(255)
-#  permission           :integer          default("student")
-#  created_at           :datetime         not null
-#  updated_at           :datetime         not null
+#  first_name           :string(255)
 #  lang                 :string(255)      default("nl")
-#  token                :string(255)
-#  time_zone            :string(255)      default("Brussels")
-#  institution_id       :bigint
+#  last_name            :string(255)
+#  open_questions_count :integer          default(0), not null
+#  permission           :integer          default("student")
 #  search               :string(4096)
 #  seen_at              :datetime
 #  sign_in_at           :datetime
-#  open_questions_count :integer          default(0), not null
 #  theme                :integer          default("system"), not null
+#  time_zone            :string(255)      default("Brussels")
+#  token                :string(255)
+#  username             :string(255)
+#  created_at           :datetime         not null
+#  updated_at           :datetime         not null
+#  institution_id       :bigint
 #
 
 require 'test_helper'


### PR DESCRIPTION
This reverts commit 5c66322b930e4be27aba57330bf6dfe9cd59465f.

This pull request updates or db annotaions in our ruby files to the format genrated by `annotate_rb`, which we upgraded to in #6062 

This is only a change in order, with the columns now being sorted alphabetically, except for default rails columns and foreign keys, which are always at the end.

I think this new order is an improvement, so didn't try to maintain the old order with settings updates.
